### PR TITLE
fix(ci): add GITHUB_TOKEN env to gitleaks-action

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -21,3 +21,4 @@ jobs:
         uses: gitleaks/gitleaks-action@v2 # pinact: ignore
         env:
           GITLEAKS_CONFIG: .gitleaks.toml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
gitleaks-action@v2 now requires GITHUB_TOKEN to scan pull requests. Pass the auto-created GITHUB_TOKEN secret as recommended by the gitleaks-action README.

## Task

Link to task file: <!-- e.g. docs/tasks/active.md#task-title -->

## Summary

<!-- What does this PR do and why? -->

## Test plan

<!-- How was this verified? Include command output, test names, or device/emulator details. -->

## Checklist

- [ ] No baseline files extended (detekt, lint, LoC)
- [ ] `timeout-minutes` added to any new CI job
- [ ] Native ABI matrix not broken (if touching native builds)
- [ ] Non-rooted device path still works (if touching VPN/root features)
