### PR TITLE
feat(ssh): make the SSH relay fully functional end to end

### DIFF
--- a/app/src/main/kotlin/com/poyka/ripdpi/proxyimport/RelayProfileActivator.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/proxyimport/RelayProfileActivator.kt
@@ -102,9 +102,7 @@ class RelayProfileActivator
                         setRelaySshStrictHostKey(profile.strictHostKey)
                     }
 
-                    else -> {
-                        Unit
-                    }
+                    else -> {}
                 }
             }
             return true

--- a/app/src/main/kotlin/com/poyka/ripdpi/proxyimport/RelayProfileActivator.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/proxyimport/RelayProfileActivator.kt
@@ -13,6 +13,7 @@ import com.poyka.ripdpi.data.RelayKindVlessReality
 import com.poyka.ripdpi.data.RelayProfileRecord
 import com.poyka.ripdpi.data.RelayProfileStore
 import com.poyka.ripdpi.data.RelaySshAuthTypePassword
+import com.poyka.ripdpi.data.RelaySshAuthTypePrivateKey
 import com.poyka.ripdpi.data.RelayVlessTransportRealityTcp
 import com.poyka.ripdpi.data.RelayVlessTransportXhttp
 import javax.inject.Inject
@@ -161,12 +162,16 @@ class RelayProfileActivator
                 }
 
                 is ProxyProfile.Ssh -> {
+                    // Persist only the auth-relevant secret so a profile carrying
+                    // both never leaks the unused credential into the Keystore,
+                    // regardless of which caller built it.
+                    val isKey = profile.authType == RelaySshAuthTypePrivateKey
                     RelayCredentialRecord(
                         profileId = profileId,
                         sshUsername = profile.username,
-                        sshPassword = profile.password,
-                        sshPrivateKey = profile.privateKey,
-                        sshPrivateKeyPassphrase = profile.privateKeyPassphrase,
+                        sshPassword = profile.password?.takeIf { !isKey },
+                        sshPrivateKey = profile.privateKey?.takeIf { isKey },
+                        sshPrivateKeyPassphrase = profile.privateKeyPassphrase?.takeIf { isKey },
                     )
                 }
 

--- a/app/src/main/kotlin/com/poyka/ripdpi/proxyimport/RelayProfileActivator.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/proxyimport/RelayProfileActivator.kt
@@ -1,0 +1,185 @@
+package com.poyka.ripdpi.proxyimport
+
+import com.poyka.ripdpi.data.AppSettingsRepository
+import com.poyka.ripdpi.data.DefaultRelayProfileId
+import com.poyka.ripdpi.data.ProxyProfile
+import com.poyka.ripdpi.data.RelayCredentialRecord
+import com.poyka.ripdpi.data.RelayCredentialStore
+import com.poyka.ripdpi.data.RelayKindAnyTls
+import com.poyka.ripdpi.data.RelayKindShadowsocks
+import com.poyka.ripdpi.data.RelayKindSsh
+import com.poyka.ripdpi.data.RelayKindTrojan
+import com.poyka.ripdpi.data.RelayKindVlessReality
+import com.poyka.ripdpi.data.RelayProfileRecord
+import com.poyka.ripdpi.data.RelayProfileStore
+import com.poyka.ripdpi.data.RelaySshAuthTypePassword
+import com.poyka.ripdpi.data.RelayVlessTransportRealityTcp
+import com.poyka.ripdpi.data.RelayVlessTransportXhttp
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Persists a parsed or edited [ProxyProfile] as the active native relay.
+ *
+ * Writes the non-secret [RelayProfileRecord], the secure [RelayCredentialRecord],
+ * and the AppSettings relay fields the runtime resolver
+ * (`UpstreamRelayRuntimeConfigResolver`) reads to build the native wire config.
+ * Shared by the import-confirmation surface and the dedicated profile editors so
+ * both reach an identical working tunnel rather than duplicating the mapping.
+ *
+ * [activate] returns `true` when [profile] is a relay-activatable kind and was
+ * applied, `false` (a no-op) for kinds that are not relay outbounds.
+ */
+@Singleton
+class RelayProfileActivator
+    @Inject
+    constructor(
+        private val relayProfileStore: RelayProfileStore,
+        private val relayCredentialStore: RelayCredentialStore,
+        private val settingsRepository: AppSettingsRepository,
+    ) {
+        suspend fun activate(profile: ProxyProfile): Boolean {
+            val profileId = DefaultRelayProfileId
+            val relayKind =
+                when (profile) {
+                    is ProxyProfile.Trojan -> RelayKindTrojan
+                    is ProxyProfile.Shadowsocks -> RelayKindShadowsocks
+                    is ProxyProfile.AnyTls -> RelayKindAnyTls
+                    is ProxyProfile.VlessReality -> RelayKindVlessReality
+                    is ProxyProfile.Ssh -> RelayKindSsh
+                    else -> return false
+                }
+            val endpoint = relayEndpoint(profile)
+            // SSH carries only a `direct-tcpip` TCP channel; every other
+            // relay-activatable kind here advertises UDP ASSOCIATE.
+            val udpEnabled = profile !is ProxyProfile.Ssh
+            val vlessTransport =
+                if (profile is ProxyProfile.VlessReality && profile.xhttpPath != null) {
+                    RelayVlessTransportXhttp
+                } else {
+                    RelayVlessTransportRealityTcp
+                }
+            relayProfileStore.save(
+                RelayProfileRecord(
+                    id = profileId,
+                    kind = relayKind,
+                    server = endpoint.server,
+                    serverPort = endpoint.serverPort,
+                    serverName = endpoint.serverName,
+                    realityPublicKey = if (profile is ProxyProfile.VlessReality) profile.realityPublicKey else "",
+                    realityShortId = if (profile is ProxyProfile.VlessReality) profile.realityShortId else "",
+                    vlessTransport = vlessTransport,
+                    xhttpPath = if (profile is ProxyProfile.VlessReality) profile.xhttpPath.orEmpty() else "",
+                    xhttpHost = if (profile is ProxyProfile.VlessReality) profile.xhttpHost.orEmpty() else "",
+                    sshAuthType = if (profile is ProxyProfile.Ssh) profile.authType else RelaySshAuthTypePassword,
+                    sshHostKeyFingerprint =
+                        if (profile is ProxyProfile.Ssh) profile.hostKeyFingerprint.orEmpty() else "",
+                    sshStrictHostKey = profile is ProxyProfile.Ssh && profile.strictHostKey,
+                    udpEnabled = udpEnabled,
+                ),
+            )
+            relayCredentialStore.save(relayCredentials(profileId, profile))
+            settingsRepository.update {
+                setRelayEnabled(true)
+                setRelayKind(relayKind)
+                setRelayProfileId(profileId)
+                setRelayServer(endpoint.server)
+                setRelayServerPort(endpoint.serverPort)
+                setRelayServerName(endpoint.serverName)
+                setRelayUdpEnabled(udpEnabled)
+                when (profile) {
+                    is ProxyProfile.VlessReality -> {
+                        setRelayRealityPublicKey(profile.realityPublicKey)
+                        setRelayRealityShortId(profile.realityShortId)
+                        setRelayVlessTransport(vlessTransport)
+                        setRelayXhttpPath(profile.xhttpPath.orEmpty())
+                        setRelayXhttpHost(profile.xhttpHost.orEmpty())
+                    }
+
+                    is ProxyProfile.Ssh -> {
+                        setRelaySshAuthType(profile.authType)
+                        setRelaySshHostKeyFingerprint(profile.hostKeyFingerprint.orEmpty())
+                        setRelaySshStrictHostKey(profile.strictHostKey)
+                    }
+
+                    else -> {
+                        Unit
+                    }
+                }
+            }
+            return true
+        }
+
+        private fun relayEndpoint(profile: ProxyProfile): RelayActivationEndpoint =
+            when (profile) {
+                is ProxyProfile.Trojan -> {
+                    RelayActivationEndpoint(profile.server, profile.serverPort, profile.server)
+                }
+
+                is ProxyProfile.Shadowsocks -> {
+                    RelayActivationEndpoint(profile.server, profile.serverPort, profile.server)
+                }
+
+                is ProxyProfile.AnyTls -> {
+                    RelayActivationEndpoint(profile.server, profile.serverPort, profile.serverName)
+                }
+
+                is ProxyProfile.VlessReality -> {
+                    RelayActivationEndpoint(profile.server, profile.serverPort, profile.serverName)
+                }
+
+                is ProxyProfile.Ssh -> {
+                    RelayActivationEndpoint(profile.server, profile.serverPort, profile.server)
+                }
+
+                else -> {
+                    error("unsupported relay activation profile ${profile::class.simpleName}")
+                }
+            }
+
+        private fun relayCredentials(
+            profileId: String,
+            profile: ProxyProfile,
+        ): RelayCredentialRecord =
+            when (profile) {
+                is ProxyProfile.Trojan -> {
+                    RelayCredentialRecord(profileId = profileId, trojanPassword = profile.password)
+                }
+
+                is ProxyProfile.Shadowsocks -> {
+                    RelayCredentialRecord(
+                        profileId = profileId,
+                        shadowsocksMethod = profile.method,
+                        shadowsocksPassword = profile.password,
+                    )
+                }
+
+                is ProxyProfile.AnyTls -> {
+                    RelayCredentialRecord(profileId = profileId, anyTlsPassword = profile.password)
+                }
+
+                is ProxyProfile.VlessReality -> {
+                    RelayCredentialRecord(profileId = profileId, vlessUuid = profile.uuid)
+                }
+
+                is ProxyProfile.Ssh -> {
+                    RelayCredentialRecord(
+                        profileId = profileId,
+                        sshUsername = profile.username,
+                        sshPassword = profile.password,
+                        sshPrivateKey = profile.privateKey,
+                        sshPrivateKeyPassphrase = profile.privateKeyPassphrase,
+                    )
+                }
+
+                else -> {
+                    error("unsupported relay activation profile ${profile::class.simpleName}")
+                }
+            }
+    }
+
+private data class RelayActivationEndpoint(
+    val server: String,
+    val serverPort: Int,
+    val serverName: String,
+)

--- a/app/src/main/kotlin/com/poyka/ripdpi/proxyimport/RelayProfileShareMapper.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/proxyimport/RelayProfileShareMapper.kt
@@ -6,11 +6,13 @@ import com.poyka.ripdpi.data.RelayKindAnyTls
 import com.poyka.ripdpi.data.RelayKindHysteria2
 import com.poyka.ripdpi.data.RelayKindMieru
 import com.poyka.ripdpi.data.RelayKindShadowsocks
+import com.poyka.ripdpi.data.RelayKindSsh
 import com.poyka.ripdpi.data.RelayKindTrojan
 import com.poyka.ripdpi.data.RelayKindVless
 import com.poyka.ripdpi.data.RelayKindVlessReality
 import com.poyka.ripdpi.data.RelayProfileRecord
 import com.poyka.ripdpi.data.RelaySecurityLayerReality
+import com.poyka.ripdpi.data.RelaySshAuthTypePrivateKey
 import com.poyka.ripdpi.data.RelayVlessTransportXhttp
 import com.poyka.ripdpi.data.uri.ProxyUriCodec
 import java.util.UUID
@@ -44,6 +46,7 @@ object RelayProfileShareMapper {
             RelayKindAnyTls -> toAnyTls(credentials)
             RelayKindShadowsocks -> toShadowsocks(credentials)
             RelayKindMieru -> toMieru(credentials)
+            RelayKindSsh -> toSsh(credentials)
             else -> null
         }
 
@@ -198,6 +201,32 @@ object RelayProfileShareMapper {
                         ).takeIf { server.isNotBlank() && serverPort > 0 }
                 }
             }
+
+    private fun RelayProfileRecord.toSsh(credentials: RelayCredentialRecord?): ProxyProfile? {
+        val username = credentials?.sshUsername?.takeIf { it.isNotBlank() } ?: return null
+        val isKey = sshAuthType == RelaySshAuthTypePrivateKey
+        val password = credentials.sshPassword?.takeIf { it.isNotBlank() }
+        val privateKey = credentials.sshPrivateKey?.takeIf { it.isNotBlank() }
+        // The auth-relevant secret must be present, or the reconstructed profile
+        // could never authenticate.
+        if (isKey && privateKey == null) return null
+        if (!isKey && password == null) return null
+        return ProxyProfile
+            .Ssh(
+                id = UUID.randomUUID().toString(),
+                displayName = shareName(),
+                groupId = "",
+                server = server,
+                serverPort = serverPort,
+                username = username,
+                authType = sshAuthType,
+                password = if (isKey) null else password,
+                privateKey = if (isKey) privateKey else null,
+                privateKeyPassphrase = credentials.sshPrivateKeyPassphrase?.takeIf { isKey && it.isNotBlank() },
+                hostKeyFingerprint = sshHostKeyFingerprint.ifBlank { null },
+                strictHostKey = sshStrictHostKey,
+            ).takeIf { server.isNotBlank() && serverPort > 0 }
+    }
 
     private fun RelayProfileRecord.shareName(): String =
         listOf(operatorName, jurisdiction)

--- a/app/src/main/kotlin/com/poyka/ripdpi/proxyimport/RelayProfileShareMapper.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/proxyimport/RelayProfileShareMapper.kt
@@ -209,8 +209,7 @@ object RelayProfileShareMapper {
         val privateKey = credentials.sshPrivateKey?.takeIf { it.isNotBlank() }
         // The auth-relevant secret must be present, or the reconstructed profile
         // could never authenticate.
-        if (isKey && privateKey == null) return null
-        if (!isKey && password == null) return null
+        val hasAuthSecret = if (isKey) privateKey != null else password != null
         return ProxyProfile
             .Ssh(
                 id = UUID.randomUUID().toString(),
@@ -225,12 +224,12 @@ object RelayProfileShareMapper {
                 privateKeyPassphrase = credentials.sshPrivateKeyPassphrase?.takeIf { isKey && it.isNotBlank() },
                 hostKeyFingerprint = sshHostKeyFingerprint.ifBlank { null },
                 strictHostKey = sshStrictHostKey,
-            ).takeIf { server.isNotBlank() && serverPort > 0 }
+            ).takeIf { hasAuthSecret && server.isNotBlank() && serverPort > 0 }
     }
-
-    private fun RelayProfileRecord.shareName(): String =
-        listOf(operatorName, jurisdiction)
-            .filter { it.isNotBlank() }
-            .joinToString(" / ")
-            .ifBlank { presetId.ifBlank { id } }
 }
+
+private fun RelayProfileRecord.shareName(): String =
+    listOf(operatorName, jurisdiction)
+        .filter { it.isNotBlank() }
+        .joinToString(" / ")
+        .ifBlank { presetId.ifBlank { id } }

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/proxyimport/NativeRelayProfileActivator.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/proxyimport/NativeRelayProfileActivator.kt
@@ -1,47 +1,32 @@
 package com.poyka.ripdpi.ui.screens.proxyimport
 
-import com.poyka.ripdpi.data.AppSettingsRepository
-import com.poyka.ripdpi.data.DefaultRelayProfileId
 import com.poyka.ripdpi.data.ProxyGroup
 import com.poyka.ripdpi.data.ProxyGroupRepository
 import com.poyka.ripdpi.data.ProxyGroupType
 import com.poyka.ripdpi.data.ProxyProfile
-import com.poyka.ripdpi.data.RelayCredentialRecord
-import com.poyka.ripdpi.data.RelayCredentialStore
-import com.poyka.ripdpi.data.RelayKindAnyTls
-import com.poyka.ripdpi.data.RelayKindShadowsocks
-import com.poyka.ripdpi.data.RelayKindTrojan
-import com.poyka.ripdpi.data.RelayKindVlessReality
-import com.poyka.ripdpi.data.RelayProfileRecord
-import com.poyka.ripdpi.data.RelayProfileStore
-import com.poyka.ripdpi.data.RelayVlessTransportRealityTcp
-import com.poyka.ripdpi.data.RelayVlessTransportXhttp
+import com.poyka.ripdpi.proxyimport.RelayProfileActivator
 import java.util.UUID
 import javax.inject.Inject
 
 /**
- * Persists a parsed [ProxyProfile] as the live native relay and records a
- * single-profile [ProxyGroupType.BASIC] group for it.
+ * Records a single-profile [ProxyGroupType.BASIC] group for a parsed
+ * [ProxyProfile] and activates it as the live native relay.
  *
- * This is the one place that maps a foreign-exit [ProxyProfile] onto the native
- * relay engine's [RelayProfileRecord] / [RelayCredentialRecord] / `AppSettings`
- * triple (profile id [DefaultRelayProfileId]). It is shared by the share-link
- * import-confirmation screen ([ProfileImportConfirmViewModel]) and the Xray
- * config import flow so the two paths cannot drift.
+ * Group creation lives here; the profile→relay mapping itself is delegated to
+ * [RelayProfileActivator], which is the single place that writes the
+ * `RelayProfileRecord` / `RelayCredentialRecord` / `AppSettings` triple. The
+ * share-link import-confirmation screen, the Xray config import flow, and the
+ * dedicated profile editors therefore all share one mapping and cannot drift.
  *
- * Only the four relay kinds with a native backend reachable from an import
- * ([ProxyProfile.VlessReality], [ProxyProfile.Trojan], [ProxyProfile.Shadowsocks],
- * [ProxyProfile.AnyTls]) activate the relay; any other profile still gets a group
- * marker but does not enable the relay (so it never yields a connection that
- * fails at connect time). Use [supports] to pre-filter.
+ * [supports] pre-filters the kinds that map to a native relay backend; any other
+ * profile still gets a group marker but does not enable the relay (so it never
+ * yields a connection that fails at connect time).
  */
 class NativeRelayProfileActivator
     @Inject
     constructor(
         private val repository: ProxyGroupRepository,
-        private val relayProfileStore: RelayProfileStore,
-        private val relayCredentialStore: RelayCredentialStore,
-        private val settingsRepository: AppSettingsRepository,
+        private val relayProfileActivator: RelayProfileActivator,
     ) {
         /** True when [profile] maps to a native relay backend reachable from import. */
         fun supports(profile: ProxyProfile): Boolean =
@@ -50,15 +35,16 @@ class NativeRelayProfileActivator
                 is ProxyProfile.Shadowsocks,
                 is ProxyProfile.AnyTls,
                 is ProxyProfile.VlessReality,
+                is ProxyProfile.Ssh,
                 -> true
 
                 else -> false
             }
 
         /**
-         * Adds a single-profile [ProxyGroupType.BASIC] group for [profile] and, when
-         * [supports] is true, activates it as the live native relay. Suspends until
-         * the stores and settings have been written.
+         * Adds a single-profile [ProxyGroupType.BASIC] group for [profile] and, when it
+         * is a relay-activatable kind, activates it as the live native relay. Suspends
+         * until the group, stores, and settings have been written.
          */
         suspend fun activate(profile: ProxyProfile) {
             val groupId = UUID.randomUUID().toString()
@@ -72,120 +58,6 @@ class NativeRelayProfileActivator
                     subscription = null,
                 ),
             )
-            activateNativeRelayProfile(profile)
+            relayProfileActivator.activate(profile)
         }
-
-        private suspend fun activateNativeRelayProfile(profile: ProxyProfile) {
-            // Unsupported profile kinds are filtered by the `else -> return` arm below.
-            val profileId = DefaultRelayProfileId
-            val relayKind =
-                when (profile) {
-                    is ProxyProfile.Trojan -> RelayKindTrojan
-                    is ProxyProfile.Shadowsocks -> RelayKindShadowsocks
-                    is ProxyProfile.AnyTls -> RelayKindAnyTls
-                    is ProxyProfile.VlessReality -> RelayKindVlessReality
-                    else -> return
-                }
-            val endpoint = relayEndpoint(profile)
-            val vlessTransport =
-                if (profile is ProxyProfile.VlessReality && profile.xhttpPath != null) {
-                    RelayVlessTransportXhttp
-                } else {
-                    RelayVlessTransportRealityTcp
-                }
-            relayProfileStore.save(
-                RelayProfileRecord(
-                    id = profileId,
-                    kind = relayKind,
-                    server = endpoint.server,
-                    serverPort = endpoint.serverPort,
-                    serverName = endpoint.serverName,
-                    realityPublicKey = if (profile is ProxyProfile.VlessReality) profile.realityPublicKey else "",
-                    realityShortId = if (profile is ProxyProfile.VlessReality) profile.realityShortId else "",
-                    vlessTransport = vlessTransport,
-                    xhttpPath = if (profile is ProxyProfile.VlessReality) profile.xhttpPath.orEmpty() else "",
-                    xhttpHost = if (profile is ProxyProfile.VlessReality) profile.xhttpHost.orEmpty() else "",
-                    udpEnabled = true,
-                ),
-            )
-            relayCredentialStore.save(
-                relayCredentials(profileId, profile),
-            )
-            settingsRepository.update {
-                setRelayEnabled(true)
-                setRelayKind(relayKind)
-                setRelayProfileId(profileId)
-                setRelayServer(endpoint.server)
-                setRelayServerPort(endpoint.serverPort)
-                setRelayServerName(endpoint.serverName)
-                setRelayUdpEnabled(true)
-                if (profile is ProxyProfile.VlessReality) {
-                    setRelayRealityPublicKey(profile.realityPublicKey)
-                    setRelayRealityShortId(profile.realityShortId)
-                    setRelayVlessTransport(vlessTransport)
-                    setRelayXhttpPath(profile.xhttpPath.orEmpty())
-                    setRelayXhttpHost(profile.xhttpHost.orEmpty())
-                }
-            }
-        }
-
-        private fun relayEndpoint(profile: ProxyProfile): RelayImportEndpoint =
-            when (profile) {
-                is ProxyProfile.Trojan -> {
-                    RelayImportEndpoint(profile.server, profile.serverPort, profile.server)
-                }
-
-                is ProxyProfile.Shadowsocks -> {
-                    RelayImportEndpoint(profile.server, profile.serverPort, profile.server)
-                }
-
-                is ProxyProfile.AnyTls -> {
-                    RelayImportEndpoint(profile.server, profile.serverPort, profile.serverName)
-                }
-
-                is ProxyProfile.VlessReality -> {
-                    RelayImportEndpoint(profile.server, profile.serverPort, profile.serverName)
-                }
-
-                else -> {
-                    // Vless, Hysteria2, Mieru, Ssh, RawConfig — not relay-importable.
-                    error("unsupported relay import profile ${profile::class.simpleName}")
-                }
-            }
-
-        private fun relayCredentials(
-            profileId: String,
-            profile: ProxyProfile,
-        ): RelayCredentialRecord =
-            when (profile) {
-                is ProxyProfile.Trojan -> {
-                    RelayCredentialRecord(profileId = profileId, trojanPassword = profile.password)
-                }
-
-                is ProxyProfile.Shadowsocks -> {
-                    RelayCredentialRecord(
-                        profileId = profileId,
-                        shadowsocksMethod = profile.method,
-                        shadowsocksPassword = profile.password,
-                    )
-                }
-
-                is ProxyProfile.AnyTls -> {
-                    RelayCredentialRecord(profileId = profileId, anyTlsPassword = profile.password)
-                }
-
-                is ProxyProfile.VlessReality -> {
-                    RelayCredentialRecord(profileId = profileId, vlessUuid = profile.uuid)
-                }
-
-                else -> {
-                    error("unsupported relay import profile ${profile::class.simpleName}")
-                }
-            }
     }
-
-private data class RelayImportEndpoint(
-    val server: String,
-    val serverPort: Int,
-    val serverName: String,
-)

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/proxyimport/ProfileImportConfirmViewModel.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/proxyimport/ProfileImportConfirmViewModel.kt
@@ -2,19 +2,18 @@ package com.poyka.ripdpi.ui.screens.proxyimport
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.poyka.ripdpi.data.AppSettingsRepository
+import com.poyka.ripdpi.data.ProxyGroup
 import com.poyka.ripdpi.data.ProxyGroupRepository
 import com.poyka.ripdpi.data.ProxyGroupType
 import com.poyka.ripdpi.data.ProxyProfile
-import com.poyka.ripdpi.data.RelayCredentialStore
-import com.poyka.ripdpi.data.RelayProfileStore
+import com.poyka.ripdpi.proxyimport.RelayProfileActivator
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.UUID
 import javax.inject.Inject
 
 /** UI state for the single-profile import-confirmation screen. */
@@ -29,31 +28,18 @@ data class ProfileImportConfirmUiState(
  *
  * This is the import-confirmation surface, not a full editor: it shows the parsed
  * [ProxyProfile] and an "Add" action that persists it into a [ProxyGroupType.BASIC]
- * group and activates it as the native relay via [NativeRelayProfileActivator]. The
- * handler activity navigates here after parsing a `vless://` / `ss://` / `trojan://`
+ * group via [ProxyGroupRepository] and, for relay-activatable kinds, applies it as
+ * the active native relay through [RelayProfileActivator]. The handler activity
+ * navigates here after parsing a `vless://` / `ss://` / `trojan://` / `ssh://`
  * style share link.
- *
- * The store/settings dependencies are kept on the constructor (rather than injecting
- * [NativeRelayProfileActivator] directly) so the existing unit tests can drive the
- * activation with their fakes; the activator is the single source of the
- * profile→relay mapping shared with the Xray import flow.
  */
 @HiltViewModel
 class ProfileImportConfirmViewModel
     @Inject
     constructor(
-        repository: ProxyGroupRepository,
-        relayProfileStore: RelayProfileStore,
-        relayCredentialStore: RelayCredentialStore,
-        settingsRepository: AppSettingsRepository,
+        private val repository: ProxyGroupRepository,
+        private val relayActivator: RelayProfileActivator,
     ) : ViewModel() {
-        private val activator =
-            NativeRelayProfileActivator(
-                repository = repository,
-                relayProfileStore = relayProfileStore,
-                relayCredentialStore = relayCredentialStore,
-                settingsRepository = settingsRepository,
-            )
         private val _uiState = MutableStateFlow(ProfileImportConfirmUiState())
         val uiState: StateFlow<ProfileImportConfirmUiState> = _uiState.asStateFlow()
 
@@ -64,25 +50,30 @@ class ProfileImportConfirmViewModel
 
         /**
          * Persists the parsed profile into a new single-profile group and activates it
-         * as the native relay. No-op when there is no profile to import or an import is
-         * already in flight.
+         * as the native relay (when the kind is relay-activatable). The group is stamped
+         * with the generated id so it is attributable. No-op when there is no profile to
+         * import or an import is already in flight.
          */
         fun confirm() {
             val profile = _uiState.value.profile ?: return
             if (_uiState.value.importing || _uiState.value.imported) return
             _uiState.update { it.copy(importing = true) }
             viewModelScope.launch {
-                val result = runCatching { activator.activate(profile) }
-                result.fold(
-                    onSuccess = { _uiState.update { it.copy(importing = false, imported = true) } },
-                    onFailure = { error ->
-                        // Don't swallow structured-concurrency cancellation.
-                        if (error is CancellationException) throw error
-                        // Store/settings I/O failed: clear the spinner so the user can retry
-                        // rather than crashing the scope or wedging on a stuck spinner.
-                        _uiState.update { it.copy(importing = false) }
-                    },
+                val groupId = UUID.randomUUID().toString()
+                repository.add(
+                    ProxyGroup(
+                        id = groupId,
+                        name = profile.displayName,
+                        type = ProxyGroupType.BASIC,
+                        order = nextOrder(),
+                        isSelector = false,
+                        subscription = null,
+                    ),
                 )
+                relayActivator.activate(profile)
+                _uiState.update { it.copy(importing = false, imported = true) }
             }
         }
+
+        private suspend fun nextOrder(): Int = repository.list().size
     }

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/proxyimport/ProfileImportConfirmViewModel.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/proxyimport/ProfileImportConfirmViewModel.kt
@@ -59,19 +59,25 @@ class ProfileImportConfirmViewModel
             if (_uiState.value.importing || _uiState.value.imported) return
             _uiState.update { it.copy(importing = true) }
             viewModelScope.launch {
-                val groupId = UUID.randomUUID().toString()
-                repository.add(
-                    ProxyGroup(
-                        id = groupId,
-                        name = profile.displayName,
-                        type = ProxyGroupType.BASIC,
-                        order = nextOrder(),
-                        isSelector = false,
-                        subscription = null,
-                    ),
-                )
-                relayActivator.activate(profile)
-                _uiState.update { it.copy(importing = false, imported = true) }
+                try {
+                    val groupId = UUID.randomUUID().toString()
+                    repository.add(
+                        ProxyGroup(
+                            id = groupId,
+                            name = profile.displayName,
+                            type = ProxyGroupType.BASIC,
+                            order = nextOrder(),
+                            isSelector = false,
+                            subscription = null,
+                        ),
+                    )
+                    relayActivator.activate(profile)
+                    _uiState.update { it.copy(imported = true) }
+                } finally {
+                    // Reset the in-flight flag even if persistence/activation
+                    // throws so the import action can be retried.
+                    _uiState.update { it.copy(importing = false) }
+                }
             }
         }
 

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/settings/AdvancedSettingsSections.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/settings/AdvancedSettingsSections.kt
@@ -452,6 +452,7 @@ private fun ProxyToggleSettings(
 ) {
     var showAllowLanWarning by rememberSaveable { mutableStateOf(false) }
     val context = LocalContext.current
+    val lanAuthTokenLabel = stringResource(R.string.clipboard_label_lan_auth_token)
 
     if (showAllowLanWarning) {
         ProxyAllowLanWarningDialog(

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileEditorState.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileEditorState.kt
@@ -1,7 +1,9 @@
 package com.poyka.ripdpi.ui.screens.ssh
 
+import com.poyka.ripdpi.data.ProxyProfile
 import com.poyka.ripdpi.data.RelaySshAuthTypePassword
 import com.poyka.ripdpi.data.RelaySshAuthTypePrivateKey
+import java.util.UUID
 
 /** Lower bound (inclusive) of a valid TCP port. */
 private const val MinPort = 1
@@ -55,8 +57,9 @@ enum class SshEditorField {
  * edit is not silently discarded; [authType] is a picker-backed whitelisted
  * selection. [privateKeyRevealed] / [passphraseRevealed] gate the secret fields
  * behind the biometric-reveal pattern used by the AmneziaWG editor; both default
- * to hidden. SSH is an editor-only relay kind: it has no URI / subscription
- * import path, so this state intentionally produces no `ProxyProfile`.
+ * to hidden. [toProfile] assembles a [ProxyProfile.Ssh] from a complete editor so
+ * the host can persist it and activate the native relay; the synthetic `ssh://`
+ * scheme (see `ProxyUriCodec`) round-trips the same shape for subscription import.
  */
 data class SshProfileEditorState(
     val rawTextByField: Map<SshEditorField, String> = emptyMap(),
@@ -119,6 +122,34 @@ data class SshProfileEditorState(
                 SshEditorField.SERVER_PORT.validate(rawText(SshEditorField.SERVER_PORT)) != null &&
                 SshEditorField.USERNAME.validate(rawText(SshEditorField.USERNAME)) != null &&
                 credentialComplete
+
+    /**
+     * Builds a [ProxyProfile.Ssh] from the current editor, or `null` when the
+     * required fields do not validate. The auth-irrelevant secret is dropped
+     * (only the password for password-auth, only the private key / passphrase for
+     * key-auth survive) and a blank pinned fingerprint becomes `null`. The display
+     * name falls back to the server when left empty.
+     */
+    fun toProfile(): ProxyProfile.Ssh? {
+        if (!isComplete) return null
+        val port = SshEditorField.SERVER_PORT.validate(rawText(SshEditorField.SERVER_PORT)) as? Int ?: return null
+        val server = rawText(SshEditorField.SERVER).trim()
+        val isKey = authType == RelaySshAuthTypePrivateKey
+        return ProxyProfile.Ssh(
+            id = UUID.randomUUID().toString(),
+            displayName = rawText(SshEditorField.DISPLAY_NAME).trim().ifEmpty { server },
+            groupId = "",
+            server = server,
+            serverPort = port,
+            username = rawText(SshEditorField.USERNAME).trim(),
+            authType = authType,
+            password = rawText(SshEditorField.PASSWORD).takeIf { !isKey && it.isNotEmpty() },
+            privateKey = rawText(SshEditorField.PRIVATE_KEY).takeIf { isKey && it.isNotBlank() },
+            privateKeyPassphrase = rawText(SshEditorField.PRIVATE_KEY_PASSPHRASE).takeIf { isKey && it.isNotEmpty() },
+            hostKeyFingerprint = rawText(SshEditorField.HOST_KEY_FINGERPRINT).trim().ifEmpty { null },
+            strictHostKey = strictHostKey,
+        )
+    }
 
     companion object {
         /** A fresh editor: empty fields, password auth, and a lenient (non-strict) host-key policy. */

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileEditorState.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileEditorState.kt
@@ -131,8 +131,8 @@ data class SshProfileEditorState(
      * name falls back to the server when left empty.
      */
     fun toProfile(): ProxyProfile.Ssh? {
-        if (!isComplete) return null
-        val port = SshEditorField.SERVER_PORT.validate(rawText(SshEditorField.SERVER_PORT)) as? Int ?: return null
+        val port = SshEditorField.SERVER_PORT.validate(rawText(SshEditorField.SERVER_PORT)) as? Int
+        if (!isComplete || port == null) return null
         val server = rawText(SshEditorField.SERVER).trim()
         val isKey = authType == RelaySshAuthTypePrivateKey
         return ProxyProfile.Ssh(

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileScreen.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileScreen.kt
@@ -3,6 +3,7 @@ package com.poyka.ripdpi.ui.screens.ssh
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -17,8 +18,6 @@ import com.poyka.ripdpi.ui.components.buttons.RipDpiButton
 import com.poyka.ripdpi.ui.components.buttons.RipDpiButtonVariant
 import com.poyka.ripdpi.ui.components.cards.RipDpiCard
 import com.poyka.ripdpi.ui.components.chrome.RipDpiPanelHeader
-import com.poyka.ripdpi.ui.components.feedback.WarningBanner
-import com.poyka.ripdpi.ui.components.feedback.WarningBannerTone
 import com.poyka.ripdpi.ui.components.inputs.RipDpiDropdown
 import com.poyka.ripdpi.ui.components.inputs.RipDpiDropdownOption
 import com.poyka.ripdpi.ui.components.inputs.RipDpiSwitch
@@ -40,14 +39,14 @@ private val SshAuthTypeDropdownOptions:
 /**
  * SSH profile editor destination.
  *
- * SSH is an editor-only outbound: there is no URI / subscription import path, so
- * this screen is the only way a profile is authored. The editor validates the
- * server and username as non-blank and the port against `1..65535`, exposes an
- * auth-type selector (`password` / `private_key`) that drives which credential is
- * required, an optional private-key passphrase, an optional pinned `SHA256:`
- * host-key fingerprint, and a strict-host-key toggle. The private key and the
- * passphrase are secrets gated behind a biometric reveal, mirroring the AmneziaWG
- * private-key reveal.
+ * The editor validates the server and username as non-blank and the port against
+ * `1..65535`, exposes an auth-type selector (`password` / `private_key`) that
+ * drives which credential is required, an optional private-key passphrase, an
+ * optional pinned `SHA256:` host-key fingerprint, and a strict-host-key toggle.
+ * The private key and the passphrase are secrets gated behind a biometric reveal,
+ * mirroring the AmneziaWG private-key reveal. Saving a complete profile applies it
+ * as the active native relay and navigates back; the same shape can also arrive via
+ * the synthetic `ssh://` URI / subscription import path.
  */
 @Composable
 fun SshProfileRoute(
@@ -58,6 +57,9 @@ fun SshProfileRoute(
     onRequestPassphraseReveal: (() -> Unit)? = null,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    LaunchedEffect(uiState.saved) {
+        if (uiState.saved) onBack()
+    }
     SshProfileScreen(
         uiState = uiState,
         onBack = onBack,
@@ -90,12 +92,6 @@ internal fun SshProfileScreen(
         navigationContentDescription = stringResource(R.string.navigation_back),
         modifier = modifier.ripDpiTestTag(RipDpiTestTags.screen(Route.SshProfile)),
     ) {
-        WarningBanner(
-            title = stringResource(R.string.ssh_not_functional_title),
-            message = stringResource(R.string.ssh_not_functional_body),
-            tone = WarningBannerTone.Error,
-            announce = false,
-        )
         EndpointSection(uiState.editor, onFieldChanged)
         AuthSection(uiState.editor, onFieldChanged, onAuthTypeSelected, onRevealPrivateKey, onRevealPassphrase)
         HostKeySection(uiState.editor, onFieldChanged, onStrictHostKeyChanged)

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileViewModel.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileViewModel.kt
@@ -1,23 +1,26 @@
 package com.poyka.ripdpi.ui.screens.ssh
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.poyka.ripdpi.proxyimport.RelayProfileActivator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
  * UI state for the SSH profile editor.
  *
- * [editor] is the immutable field/validation snapshot. [saved] flips to `true`
- * once the user commits a complete, valid profile so the host can navigate away.
- * SSH is editor-only (no subscription / URI import path) so the editor produces
- * no `ProxyProfile`; persistence is wired by the host once the engine lands.
+ * [editor] is the immutable field/validation snapshot. [saving] is `true` while the
+ * profile is being persisted and the native relay activated; [saved] flips to `true`
+ * once the active relay has been set so the host can navigate away.
  */
 data class SshProfileUiState(
     val editor: SshProfileEditorState,
+    val saving: Boolean = false,
     val saved: Boolean = false,
 )
 
@@ -27,15 +30,21 @@ data class SshProfileUiState(
  * SSH authenticates either with a password or a private key (the [authType]
  * selector decides which credential is required); the private-key passphrase and
  * the pinned `SHA256:` host-key fingerprint are optional, and a strict-host-key
- * toggle controls whether a host-key mismatch is rejected on connect. The private
- * key and passphrase are persisted via the secure relay-credential store (Android
- * Keystore-backed `EncryptedFile`-equivalent), the same mechanism the WireGuard /
- * AmneziaWG editor uses, and stay hidden behind a biometric reveal.
+ * toggle controls whether a host-key mismatch is rejected on connect.
+ *
+ * On save a complete editor is assembled into a
+ * [com.poyka.ripdpi.data.ProxyProfile.Ssh] and applied as the active native relay
+ * through [RelayProfileActivator] — the same activation path the import-confirmation
+ * surface uses — so the editor leads directly to a working tunnel. The private key
+ * and passphrase are persisted via the secure relay-credential store (Android
+ * Keystore-backed) and stay hidden behind a biometric reveal.
  */
 @HiltViewModel
 class SshProfileViewModel
     @Inject
-    constructor() : ViewModel() {
+    constructor(
+        private val relayActivator: RelayProfileActivator,
+    ) : ViewModel() {
         private val _uiState = MutableStateFlow(SshProfileUiState(editor = SshProfileEditorState.initial()))
         val uiState: StateFlow<SshProfileUiState> = _uiState.asStateFlow()
 
@@ -72,9 +81,18 @@ class SshProfileViewModel
             _uiState.update { it.copy(editor = it.editor.relockSecrets()) }
         }
 
-        /** Commits the editor; a no-op when the required fields do not validate. */
+        /**
+         * Assembles a complete editor into a [com.poyka.ripdpi.data.ProxyProfile.Ssh]
+         * and applies it as the active native relay. A no-op when the required fields do
+         * not validate or a save is already in flight.
+         */
         fun onSave() {
-            if (!_uiState.value.editor.isComplete) return
-            _uiState.update { it.copy(saved = true) }
+            val profile = _uiState.value.editor.toProfile() ?: return
+            if (_uiState.value.saving || _uiState.value.saved) return
+            _uiState.update { it.copy(saving = true) }
+            viewModelScope.launch {
+                relayActivator.activate(profile)
+                _uiState.update { it.copy(saving = false, saved = true) }
+            }
         }
     }

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileViewModel.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileViewModel.kt
@@ -91,8 +91,15 @@ class SshProfileViewModel
             if (_uiState.value.saving || _uiState.value.saved) return
             _uiState.update { it.copy(saving = true) }
             viewModelScope.launch {
-                relayActivator.activate(profile)
-                _uiState.update { it.copy(saving = false, saved = true) }
+                try {
+                    relayActivator.activate(profile)
+                    _uiState.update { it.copy(saved = true) }
+                } finally {
+                    // Reset the in-flight flag even if activation throws (e.g. a
+                    // Keystore write failure) so the editor stays usable and the
+                    // user can retry rather than being stranded on a disabled Save.
+                    _uiState.update { it.copy(saving = false) }
+                }
             }
         }
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -3266,8 +3266,6 @@ fakeddisorder endhost</string>
     <string name="ssh_secret_hidden">مخفي — انقر على الكشف للعرض</string>
     <string name="ssh_reveal_secret_action">كشف</string>
     <string name="ssh_save_action">حفظ</string>
-    <string name="ssh_not_functional_title">غير وظيفي بعد — ستفشل الاتصالات</string>
-    <string name="ssh_not_functional_body">لم يُنفَّذ بعد الواجهة الخلفية لريلاي SSH. يمكن حفظ ملف التعريف، لكن بدء الاتصال سيفشل دائمًا بخطأ. لا تستخدمه للحركة الحقيقية.</string>
 
     <!-- onboarding refactor additions -->
     <!-- intro chips -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2860,8 +2860,6 @@ Quelle: %2$s</string>
     <string name="ssh_secret_hidden">Verborgen – zum Anzeigen tippen</string>
     <string name="ssh_reveal_secret_action">Anzeigen</string>
     <string name="ssh_save_action">Speichern</string>
-    <string name="ssh_not_functional_title">Noch nicht funktionsfähig — Verbindungen schlagen fehl</string>
-    <string name="ssh_not_functional_body">Das SSH-Relay-Backend ist noch nicht implementiert. Ein Profil kann gespeichert werden, aber der Verbindungsaufbau schlägt stets mit einem Fehler fehl. Nicht für echten Datenverkehr verwenden.</string>
 
     <!-- App widget strings -->
     <string name="widget_description_connect_toggle">Verbindungsschalter</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2860,8 +2860,6 @@ Origen: %2$s</string>
     <string name="ssh_secret_hidden">Oculto: toca «Mostrar» para verlo</string>
     <string name="ssh_reveal_secret_action">Mostrar</string>
     <string name="ssh_save_action">Guardar</string>
-    <string name="ssh_not_functional_title">Aún no funcional — las conexiones fallarán</string>
-    <string name="ssh_not_functional_body">El backend del relay SSH aún no está implementado. Es posible guardar un perfil, pero iniciar una conexión siempre fallará con un error. No usar para tráfico real.</string>
 
     <!-- App widget strings -->
     <string name="widget_description_connect_toggle">Interruptor de conexión</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -2865,8 +2865,6 @@ fakeddisorder endhost</string>
     <string name="ssh_secret_hidden">پنهان — برای نمایش ضربه بزنید</string>
     <string name="ssh_reveal_secret_action">نمایش</string>
     <string name="ssh_save_action">ذخیره</string>
-    <string name="ssh_not_functional_title">هنوز کارآمد نیست — اتصالات ناموفق خواهند بود</string>
-    <string name="ssh_not_functional_body">پشتیبان رله SSH هنوز پیاده‌سازی نشده است. ذخیره یک نمایه ممکن است، اما شروع اتصال همیشه با خطا مواجه می‌شود. برای ترافیک واقعی استفاده نکنید.</string>
 
     <!-- App widget strings -->
     <string name="widget_description_connect_toggle">کلید اتصال</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2860,8 +2860,6 @@ Source : %2$s</string>
     <string name="ssh_secret_hidden">Masqué — appuyez sur Afficher</string>
     <string name="ssh_reveal_secret_action">Afficher</string>
     <string name="ssh_save_action">Enregistrer</string>
-    <string name="ssh_not_functional_title">Pas encore fonctionnel — les connexions échoueront</string>
-    <string name="ssh_not_functional_body">Le backend du relay SSH n\'est pas encore implémenté. Il est possible d\'enregistrer un profil, mais démarrer une connexion échouera toujours avec une erreur. Ne pas utiliser pour du trafic réel.</string>
 
     <!-- App widget strings -->
     <string name="widget_description_connect_toggle">Bouton de connexion</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2979,8 +2979,6 @@ fakeddisorder endhost</string>
     <string name="ssh_secret_hidden">Скрыто — нажмите «Показать»</string>
     <string name="ssh_reveal_secret_action">Показать</string>
     <string name="ssh_save_action">Сохранить</string>
-    <string name="ssh_not_functional_title">Ещё не работает — соединения завершатся ошибкой</string>
-    <string name="ssh_not_functional_body">Серверная часть SSH-ретранслятора ещё не реализована. Сохранить профиль можно, но запуск соединения всегда завершится ошибкой. Не используйте для реального трафика.</string>
 
     <!-- App widget strings -->
     <string name="widget_description_connect_toggle">Переключатель подключения</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2861,8 +2861,6 @@ fake_burst 3</string>
     <string name="ssh_secret_hidden">已隐藏 — 点按显示</string>
     <string name="ssh_reveal_secret_action">显示</string>
     <string name="ssh_save_action">保存</string>
-    <string name="ssh_not_functional_title">尚未可用 — 连接将失败</string>
-    <string name="ssh_not_functional_body">SSH 中继后端尚未实现。可以保存配置，但启动连接将始终报错失败。请勿用于真实流量。</string>
 
     <!-- App widget strings -->
     <string name="widget_description_connect_toggle">连接开关</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3013,8 +3013,6 @@ Source: %2$s</string>
     <string name="ssh_secret_hidden">Hidden — tap reveal to show</string>
     <string name="ssh_reveal_secret_action">Reveal</string>
     <string name="ssh_save_action">Save</string>
-    <string name="ssh_not_functional_title">Not yet functional — connections will fail</string>
-    <string name="ssh_not_functional_body">The SSH relay backend is not yet implemented. Saving a profile is possible but starting a connection will always fail with an error. Do not use for real traffic.</string>
 
     <!-- App widget strings -->
     <string name="widget_description_connect_toggle">Connect Toggle</string>

--- a/app/src/test/kotlin/com/poyka/ripdpi/proxyimport/ImportConfirmViewModelTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/proxyimport/ImportConfirmViewModelTest.kt
@@ -11,10 +11,12 @@ import com.poyka.ripdpi.data.RelayCredentialRecord
 import com.poyka.ripdpi.data.RelayCredentialStore
 import com.poyka.ripdpi.data.RelayKindAnyTls
 import com.poyka.ripdpi.data.RelayKindShadowsocks
+import com.poyka.ripdpi.data.RelayKindSsh
 import com.poyka.ripdpi.data.RelayKindTrojan
 import com.poyka.ripdpi.data.RelayKindVlessReality
 import com.poyka.ripdpi.data.RelayProfileRecord
 import com.poyka.ripdpi.data.RelayProfileStore
+import com.poyka.ripdpi.data.RelaySshAuthTypePassword
 import com.poyka.ripdpi.data.RelayVlessTransportRealityTcp
 import com.poyka.ripdpi.data.RelayVlessTransportXhttp
 import com.poyka.ripdpi.data.SubscriptionKind
@@ -60,9 +62,12 @@ class ImportConfirmViewModelTest {
             val viewModel =
                 ProfileImportConfirmViewModel(
                     repository = repository,
-                    relayProfileStore = FakeRelayProfileStore(),
-                    relayCredentialStore = FakeRelayCredentialStore(),
-                    settingsRepository = FakeAppSettingsRepository(),
+                    relayActivator =
+                        RelayProfileActivator(
+                            FakeRelayProfileStore(),
+                            FakeRelayCredentialStore(),
+                            FakeAppSettingsRepository(),
+                        ),
                 )
 
             viewModel.setProfile(profile)
@@ -95,9 +100,8 @@ class ImportConfirmViewModelTest {
             val viewModel =
                 ProfileImportConfirmViewModel(
                     repository = repository,
-                    relayProfileStore = relayProfileStore,
-                    relayCredentialStore = relayCredentialStore,
-                    settingsRepository = settingsRepository,
+                    relayActivator =
+                        RelayProfileActivator(relayProfileStore, relayCredentialStore, settingsRepository),
                 )
 
             viewModel.setProfile(profile)
@@ -137,9 +141,8 @@ class ImportConfirmViewModelTest {
             val viewModel =
                 ProfileImportConfirmViewModel(
                     repository = repository,
-                    relayProfileStore = relayProfileStore,
-                    relayCredentialStore = relayCredentialStore,
-                    settingsRepository = settingsRepository,
+                    relayActivator =
+                        RelayProfileActivator(relayProfileStore, relayCredentialStore, settingsRepository),
                 )
 
             viewModel.setProfile(profile)
@@ -179,9 +182,8 @@ class ImportConfirmViewModelTest {
             val viewModel =
                 ProfileImportConfirmViewModel(
                     repository = repository,
-                    relayProfileStore = relayProfileStore,
-                    relayCredentialStore = relayCredentialStore,
-                    settingsRepository = settingsRepository,
+                    relayActivator =
+                        RelayProfileActivator(relayProfileStore, relayCredentialStore, settingsRepository),
                 )
 
             viewModel.setProfile(profile)
@@ -225,9 +227,8 @@ class ImportConfirmViewModelTest {
             val viewModel =
                 ProfileImportConfirmViewModel(
                     repository = repository,
-                    relayProfileStore = relayProfileStore,
-                    relayCredentialStore = relayCredentialStore,
-                    settingsRepository = settingsRepository,
+                    relayActivator =
+                        RelayProfileActivator(relayProfileStore, relayCredentialStore, settingsRepository),
                 )
 
             viewModel.setProfile(profile)
@@ -282,9 +283,8 @@ class ImportConfirmViewModelTest {
             val viewModel =
                 ProfileImportConfirmViewModel(
                     repository = repository,
-                    relayProfileStore = relayProfileStore,
-                    relayCredentialStore = relayCredentialStore,
-                    settingsRepository = settingsRepository,
+                    relayActivator =
+                        RelayProfileActivator(relayProfileStore, relayCredentialStore, settingsRepository),
                 )
 
             viewModel.setProfile(profile)
@@ -306,6 +306,62 @@ class ImportConfirmViewModelTest {
             assertEquals("/tunnel", relayProfile?.xhttpPath)
             assertEquals("cdn.example.com", relayProfile?.xhttpHost)
             assertEquals("dddddddd-dddd-dddd-dddd-dddddddddddd", relayCredentials?.vlessUuid)
+        }
+
+    @Test
+    fun `confirming an ssh password profile import activates the native relay with udp disabled`() =
+        runTest {
+            val repository = FakeProxyGroupRepository()
+            val relayProfileStore = FakeRelayProfileStore()
+            val relayCredentialStore = FakeRelayCredentialStore()
+            val settingsRepository = FakeAppSettingsRepository()
+            val sshPassword = relayImportCredentialFixture("ssh")
+            val profile =
+                ProxyProfile.Ssh(
+                    id = "ssh-node",
+                    displayName = "SSH",
+                    groupId = "",
+                    server = "ssh.example",
+                    serverPort = 22,
+                    username = "alice",
+                    authType = RelaySshAuthTypePassword,
+                    password = sshPassword,
+                    hostKeyFingerprint = "SHA256:n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg",
+                    strictHostKey = true,
+                )
+            val viewModel =
+                ProfileImportConfirmViewModel(
+                    repository = repository,
+                    relayActivator =
+                        RelayProfileActivator(relayProfileStore, relayCredentialStore, settingsRepository),
+                )
+
+            viewModel.setProfile(profile)
+            viewModel.confirm()
+            advanceUntilIdle()
+
+            val settings = settingsRepository.snapshot()
+            val relayProfile = relayProfileStore.load(DefaultRelayProfileId)
+            val relayCredentials = relayCredentialStore.load(DefaultRelayProfileId)
+            assertEquals(RelayKindSsh, settings.relayKind)
+            assertTrue(settings.relayEnabled)
+            assertEquals("ssh.example", settings.relayServer)
+            assertEquals(22, settings.relayServerPort)
+            // SSH carries only a direct-tcpip TCP channel.
+            assertEquals(false, settings.relayUdpEnabled)
+            assertEquals(RelaySshAuthTypePassword, settings.relaySshAuthType)
+            assertEquals(
+                "SHA256:n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg",
+                settings.relaySshHostKeyFingerprint,
+            )
+            assertTrue(settings.relaySshStrictHostKey)
+            assertEquals(RelayKindSsh, relayProfile?.kind)
+            assertEquals("ssh.example", relayProfile?.server)
+            assertEquals(false, relayProfile?.udpEnabled)
+            assertEquals(RelaySshAuthTypePassword, relayProfile?.sshAuthType)
+            assertTrue(relayProfile?.sshStrictHostKey == true)
+            assertEquals("alice", relayCredentials?.sshUsername)
+            assertEquals(sshPassword, relayCredentials?.sshPassword)
         }
 
     @Test

--- a/app/src/test/kotlin/com/poyka/ripdpi/proxyimport/RelayProfileShareMapperSshTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/proxyimport/RelayProfileShareMapperSshTest.kt
@@ -1,0 +1,106 @@
+package com.poyka.ripdpi.proxyimport
+
+import com.poyka.ripdpi.data.ProxyProfile
+import com.poyka.ripdpi.data.RelayCredentialRecord
+import com.poyka.ripdpi.data.RelayKindSsh
+import com.poyka.ripdpi.data.RelayProfileRecord
+import com.poyka.ripdpi.data.RelaySshAuthTypePassword
+import com.poyka.ripdpi.data.RelaySshAuthTypePrivateKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * SSH coverage for [RelayProfileShareMapper]: a saved SSH relay record plus its
+ * secure credentials must reconstruct a [ProxyProfile.Ssh] and a canonical
+ * `ssh://` share URI, and must refuse to share when the auth-relevant secret is
+ * absent. The `ssh://` codec round-trip itself is covered by `ProxyUriCodecTest`.
+ */
+class RelayProfileShareMapperSshTest {
+    private val fingerprint = "SHA256:n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg"
+
+    // Named *Fixture so the no-secrets pre-commit hook excludes these lines.
+    private val passwordFixture = "ssh-relay-fixture-secret"
+    private val privateKeyFixture =
+        "-----BEGIN OPENSSH PRIVATE KEY-----\nfixtureAAAA\n-----END OPENSSH PRIVATE KEY-----"
+
+    @Test
+    fun `password ssh record maps to a shareable ssh profile`() {
+        val record =
+            RelayProfileRecord(
+                kind = RelayKindSsh,
+                server = "ssh.example",
+                serverPort = 22,
+                sshAuthType = RelaySshAuthTypePassword,
+                sshHostKeyFingerprint = fingerprint,
+                sshStrictHostKey = true,
+            )
+        val credentials =
+            RelayCredentialRecord(
+                profileId = record.id,
+                sshUsername = "alice",
+                sshPassword = passwordFixture,
+            )
+
+        val shareable = RelayProfileShareMapper.toShareable(record, credentials)
+
+        assertNotNull(shareable)
+        val profile = shareable!!.profile as ProxyProfile.Ssh
+        assertEquals("ssh.example", profile.server)
+        assertEquals(22, profile.serverPort)
+        assertEquals("alice", profile.username)
+        assertEquals(RelaySshAuthTypePassword, profile.authType)
+        assertEquals(passwordFixture, profile.password)
+        assertNull(profile.privateKey)
+        assertEquals(fingerprint, profile.hostKeyFingerprint)
+        assertTrue(profile.strictHostKey)
+        assertTrue("share URI must use the ssh scheme", shareable.shareUri.startsWith("ssh://"))
+    }
+
+    @Test
+    fun `private-key ssh record maps with the key and drops the password`() {
+        val record =
+            RelayProfileRecord(
+                kind = RelayKindSsh,
+                server = "ssh.example",
+                serverPort = 2222,
+                sshAuthType = RelaySshAuthTypePrivateKey,
+            )
+        val credentials =
+            RelayCredentialRecord(
+                profileId = record.id,
+                sshUsername = "bob",
+                sshPrivateKey = privateKeyFixture,
+                sshPrivateKeyPassphrase = "pp",
+            )
+
+        val profile = RelayProfileShareMapper.toShareable(record, credentials)?.profile as? ProxyProfile.Ssh
+
+        assertNotNull(profile)
+        assertEquals(RelaySshAuthTypePrivateKey, profile!!.authType)
+        assertNull(profile.password)
+        assertEquals("pp", profile.privateKeyPassphrase)
+        assertTrue(profile.privateKey.orEmpty().contains("OPENSSH PRIVATE KEY"))
+    }
+
+    @Test
+    fun `ssh record without a username is not shareable`() {
+        val record = RelayProfileRecord(kind = RelayKindSsh, server = "ssh.example", serverPort = 22)
+        assertNull(RelayProfileShareMapper.toShareable(record, RelayCredentialRecord(profileId = record.id)))
+    }
+
+    @Test
+    fun `password-auth ssh record missing the password is not shareable`() {
+        val record =
+            RelayProfileRecord(
+                kind = RelayKindSsh,
+                server = "ssh.example",
+                serverPort = 22,
+                sshAuthType = RelaySshAuthTypePassword,
+            )
+        val credentials = RelayCredentialRecord(profileId = record.id, sshUsername = "alice")
+        assertNull(RelayProfileShareMapper.toShareable(record, credentials))
+    }
+}

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileEditorStateTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileEditorStateTest.kt
@@ -1,0 +1,109 @@
+package com.poyka.ripdpi.ui.screens.ssh
+
+import com.poyka.ripdpi.data.RelaySshAuthTypePassword
+import com.poyka.ripdpi.data.RelaySshAuthTypePrivateKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit coverage for [SshProfileEditorState] — the branch-dense `toProfile()`
+ * assembly (auth-secret dropping, blank→null normalization, display-name
+ * fallback) and the `isComplete` gate.
+ */
+class SshProfileEditorStateTest {
+    /** A complete password-auth editor (server, port, username, password all valid). */
+    private fun passwordEditor(): SshProfileEditorState =
+        SshProfileEditorState
+            .initial()
+            .updateField(SshEditorField.SERVER, "ssh.example")
+            .updateField(SshEditorField.SERVER_PORT, "22")
+            .updateField(SshEditorField.USERNAME, "alice")
+            .updateField(SshEditorField.PASSWORD, "pw-value")
+
+    @Test
+    fun `password auth produces a password profile and no key material`() {
+        val profile = passwordEditor().toProfile()
+
+        assertNotNull(profile)
+        assertEquals("ssh.example", profile!!.server)
+        assertEquals(22, profile.serverPort)
+        assertEquals("alice", profile.username)
+        assertEquals(RelaySshAuthTypePassword, profile.authType)
+        assertEquals("pw-value", profile.password)
+        assertNull(profile.privateKey)
+        assertNull(profile.privateKeyPassphrase)
+    }
+
+    @Test
+    fun `private-key auth produces a key profile and drops the password`() {
+        val profile =
+            passwordEditor()
+                .selectAuthType(RelaySshAuthTypePrivateKey)
+                .updateField(SshEditorField.PRIVATE_KEY, "key-body")
+                .updateField(SshEditorField.PRIVATE_KEY_PASSPHRASE, "pp")
+                .toProfile()
+
+        assertNotNull(profile)
+        assertEquals(RelaySshAuthTypePrivateKey, profile!!.authType)
+        assertEquals("key-body", profile.privateKey)
+        assertEquals("pp", profile.privateKeyPassphrase)
+        assertNull("password auth-irrelevant for key auth must be dropped", profile.password)
+    }
+
+    @Test
+    fun `password auth drops a typed-then-abandoned private key`() {
+        val profile =
+            passwordEditor()
+                .updateField(SshEditorField.PRIVATE_KEY, "stale-key")
+                .toProfile()
+
+        assertNotNull(profile)
+        assertEquals("pw-value", profile!!.password)
+        assertNull("a private key typed while on password auth must not survive", profile.privateKey)
+    }
+
+    @Test
+    fun `blank pinned fingerprint becomes null and a real one is carried`() {
+        val blank = passwordEditor().updateField(SshEditorField.HOST_KEY_FINGERPRINT, "   ").toProfile()
+        assertNull(blank!!.hostKeyFingerprint)
+
+        val pinned = passwordEditor().updateField(SshEditorField.HOST_KEY_FINGERPRINT, "SHA256:abc").toProfile()
+        assertEquals("SHA256:abc", pinned!!.hostKeyFingerprint)
+    }
+
+    @Test
+    fun `display name falls back to the server when left empty`() {
+        assertEquals("ssh.example", passwordEditor().toProfile()!!.displayName)
+        val named = passwordEditor().updateField(SshEditorField.DISPLAY_NAME, "My SSH").toProfile()
+        assertEquals("My SSH", named!!.displayName)
+    }
+
+    @Test
+    fun `strict host-key toggle is carried`() {
+        assertFalse(passwordEditor().toProfile()!!.strictHostKey)
+        assertTrue(passwordEditor().setStrictHostKey(true).toProfile()!!.strictHostKey)
+    }
+
+    @Test
+    fun `incomplete editors produce no profile`() {
+        // Fresh editor: no endpoint, no credential.
+        assertNull(SshProfileEditorState.initial().toProfile())
+        // Endpoint present but the (default) password is missing.
+        val noCredential =
+            SshProfileEditorState
+                .initial()
+                .updateField(SshEditorField.SERVER, "ssh.example")
+                .updateField(SshEditorField.SERVER_PORT, "22")
+                .updateField(SshEditorField.USERNAME, "alice")
+        assertFalse(noCredential.isComplete)
+        assertNull(noCredential.toProfile())
+        // Key auth selected but no key supplied.
+        assertNull(noCredential.selectAuthType(RelaySshAuthTypePrivateKey).toProfile())
+        // Out-of-range port.
+        assertNull(passwordEditor().updateField(SshEditorField.SERVER_PORT, "70000").toProfile())
+    }
+}

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileViewModelTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/ssh/SshProfileViewModelTest.kt
@@ -1,0 +1,143 @@
+package com.poyka.ripdpi.ui.screens.ssh
+
+import com.poyka.ripdpi.data.AppSettingsRepository
+import com.poyka.ripdpi.data.AppSettingsSerializer
+import com.poyka.ripdpi.data.DefaultRelayProfileId
+import com.poyka.ripdpi.data.RelayCredentialRecord
+import com.poyka.ripdpi.data.RelayCredentialStore
+import com.poyka.ripdpi.data.RelayKindSsh
+import com.poyka.ripdpi.data.RelayProfileRecord
+import com.poyka.ripdpi.data.RelayProfileStore
+import com.poyka.ripdpi.proto.AppSettings
+import com.poyka.ripdpi.proxyimport.RelayProfileActivator
+import com.poyka.ripdpi.util.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Verifies the dedicated SSH editor's save path: a complete editor activates the
+ * native relay (TCP-only) through [RelayProfileActivator] and flips `saved`, and
+ * an incomplete editor is a no-op.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SshProfileViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    // Named *Fixture so the no-secrets pre-commit hook excludes the line.
+    private val passwordFixture = "ssh-vm-fixture-secret"
+
+    private fun viewModel(
+        profileStore: RelayProfileStore,
+        credentialStore: RelayCredentialStore,
+        settings: AppSettingsRepository,
+    ): SshProfileViewModel = SshProfileViewModel(RelayProfileActivator(profileStore, credentialStore, settings))
+
+    @Test
+    fun `onSave activates the ssh relay with udp disabled and flips saved`() =
+        runTest {
+            val profileStore = FakeRelayProfileStore()
+            val credentialStore = FakeRelayCredentialStore()
+            val settings = FakeAppSettingsRepository()
+            val viewModel = viewModel(profileStore, credentialStore, settings)
+
+            viewModel.onFieldChanged(SshEditorField.SERVER, "ssh.example")
+            viewModel.onFieldChanged(SshEditorField.SERVER_PORT, "22")
+            viewModel.onFieldChanged(SshEditorField.USERNAME, "alice")
+            viewModel.onFieldChanged(SshEditorField.PASSWORD, passwordFixture)
+            viewModel.onSave()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.saved)
+            assertFalse(viewModel.uiState.value.saving)
+
+            val snapshot = settings.snapshot()
+            assertEquals(RelayKindSsh, snapshot.relayKind)
+            assertTrue(snapshot.relayEnabled)
+            assertEquals("ssh.example", snapshot.relayServer)
+            assertEquals(22, snapshot.relayServerPort)
+            assertFalse("SSH is direct-tcpip / TCP-only", snapshot.relayUdpEnabled)
+
+            val profile = profileStore.load(DefaultRelayProfileId)
+            assertEquals(RelayKindSsh, profile?.kind)
+            assertFalse(profile?.udpEnabled ?: true)
+
+            val credentials = credentialStore.load(DefaultRelayProfileId)
+            assertEquals("alice", credentials?.sshUsername)
+            assertEquals(passwordFixture, credentials?.sshPassword)
+        }
+
+    @Test
+    fun `onSave is a no-op for an incomplete editor`() =
+        runTest {
+            val settings = FakeAppSettingsRepository()
+            val viewModel = viewModel(FakeRelayProfileStore(), FakeRelayCredentialStore(), settings)
+
+            viewModel.onFieldChanged(SshEditorField.SERVER, "ssh.example") // no port / username / secret
+            viewModel.onSave()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.saved)
+            assertFalse(settings.snapshot().relayEnabled)
+        }
+}
+
+private class FakeRelayProfileStore : RelayProfileStore {
+    private val profiles = mutableMapOf<String, RelayProfileRecord>()
+
+    override suspend fun load(profileId: String): RelayProfileRecord? = profiles[profileId]
+
+    override suspend fun list(): List<RelayProfileRecord> = profiles.values.toList()
+
+    override suspend fun save(profile: RelayProfileRecord) {
+        profiles[profile.id] = profile
+    }
+
+    override suspend fun clear(profileId: String) {
+        profiles.remove(profileId)
+    }
+}
+
+private class FakeRelayCredentialStore : RelayCredentialStore {
+    private val credentials = mutableMapOf<String, RelayCredentialRecord>()
+
+    override suspend fun load(profileId: String): RelayCredentialRecord? = credentials[profileId]
+
+    override suspend fun save(credentials: RelayCredentialRecord) {
+        this.credentials[credentials.profileId] = credentials
+    }
+
+    override suspend fun clear(profileId: String) {
+        credentials.remove(profileId)
+    }
+}
+
+private class FakeAppSettingsRepository : AppSettingsRepository {
+    private val state = MutableStateFlow(AppSettingsSerializer.defaultValue)
+
+    override val settings: Flow<AppSettings> = state.asStateFlow()
+
+    override suspend fun snapshot(): AppSettings = settings.first()
+
+    override suspend fun update(transform: AppSettings.Builder.() -> Unit) {
+        state.value =
+            state.value
+                .toBuilder()
+                .apply(transform)
+                .build()
+    }
+
+    override suspend fun replace(settings: AppSettings) {
+        state.value = settings
+    }
+}

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/xray/XrayImportNativeActivationTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/xray/XrayImportNativeActivationTest.kt
@@ -17,6 +17,7 @@ import com.poyka.ripdpi.data.RelayVlessTransportRealityTcp
 import com.poyka.ripdpi.data.subscription.XrayConfigImportParser
 import com.poyka.ripdpi.data.subscription.XrayConfigImportResult
 import com.poyka.ripdpi.proto.AppSettings
+import com.poyka.ripdpi.proxyimport.RelayProfileActivator
 import com.poyka.ripdpi.ui.screens.proxyimport.NativeRelayProfileActivator
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -58,7 +59,10 @@ class XrayImportNativeActivationTest {
             val relayCredentialStore = FakeRelayCredentialStore()
             val settingsRepository = FakeAppSettingsRepository()
             val activator =
-                NativeRelayProfileActivator(repository, relayProfileStore, relayCredentialStore, settingsRepository)
+                NativeRelayProfileActivator(
+                    repository,
+                    RelayProfileActivator(relayProfileStore, relayCredentialStore, settingsRepository),
+                )
 
             val config =
                 """
@@ -97,7 +101,10 @@ class XrayImportNativeActivationTest {
             val relayCredentialStore = FakeRelayCredentialStore()
             val settingsRepository = FakeAppSettingsRepository()
             val activator =
-                NativeRelayProfileActivator(repository, relayProfileStore, relayCredentialStore, settingsRepository)
+                NativeRelayProfileActivator(
+                    repository,
+                    RelayProfileActivator(relayProfileStore, relayCredentialStore, settingsRepository),
+                )
 
             val config =
                 """

--- a/config/i18n/translatable-keys.txt
+++ b/config/i18n/translatable-keys.txt
@@ -2834,8 +2834,6 @@ app:ssh_field_server_port
 app:ssh_field_strict_host_key
 app:ssh_field_strict_host_key_body
 app:ssh_field_username
-app:ssh_not_functional_body
-app:ssh_not_functional_title
 app:ssh_reveal_secret_action
 app:ssh_save_action
 app:ssh_secret_hidden

--- a/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/RelayStores.kt
+++ b/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/RelayStores.kt
@@ -68,6 +68,11 @@ data class RelayProfileRecord(
     val ptWebTunnelUrl: String = "",
     val ptSnowflakeBrokerUrl: String = DefaultSnowflakeBrokerUrl,
     val ptSnowflakeFrontDomain: String = DefaultSnowflakeFrontDomain,
+    // SSH non-secret config. The endpoint reuses [server]/[serverPort]; the
+    // username/password/private-key/passphrase live in [RelayCredentialRecord].
+    val sshAuthType: String = RelaySshAuthTypePassword,
+    val sshHostKeyFingerprint: String = "",
+    val sshStrictHostKey: Boolean = false,
     val localSocksHost: String = DefaultRelayLocalSocksHost,
     val localSocksPort: Int = DefaultRelayLocalSocksPort,
     val udpEnabled: Boolean = false,

--- a/core/service/src/test/kotlin/com/poyka/ripdpi/services/RelayKindDescriptorDriftTest.kt
+++ b/core/service/src/test/kotlin/com/poyka/ripdpi/services/RelayKindDescriptorDriftTest.kt
@@ -120,6 +120,7 @@ class RelayKindDescriptorDriftTest {
                 "shadowsocks" to listOf(true, true, false, true),
                 "tor" to listOf(true, false, true, false),
                 "naiveproxy" to listOf(true, false, false, true),
+                "ssh" to listOf(true, false, false, false),
             )
         rustPinned.forEach { (kindId, caps) ->
             val descriptor = relayKindDescriptor(kindId) ?: error("missing Kotlin descriptor for $kindId")

--- a/native/rust/crates/ripdpi-relay-core/src/backend/builder/builders/ssh.rs
+++ b/native/rust/crates/ripdpi-relay-core/src/backend/builder/builders/ssh.rs
@@ -8,12 +8,18 @@ use crate::protocols::SshSessionFactory;
 
 /// Build the SSH relay backend.
 ///
-/// SSH is TCP-only (a `direct-tcpip` channel) and non-reusable in this
-/// foundation. The `russh` wire engine in `ripdpi-ssh` is stubbed because the
-/// relay layer exposes no protected outbound connector to hand `russh` a
-/// pre-connected `VpnService.protect()`-honoured stream (see the `ripdpi-ssh`
-/// crate doc). The built backend therefore validates config and fails session
-/// creation with `Unimplemented` rather than opening an unprotected socket.
+/// SSH is TCP-only (a `direct-tcpip` channel) and non-reusable (one fresh
+/// session per flow). This wires the real `russh` engine in `ripdpi-ssh`:
+/// `build` validates the config and returns a [`RelayBackend::Ssh`] whose
+/// [`SshSessionFactory`] dials, verifies the host key (TOFU / strict pin),
+/// authenticates by password or private key, and opens one `direct-tcpip`
+/// channel per relay flow.
+///
+/// The outbound socket `russh` opens needs no per-socket `VpnService.protect()`
+/// call: the relay runs in-process under the app UID, which is excluded from
+/// the TUN by UID-level routing — the same socket-safety model the sibling
+/// `ripdpi-trojan` backend relies on (see the `ripdpi-ssh` crate doc and
+/// `.claude/rules/vpnservice-protect-invariant.md`).
 pub(crate) fn build(config: &ResolvedRelayRuntimeConfig, context: &BuildContext) -> io::Result<RelayBackend> {
     let RelayBackendConfig::Ssh(ssh) = &config.backend else {
         return Err(io::Error::new(io::ErrorKind::InvalidInput, "expected SSH config"));

--- a/native/rust/crates/ripdpi-ssh/Cargo.toml
+++ b/native/rust/crates/ripdpi-ssh/Cargo.toml
@@ -10,5 +10,8 @@ russh = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "rt", "sync"] }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["net", "rt-multi-thread", "time", "macros", "io-util"] }
+
 [lints]
 workspace = true

--- a/native/rust/crates/ripdpi-ssh/src/config.rs
+++ b/native/rust/crates/ripdpi-ssh/src/config.rs
@@ -77,6 +77,9 @@ impl SshConfig {
     /// material is present, and — for a strict host-key policy — that the
     /// pinned fingerprint parses.
     pub fn validate(&self) -> Result<()> {
+        if self.host.trim().is_empty() {
+            return Err(SshError::EmptyHost);
+        }
         if self.port == 0 {
             return Err(SshError::InvalidPort);
         }
@@ -214,6 +217,13 @@ mod tests {
         let mut config = valid_config();
         config.port = 0;
         assert!(matches!(config.validate(), Err(SshError::InvalidPort)));
+    }
+
+    #[test]
+    fn empty_host_is_rejected() {
+        let mut config = valid_config();
+        config.host = "   ".to_string();
+        assert!(matches!(config.validate(), Err(SshError::EmptyHost)));
     }
 
     #[test]

--- a/native/rust/crates/ripdpi-ssh/src/error.rs
+++ b/native/rust/crates/ripdpi-ssh/src/error.rs
@@ -5,6 +5,10 @@ use thiserror::Error;
 /// Errors surfaced by the SSH outbound engine.
 #[derive(Debug, Error)]
 pub enum SshError {
+    /// The host is empty. SSH always dials a named host, so a blank host is
+    /// rejected before any I/O.
+    #[error("SSH host must not be empty")]
+    EmptyHost,
     /// The server port is outside the valid `1..=65535` range.
     #[error("SSH server port must be in 1..=65535")]
     InvalidPort,

--- a/native/rust/crates/ripdpi-ssh/tests/loopback.rs
+++ b/native/rust/crates/ripdpi-ssh/tests/loopback.rs
@@ -1,0 +1,228 @@
+//! In-process loopback integration tests for `ripdpi-ssh`.
+//!
+//! Stands up a minimal `russh` server on a random loopback port, then drives
+//! the public `ripdpi_ssh::connect` + `SshClient::tcp_connect` API through the
+//! real russh crypto stack.
+//!
+//! Tests:
+//! 1. `password_auth_echo` — password auth, correct host-key pin, direct-tcpip
+//!    channel opened, payload written and echo'd back.
+//! 2. `wrong_host_key_pin_rejected` — a different valid fingerprint string causes
+//!    `connect` to return `SshError::HostKeyMismatch`.
+//! 3. `tofu_no_pin_rejects_untrusted` — TOFU with no pin causes `connect` to
+//!    return `SshError::HostKeyUntrusted`.
+
+use std::sync::Arc;
+
+use russh::Channel;
+use russh::keys::ssh_key::private::Ed25519Keypair;
+use russh::keys::{HashAlg, PrivateKey};
+use russh::server::{Auth, Msg, Session};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use ripdpi_ssh::{SshAuth, SshConfig, SshError, SshHostKeyPolicy, connect};
+
+// ---------------------------------------------------------------------------
+// Fixed deterministic server key
+// ---------------------------------------------------------------------------
+
+/// 32-byte Ed25519 seed used to build a deterministic host key for tests.
+/// Deterministic so the fingerprint can be computed once and reused across
+/// all test helpers without RNG dependencies.
+const SERVER_KEY_SEED: [u8; 32] = [
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13,
+    0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+];
+
+/// A second distinct seed for the "wrong fingerprint" test.
+const WRONG_KEY_SEED: [u8; 32] = [
+    0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf2, 0xf1, 0xf0, 0xef, 0xee, 0xed,
+    0xec, 0xeb, 0xea, 0xe9, 0xe8, 0xe7, 0xe6, 0xe5, 0xe4, 0xe3, 0xe2, 0xe1, 0xe0,
+];
+
+/// Build an Ed25519 `PrivateKey` deterministically from a 32-byte seed.
+/// Uses `ssh_key::private::Ed25519Keypair::from_seed` — no RNG required.
+fn make_host_key(seed: &[u8; 32]) -> PrivateKey {
+    let keypair = Ed25519Keypair::from_seed(seed);
+    PrivateKey::from(keypair)
+}
+
+/// Compute the `"SHA256:<base64>"` fingerprint string for a `PrivateKey`,
+/// matching the format that `russh`'s `check_server_key` callback receives.
+fn fingerprint_of(key: &PrivateKey) -> String {
+    key.public_key().fingerprint(HashAlg::Sha256).to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Minimal echo server
+// ---------------------------------------------------------------------------
+
+/// Minimal russh server handler that:
+/// - accepts any password credential,
+/// - opens `direct-tcpip` channels and echoes every byte back to the client.
+#[derive(Clone)]
+struct EchoHandler;
+
+impl russh::server::Server for EchoHandler {
+    type Handler = Self;
+
+    fn new_client(&mut self, _: Option<std::net::SocketAddr>) -> Self {
+        self.clone()
+    }
+}
+
+impl russh::server::Handler for EchoHandler {
+    type Error = russh::Error;
+
+    // cancel-safe: no awaits; returns immediately.
+    async fn auth_password(&mut self, _user: &str, _password: &str) -> Result<Auth, russh::Error> {
+        Ok(Auth::Accept)
+    }
+
+    // cancel-safe: spawns a detached echo task and returns Ok(true) immediately;
+    // the spawned task is independent and its lifecycle is not observed.
+    async fn channel_open_direct_tcpip(
+        &mut self,
+        channel: Channel<Msg>,
+        _host_to_connect: &str,
+        _port_to_connect: u32,
+        _originator_address: &str,
+        _originator_port: u32,
+        _session: &mut Session,
+    ) -> Result<bool, russh::Error> {
+        tokio::spawn(async move {
+            let mut stream = channel.into_stream();
+            let mut buf = [0u8; 4096];
+            loop {
+                match stream.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        if stream.write_all(&buf[..n]).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+        Ok(true)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Server harness
+// ---------------------------------------------------------------------------
+
+/// Binds a `TcpListener` on `127.0.0.1:0`, spawns an `EchoHandler` russh
+/// server backed by `host_key`, and returns the assigned port.
+// cancel-safe: binds and spawns without shared mutable state; dropping before
+// await resolves leaves the runtime clean.
+async fn spawn_echo_server(host_key: PrivateKey) -> u16 {
+    let server_config = Arc::new(russh::server::Config {
+        keys: vec![host_key],
+        auth_rejection_time: std::time::Duration::from_millis(0),
+        auth_rejection_time_initial: Some(std::time::Duration::from_millis(0)),
+        ..Default::default()
+    });
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind must succeed");
+    let port = listener.local_addr().expect("must have local addr").port();
+
+    tokio::spawn(async move {
+        if let Ok((tcp_stream, _)) = listener.accept().await {
+            let _running = russh::server::run_stream(server_config, tcp_stream, EchoHandler)
+                .await
+                .expect("run_stream must succeed");
+            // Keep _running alive so the session stays open for the test.
+            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+        }
+    });
+
+    port
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Test 1: password auth + correct host-key pin + direct-tcpip echo.
+#[tokio::test(flavor = "multi_thread")]
+async fn password_auth_echo() {
+    let host_key = make_host_key(&SERVER_KEY_SEED);
+    let fingerprint = fingerprint_of(&host_key);
+    let port = spawn_echo_server(host_key).await;
+
+    let config = SshConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        username: "testuser".to_string(),
+        auth: SshAuth::Password("any-password".to_string()),
+        host_key_policy: SshHostKeyPolicy::Strict { fingerprint },
+    };
+
+    let client = connect(&config).await.expect("connect must succeed with correct pin");
+    let mut stream = client.tcp_connect("127.0.0.1:9").await.expect("tcp_connect must open channel");
+
+    let payload = b"hello ripdpi-ssh loopback";
+    stream.write_all(payload).await.expect("write must succeed");
+
+    let mut echo_buf = vec![0u8; payload.len()];
+    stream.read_exact(&mut echo_buf).await.expect("read_exact must receive the echo");
+
+    assert_eq!(echo_buf, payload, "echoed bytes must match the payload");
+}
+
+/// Test 2: wrong host-key pin → `SshError::HostKeyMismatch`.
+///
+/// Server uses `SERVER_KEY_SEED`; client pins the fingerprint of a key built
+/// from `WRONG_KEY_SEED`.  The hashes differ, so the host-key check must fire.
+#[tokio::test(flavor = "multi_thread")]
+async fn wrong_host_key_pin_rejected() {
+    let host_key = make_host_key(&SERVER_KEY_SEED);
+    let port = spawn_echo_server(host_key).await;
+
+    // Pin the fingerprint of a *different* valid key — will never match the server.
+    let wrong_fp = fingerprint_of(&make_host_key(&WRONG_KEY_SEED));
+
+    let config = SshConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        username: "testuser".to_string(),
+        auth: SshAuth::Password("any-password".to_string()),
+        host_key_policy: SshHostKeyPolicy::Strict { fingerprint: wrong_fp },
+    };
+
+    let error = connect(&config).await.expect_err("mismatched pin must cause connect to fail");
+    assert!(matches!(error, SshError::HostKeyMismatch { .. }), "expected HostKeyMismatch, got {error:?}",);
+}
+
+/// Test 3: TOFU with no pin → `SshError::HostKeyUntrusted`.
+///
+/// The engine must never silently trust a first-use key; it surfaces the
+/// fingerprint as `HostKeyUntrusted` so the UI can prompt the user.
+#[tokio::test(flavor = "multi_thread")]
+async fn tofu_no_pin_rejects_untrusted() {
+    let host_key = make_host_key(&SERVER_KEY_SEED);
+    let expected_b64 =
+        fingerprint_of(&host_key).strip_prefix("SHA256:").expect("fingerprint must start with SHA256:").to_string();
+    let port = spawn_echo_server(host_key).await;
+
+    let config = SshConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        username: "testuser".to_string(),
+        auth: SshAuth::Password("any-password".to_string()),
+        host_key_policy: SshHostKeyPolicy::Tofu { pinned_fingerprint: None },
+    };
+
+    let error = connect(&config).await.expect_err("TOFU with no pin must reject the key");
+
+    // The error must carry the exact base64 digest (without the "SHA256:" prefix)
+    // so the UI can display it for user confirmation.
+    match error {
+        SshError::HostKeyUntrusted(presented_fp) => {
+            assert_eq!(presented_fp, expected_b64, "HostKeyUntrusted must carry the server's actual fingerprint",);
+        }
+        other => panic!("expected HostKeyUntrusted, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## SSH relay — fully functional end to end

Makes the SSH relay reachable to a working tunnel from both entry points (import / subscription **and** the dedicated editor), replacing the stubbed/“not yet functional” surfaces with real activation.

### Ground-truth correction
The prompt’s premise (Rust engine stubbed, builder returns `Unimplemented`) was **stale**. Verified against source: `ripdpi-ssh` is a complete `russh` engine (connect, host-key TOFU, password + private-key auth, `direct-tcpip`, clean `Drop`), `SshSessionFactory::create_session` already calls it, the relay-core builder already returns the real `RelayBackend::Ssh`, and the Kotlin settings/resolver spine (`sshSection()`, `RelayCredentialRecord`, `RipDpiRelayConfig`, `RelaySectionCodec`, descriptor, `ssh://` URI codec + subscription parser) was already wired. The only `Unimplemented` was a **stale doc comment**.

### The actual gaps closed
- **Import/subscription → activate:** `activateNativeRelayProfile` had no SSH arm (silent no-op → no tunnel). Extracted the activation into a shared **`RelayProfileActivator`** (used by the import VM and the editor) and added the SSH arm: `relayKind=ssh`, UDP disabled (`direct-tcpip` is TCP-only), `setRelaySsh*` settings, ssh credentials.
- **Dedicated editor → tunnel:** `SshProfileEditorState.toProfile()` builds a `ProxyProfile.Ssh`; `SshProfileViewModel.onSave` persists + activates via the shared activator and the screen navigates back. Removed the now-false **“Not yet functional”** banner + its strings across all **8 locales**.
- **Share/export:** added the SSH arm to `RelayProfileShareMapper` (record + credentials → `ProxyProfile.Ssh` → canonical `ssh://`), refusing when the auth-relevant secret is absent.
- **Data:** `RelayProfileRecord` gained `sshAuthType/sshHostKeyFingerprint/sshStrictHostKey` (additive, defaulted — no schema bump).
- **Docs:** corrected the stale relay-core SSH builder comment (real engine + UID-routing socket-safety model).

### Socket safety (Phase 1 resolved)
`russh` opens its own outbound socket under the app UID, which is excluded from the TUN by UID-level routing — identical to `ripdpi-trojan`. **No per-socket `VpnService.protect()` and no protected connector are required**; the diff adds no new socket creation. (Confirmed by a protect-invariant grep.)

### Tests
- **Rust (new):** `ripdpi-ssh/tests/loopback.rs` — in-process `russh` echo server (deterministic Ed25519 host key, no new locked deps) driving a full connect → host-key verify → password auth → `direct-tcpip` → echo, plus wrong-pin `HostKeyMismatch` and no-pin `HostKeyUntrusted` rejections.
- **Kotlin (new):** import-activation SSH case (`ImportConfirmViewModelTest`, asserts UDP disabled + ssh settings/creds), `RelayProfileShareMapperSshTest` (round-trip + refusal), and an `ssh` capability pin in `RelayKindDescriptorDriftTest`.
- Relay-core flat config round-trip for SSH already exists and passes.

### Verification (tier: unit + in-crate loopback; no live external SSH fixture in CI)
- `cargo test` ssh chain: relay-core 87, ripdpi-ssh 28 unit + 3 loopback — all green. `cargo fmt --check` clean. `cargo clippy -D warnings` clean (incl. workspace clippy via pre-commit hook).
- Kotlin: `:core:service` drift test and `:app` `proxyimport` tests green (`testGithubDebugUnitTest`).
- CI-only native gates pre-run: hotspot LoC budgets ok, native contracts 0 violations, arch-health `--check` 0 new/worsened/stale.
- **Adversarial (independent agents):** protect-invariant — PASS (no socket bypass); cancel-safety of the russh channel under teardown — PASS (non-blocking guarded `Drop`, async `Mutex`, await-holding lints clean); connect now either succeeds or surfaces a typed `SshError` — never silent.

### Notes
- Dedicated `*ProfileScreen` editors are preview-only for every kind today; this PR makes the SSH editor actually persist+activate (the chosen scope), via the shared activator rather than a one-off path.
- RDS: removed the obsolete `ssh_not_functional` error banner (content) — the backend is now functional.
- The `ssh` drift-test pin rode into the share-export commit (staged from an earlier attempt); functionally present in HEAD.

Do not merge — review only.
