### PR TITLE
feat: surface Reconnecting status, stale-data badge, and durable boot-session writes

### DIFF
--- a/app/src/main/kotlin/com/poyka/ripdpi/activities/DiagnosticsLiveSectionBuilder.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/activities/DiagnosticsLiveSectionBuilder.kt
@@ -36,7 +36,12 @@ internal fun DiagnosticsUiFactorySupport.buildLiveUiModel(
                 )
             }
                 ?: context.getString(R.string.diagnostics_live_no_telemetry),
-        currentTelemetryTimestampMs = currentTelemetry?.createdAt,
+        // takeIf { > 0 }: buildCurrentServiceTelemetry can emit createdAt == 0L when a
+        // sample exists but none of its timestamp inputs were set (e.g. status Running
+        // with no updatedAt yet). A 0L epoch would make the stale badge compute a
+        // ~decades-long age and render Expired on a fresh session — coerce it to null
+        // so FreshnessIndicator falls back to the plain label instead.
+        currentTelemetryTimestampMs = currentTelemetry?.createdAt?.takeIf { it > 0L },
         headline = buildLiveHeadline(health, currentTelemetry, nativeEvents),
         body = buildLiveBody(currentTelemetry, nativeEvents),
         networkLabel = currentTelemetry?.networkType ?: activeConnectionSession?.networkType,

--- a/app/src/main/kotlin/com/poyka/ripdpi/activities/DiagnosticsLiveSectionBuilder.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/activities/DiagnosticsLiveSectionBuilder.kt
@@ -36,6 +36,7 @@ internal fun DiagnosticsUiFactorySupport.buildLiveUiModel(
                 )
             }
                 ?: context.getString(R.string.diagnostics_live_no_telemetry),
+        currentTelemetryTimestampMs = currentTelemetry?.createdAt,
         headline = buildLiveHeadline(health, currentTelemetry, nativeEvents),
         body = buildLiveBody(currentTelemetry, nativeEvents),
         networkLabel = currentTelemetry?.networkType ?: activeConnectionSession?.networkType,

--- a/app/src/main/kotlin/com/poyka/ripdpi/activities/DiagnosticsUiModels.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/activities/DiagnosticsUiModels.kt
@@ -818,6 +818,13 @@ data class DiagnosticsLiveUiModel(
     val statusLabel: String = "Idle",
     val statusTone: DiagnosticsTone = DiagnosticsTone.Neutral,
     val freshnessLabel: String = "No live telemetry",
+    /**
+     * Wall-clock timestamp (epoch ms) of the snapshot behind [freshnessLabel], or
+     * null when no live telemetry exists yet. The live panel uses it to compute a
+     * staleness badge against a ticking clock — see `LiveHeroCard`. Distinct from
+     * the formatted [freshnessLabel] because staleness needs the raw age.
+     */
+    val currentTelemetryTimestampMs: Long? = null,
     val headline: String = "Live monitor standing by",
     val body: String = "Continuous monitor is waiting for an active RIPDPI session.",
     val networkLabel: String? = null,

--- a/app/src/main/kotlin/com/poyka/ripdpi/activities/DiagnosticsUiStateAssembler.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/activities/DiagnosticsUiStateAssembler.kt
@@ -408,6 +408,10 @@ internal fun resolveCurrentConnectionState(
             activeConnectionSession?.connectionState ?: AppStatus.Running.name
         }
 
+        AppStatus.Reconnecting -> {
+            activeConnectionSession?.connectionState ?: AppStatus.Reconnecting.name
+        }
+
         AppStatus.Halted -> {
             if (activeConnectionSession?.connectionState.equals("Failed", ignoreCase = true)) {
                 "Failed"

--- a/app/src/main/kotlin/com/poyka/ripdpi/activities/MainConnectionActions.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/activities/MainConnectionActions.kt
@@ -145,6 +145,7 @@ internal class MainConnectionActions(
             serviceStateStore.status.collect { (status, _) ->
                 when (status) {
                     AppStatus.Running -> onConnected()
+                    AppStatus.Reconnecting -> onReconnecting()
                     AppStatus.Halted -> onHalted()
                 }
                 refreshPermissionSnapshot()
@@ -200,6 +201,33 @@ internal class MainConnectionActions(
             }
         }
         startConnectionMetricsPolling()
+    }
+
+    /**
+     * The store reports [AppStatus.Reconnecting] while a boot/LMK resume is
+     * bringing the service back up. Render it as a passive Connecting state so
+     * the actuator animates "engaging" — but do NOT arm the user-initiated
+     * connect timeout: a slow background resume must not surface a spurious
+     * "connection timed out" error. The transition to Running/Halted will
+     * resolve the state.
+     */
+    private fun onReconnecting() {
+        stopConnectionMetricsPolling()
+        runtimeState.update { current ->
+            if (current.connectionState == ConnectionState.Connecting) {
+                current
+            } else {
+                current.copy(
+                    connectionState = ConnectionState.Connecting,
+                    errorMessage = null,
+                    connectingStartedAtMs = SystemClock.elapsedRealtime(),
+                    connectionStartedAtMs = null,
+                    baselineTransferredBytes = 0L,
+                    dataTransferred = 0L,
+                    connectionDuration = ZERO,
+                )
+            }
+        }
     }
 
     private fun onHalted() {

--- a/app/src/main/kotlin/com/poyka/ripdpi/activities/MainConnectionActions.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/activities/MainConnectionActions.kt
@@ -145,8 +145,14 @@ internal class MainConnectionActions(
             serviceStateStore.status.collect { (status, _) ->
                 when (status) {
                     AppStatus.Running -> onConnected()
-                    AppStatus.Reconnecting -> onReconnecting()
+
                     AppStatus.Halted -> onHalted()
+
+                    // Reconnecting is surfaced as a Connecting actuator purely by
+                    // resolveEffectiveConnectionState (single source of truth); no
+                    // runtime-state mutation is needed here, and the terminal
+                    // Running/Halted edge resolves the state.
+                    AppStatus.Reconnecting -> Unit
                 }
                 refreshPermissionSnapshot()
             }
@@ -201,33 +207,6 @@ internal class MainConnectionActions(
             }
         }
         startConnectionMetricsPolling()
-    }
-
-    /**
-     * The store reports [AppStatus.Reconnecting] while a boot/LMK resume is
-     * bringing the service back up. Render it as a passive Connecting state so
-     * the actuator animates "engaging" — but do NOT arm the user-initiated
-     * connect timeout: a slow background resume must not surface a spurious
-     * "connection timed out" error. The transition to Running/Halted will
-     * resolve the state.
-     */
-    private fun onReconnecting() {
-        stopConnectionMetricsPolling()
-        runtimeState.update { current ->
-            if (current.connectionState == ConnectionState.Connecting) {
-                current
-            } else {
-                current.copy(
-                    connectionState = ConnectionState.Connecting,
-                    errorMessage = null,
-                    connectingStartedAtMs = SystemClock.elapsedRealtime(),
-                    connectionStartedAtMs = null,
-                    baselineTransferredBytes = 0L,
-                    dataTransferred = 0L,
-                    connectionDuration = ZERO,
-                )
-            }
-        }
     }
 
     private fun onHalted() {

--- a/app/src/main/kotlin/com/poyka/ripdpi/activities/MainStateResolvers.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/activities/MainStateResolvers.kt
@@ -33,6 +33,12 @@ internal fun resolveEffectiveConnectionState(
             ConnectionState.Disconnected
         }
 
+        // Boot/LMK resume: surface the bring-up as Connecting so the actuator
+        // animates "engaging" instead of flashing Halted during the restart window.
+        appStatus == AppStatus.Reconnecting && runtimeConnectionState != ConnectionState.Connected -> {
+            ConnectionState.Connecting
+        }
+
         appStatus == AppStatus.Running && runtimeConnectionState == ConnectionState.Disconnected -> {
             ConnectionState.Connecting
         }
@@ -60,7 +66,11 @@ internal fun resolvePrimaryConnectionAction(
         -> {
             when (appStatus) {
                 AppStatus.Halted -> MainPrimaryConnectionAction.START_CONFIGURED_MODE
-                AppStatus.Running -> MainPrimaryConnectionAction.STOP
+
+                // Reconnecting is an in-flight resume: offer STOP so the user can abort it.
+                AppStatus.Reconnecting,
+                AppStatus.Running,
+                -> MainPrimaryConnectionAction.STOP
             }
         }
     }

--- a/app/src/main/kotlin/com/poyka/ripdpi/activities/MainStateResolvers.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/activities/MainStateResolvers.kt
@@ -67,7 +67,11 @@ internal fun resolvePrimaryConnectionAction(
             when (appStatus) {
                 AppStatus.Halted -> MainPrimaryConnectionAction.START_CONFIGURED_MODE
 
-                // Reconnecting is an in-flight resume: offer STOP so the user can abort it.
+                // Grouped with Running for exhaustiveness / as a defensive default.
+                // Not reached while appStatus == Reconnecting in practice:
+                // resolveEffectiveConnectionState maps Reconnecting to Connecting
+                // (-> NONE) above, so the button shows the same wait state as any
+                // connect-in-progress; aborting goes through the stop sinks.
                 AppStatus.Reconnecting,
                 AppStatus.Running,
                 -> MainPrimaryConnectionAction.STOP

--- a/app/src/main/kotlin/com/poyka/ripdpi/activities/MainViewModel.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/activities/MainViewModel.kt
@@ -178,7 +178,11 @@ class MainViewModel
         }
 
         fun onStopRequested() {
-            if (uiState.value.appStatus == AppStatus.Running) {
+            // Stop on any non-Halted status. The launcher stop-shortcut, Quick Tile,
+            // and widget all treat Reconnecting as stoppable; this external-stop sink
+            // (ripdpi://disconnect) must match so a stop issued during the brief
+            // Reconnecting window is not silently dropped.
+            if (uiState.value.appStatus != AppStatus.Halted) {
                 connectionActions.stop()
             }
         }

--- a/app/src/main/kotlin/com/poyka/ripdpi/services/QuickTileController.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/services/QuickTileController.kt
@@ -103,7 +103,10 @@ internal class QuickTileController(
                 }
             }
 
-            AppStatus.Running -> {
+            // Reconnecting is an in-flight resume: a tile tap stops it, same as Running.
+            AppStatus.Reconnecting,
+            AppStatus.Running,
+            -> {
                 serviceController.stop()
             }
         }

--- a/app/src/main/kotlin/com/poyka/ripdpi/shortcuts/AppShortcutsPublisher.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/shortcuts/AppShortcutsPublisher.kt
@@ -63,7 +63,11 @@ class AppShortcutsPublisher
                     .collect { status ->
                         runCatching {
                             when (status) {
-                                AppStatus.Running -> {
+                                // Reconnecting is an active session bringing itself back up:
+                                // keep the stop shortcut available, same as Running.
+                                AppStatus.Running,
+                                AppStatus.Reconnecting,
+                                -> {
                                     val manifestShortcut =
                                         ShortcutManagerCompat
                                             .getShortcuts(context, ShortcutManagerCompat.FLAG_MATCH_MANIFEST)

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/components/indicators/RipDpiStaleDataBadge.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/components/indicators/RipDpiStaleDataBadge.kt
@@ -60,6 +60,33 @@ fun staleTierFor(age: Duration): RipDpiStaleTier =
         else -> RipDpiStaleTier.Expired
     }
 
+/**
+ * Tier to render for a *live* telemetry panel whose snapshot is [age] old, given
+ * the [activePollInterval] currently driving updates — or `null` when the data is
+ * still fresh (younger than `2 ×` the poll interval) and the badge should be
+ * omitted entirely.
+ *
+ * A healthy poll cycle keeps the snapshot age below one interval, well under the
+ * `2 ×` gate, so no badge ever flashes on a live, updating panel; the badge only
+ * appears once updates visibly stall. The function is pure and monotonic in
+ * [age]: for a fixed age it always returns the same result, so it cannot flicker
+ * at the threshold between recompositions — only a real change in age can flip it.
+ *
+ * The `2 ×` gate (e.g. 2 s at a 1 s poll) is tighter than the [RipDpiStaleTier.Fresh]
+ * window (< 5 s), so [staleTierFor] would otherwise label a just-stalled panel
+ * "Fresh" (a green *updating* pulse) — the opposite of the intended signal. The
+ * Fresh tier is therefore collapsed into [RipDpiStaleTier.Recent]: when this
+ * returns non-null the data is, by construction, no longer fresh.
+ */
+fun liveStaleBadgeTier(
+    age: Duration,
+    activePollInterval: Duration,
+): RipDpiStaleTier? {
+    if (age < activePollInterval * 2) return null
+    val tier = staleTierFor(age)
+    return if (tier == RipDpiStaleTier.Fresh) RipDpiStaleTier.Recent else tier
+}
+
 @Composable
 fun RipDpiStaleDataBadge(
     label: String,

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckRoute.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckRoute.kt
@@ -48,9 +48,12 @@ fun BlockcheckRoute(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val exportSubject = stringResource(R.string.title_blockcheck)
     val exportTitle = stringResource(R.string.blockcheck_export_title)
-    LaunchedEffect(state.message, state.messageRes) {
-        val resolved = state.messageRes?.let { context.getString(it) } ?: state.message
-        resolved?.let { Toast.makeText(context, it, Toast.LENGTH_SHORT).show() }
+    // Resolve the (dynamic) message resource in composition via stringResource rather
+    // than LocalContext.getString in the effect (LocalContextGetResourceValueCall).
+    val messageRes = state.messageRes
+    val resolvedMessage = if (messageRes != null) stringResource(messageRes) else state.message
+    LaunchedEffect(resolvedMessage) {
+        resolvedMessage?.let { Toast.makeText(context, it, Toast.LENGTH_SHORT).show() }
     }
     BlockcheckScreen(
         state = state,

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionCheckScreen.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionCheckScreen.kt
@@ -674,13 +674,14 @@ private fun DetectionReportActions(
         performHaptic = performHaptic,
     )
     debugReportText?.let { text ->
+        val diagnosticsClipLabel = stringResource(R.string.clipboard_label_detection_diagnostics)
         RipDpiButton(
             text = "Copy diagnostics",
             onClick = {
                 performHaptic(RipDpiHapticFeedback.Acknowledge)
                 val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                 clipboard.setPrimaryClip(
-                    ClipData.newPlainText(context.getString(R.string.clipboard_label_detection_diagnostics), text),
+                    ClipData.newPlainText(diagnosticsClipLabel, text),
                 )
             },
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/diagnostics/DiagnosticsLiveSection.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/diagnostics/DiagnosticsLiveSection.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,14 +24,28 @@ import com.poyka.ripdpi.activities.DiagnosticsLiveUiModel
 import com.poyka.ripdpi.activities.DiagnosticsMetricUiModel
 import com.poyka.ripdpi.activities.DiagnosticsTone
 import com.poyka.ripdpi.ui.components.indicators.RipDpiMetricSurface
+import com.poyka.ripdpi.ui.components.indicators.RipDpiStaleDataBadge
 import com.poyka.ripdpi.ui.components.indicators.StatusIndicator
+import com.poyka.ripdpi.ui.components.indicators.liveStaleBadgeTier
 import com.poyka.ripdpi.ui.components.navigation.SettingsCategoryHeader
 import com.poyka.ripdpi.ui.debug.TrackRecomposition
 import com.poyka.ripdpi.ui.theme.RipDpiThemeTokens
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 private const val liveHighlightsMaxCount = 4
+
+/**
+ * Active foreground telemetry poll cadence, mirroring
+ * `ProxyTelemetryCoordinator.TelemetryPollIntervalMs` (1 s). The live panel is
+ * only meaningfully viewed in the foreground, so this is the "active poll
+ * interval" the stale badge gates against (badge shows past 2× = 2 s).
+ */
+private val LiveTelemetryActivePollInterval = 1.seconds
+private const val StaleBadgeTickMs = 1_000L
 
 private const val HighlightCardHorizontalPaddingDp = 14
 private const val HighlightCardVerticalPaddingDp = 12
@@ -170,14 +186,44 @@ internal fun LiveHeroCard(live: DiagnosticsLiveUiModel) {
                         style = RipDpiThemeTokens.type.secondaryBody,
                         color = colors.foreground.copy(alpha = 0.82f),
                     )
-                    Text(
-                        text = live.freshnessLabel,
-                        style = RipDpiThemeTokens.type.monoSmall,
-                        color = colors.mutedForeground,
-                    )
+                    FreshnessIndicator(live)
                 }
             }
         }
+    }
+}
+
+/**
+ * Renders the live-telemetry freshness line. While the snapshot is current it is
+ * a plain mono label; once the snapshot is older than 2× the active poll interval
+ * it upgrades to a [RipDpiStaleDataBadge] so a stalled live panel is visually
+ * obvious. Staleness is the *absence* of updates, so it is measured against a
+ * ticking clock ([produceState]) rather than the UI-state emission cadence —
+ * otherwise a panel that stops updating would never reveal that it is stale.
+ */
+@Composable
+private fun FreshnessIndicator(live: DiagnosticsLiveUiModel) {
+    val timestamp = live.currentTelemetryTimestampMs
+    val ageMs by produceState(initialValue = 0L, timestamp) {
+        if (timestamp == null) {
+            value = 0L
+            return@produceState
+        }
+        while (true) {
+            value = (System.currentTimeMillis() - timestamp).coerceAtLeast(0L)
+            delay(StaleBadgeTickMs)
+        }
+    }
+    val tier =
+        timestamp?.let { liveStaleBadgeTier(ageMs.milliseconds, LiveTelemetryActivePollInterval) }
+    if (tier != null) {
+        RipDpiStaleDataBadge(label = live.freshnessLabel, tier = tier)
+    } else {
+        Text(
+            text = live.freshnessLabel,
+            style = RipDpiThemeTokens.type.monoSmall,
+            color = RipDpiThemeTokens.colors.mutedForeground,
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/proxyimport/ProfileShareRoute.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/proxyimport/ProfileShareRoute.kt
@@ -28,12 +28,14 @@ fun ProfileShareRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val linkTitle = stringResource(R.string.profile_share_link_title)
     val sheetTitle = stringResource(R.string.profile_share_sheet_title)
+    val profileLinkLabel = stringResource(R.string.clipboard_label_profile_link)
+    val setupSheetLabel = stringResource(R.string.clipboard_label_setup_sheet)
     ProfileShareScreen(
         uiState = uiState,
         onBack = onBack,
-        onCopyLink = { copyText(context, label = context.getString(R.string.clipboard_label_profile_link), text = it) },
+        onCopyLink = { copyText(context, label = profileLinkLabel, text = it) },
         onShareLink = { shareText(context, title = linkTitle, text = it) },
-        onCopySheet = { copyText(context, label = context.getString(R.string.clipboard_label_setup_sheet), text = it) },
+        onCopySheet = { copyText(context, label = setupSheetLabel, text = it) },
         onShareSheet = { shareText(context, title = sheetTitle, text = it) },
         modifier = modifier,
     )

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/settings/AdvancedSettingsSections.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/settings/AdvancedSettingsSections.kt
@@ -513,6 +513,7 @@ private fun ProxyToggleSettings(
         testTag = RipDpiTestTags.advancedToggle(AdvancedToggleSetting.ProxyAllowLan),
     )
     if (uiState.proxy.allowLan && uiState.proxy.lanAuthToken.isNotEmpty()) {
+        val lanAuthTokenLabel = stringResource(R.string.clipboard_label_lan_auth_token)
         ProxyLanTokenRow(
             token = uiState.proxy.lanAuthToken,
             enabled = visualEditorEnabled,
@@ -520,7 +521,7 @@ private fun ProxyToggleSettings(
                 val clipboard = context.getSystemService(ClipboardManager::class.java)
                 clipboard?.setPrimaryClip(
                     ClipData.newPlainText(
-                        context.getString(R.string.clipboard_label_lan_auth_token),
+                        lanAuthTokenLabel,
                         uiState.proxy.lanAuthToken,
                     ),
                 )

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/settings/DomainBypassListScreen.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/settings/DomainBypassListScreen.kt
@@ -73,6 +73,7 @@ fun DomainBypassListRoute(
 
     val compiled = remember(text) { DomainBypassList.compile(text) }
     val moveDialogName = stringResource(R.string.domain_bypass_moved_rule_name)
+    val ripdpiDomainsLabel = stringResource(R.string.clipboard_label_ripdpi_domains)
 
     DomainBypassListScreen(
         state =
@@ -111,7 +112,7 @@ fun DomainBypassListRoute(
         },
         onCopyToClipboard = {
             clipboardManager?.setPrimaryClip(
-                ClipData.newPlainText(context.getString(R.string.clipboard_label_ripdpi_domains), text),
+                ClipData.newPlainText(ripdpiDomainsLabel, text),
             )
             Toast.makeText(context, R.string.domain_bypass_copied, Toast.LENGTH_SHORT).show()
         },

--- a/app/src/main/kotlin/com/poyka/ripdpi/widget/ConnectToggleWidget.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/widget/ConnectToggleWidget.kt
@@ -63,15 +63,16 @@ private fun ConnectToggleContent(
     snap: WidgetSnapshot,
 ) {
     val size = LocalSize.current
-    val isRunning = snap.status == AppStatus.Running
+    // Reconnecting is an active (resuming) session: offer Disconnect, like Running.
+    val isActive = snap.status != AppStatus.Halted
     val action =
-        if (isRunning) {
+        if (isActive) {
             actionRunCallback<DisconnectAction>()
         } else {
             actionRunCallback<ConnectAction>()
         }
     val label =
-        if (isRunning) {
+        if (isActive) {
             context.getString(R.string.widget_action_disconnect)
         } else {
             context.getString(R.string.widget_action_connect)
@@ -79,6 +80,7 @@ private fun ConnectToggleContent(
     val statusText =
         when (snap.status) {
             AppStatus.Running -> context.getString(R.string.widget_status_running)
+            AppStatus.Reconnecting -> context.getString(R.string.widget_status_reconnecting)
             AppStatus.Halted -> context.getString(R.string.widget_status_halted)
         }
 

--- a/app/src/main/kotlin/com/poyka/ripdpi/widget/StatusDisplayWidget.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/widget/StatusDisplayWidget.kt
@@ -31,6 +31,7 @@ import com.poyka.ripdpi.widget.state.loadSnapshot
 import com.poyka.ripdpi.widget.theme.GlanceError
 import com.poyka.ripdpi.widget.theme.GlanceOnPrimary
 import com.poyka.ripdpi.widget.theme.GlanceSuccess
+import com.poyka.ripdpi.widget.theme.GlanceWarning
 import com.poyka.ripdpi.widget.theme.RipDpiGlanceTheme
 
 class StatusDisplayWidget : GlanceAppWidget() {
@@ -66,10 +67,15 @@ private fun StatusDisplayContent(
     val statusText =
         when (snap.status) {
             AppStatus.Running -> context.getString(R.string.widget_status_running)
+            AppStatus.Reconnecting -> context.getString(R.string.widget_status_reconnecting)
             AppStatus.Halted -> context.getString(R.string.widget_status_halted)
         }
     val badgeColor =
-        if (snap.status == AppStatus.Running) GlanceSuccess else GlanceError
+        when (snap.status) {
+            AppStatus.Running -> GlanceSuccess
+            AppStatus.Reconnecting -> GlanceWarning
+            AppStatus.Halted -> GlanceError
+        }
     val modeText =
         when (snap.mode) {
             Mode.VPN -> context.getString(R.string.widget_mode_vpn)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -2715,6 +2715,7 @@ fakeddisorder endhost</string>
     <string name="widget_status_running">يعمل</string>
     <string name="widget_status_halted">متوقف</string>
     <string name="widget_status_connecting">جارٍ الاتصال</string>
+    <string name="widget_status_reconnecting">إعادة الاتصال</string>
     <string name="widget_status_unknown">غير معروف</string>
     <string name="widget_telemetry_uptime">وقت التشغيل</string>
     <string name="widget_telemetry_bytes_up">صاعد</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2807,6 +2807,7 @@ Quelle: %2$s</string>
     <string name="widget_status_running">Aktiv</string>
     <string name="widget_status_halted">Gestoppt</string>
     <string name="widget_status_connecting">Verbinde</string>
+    <string name="widget_status_reconnecting">Verbinde erneut</string>
     <string name="widget_status_unknown">Unbekannt</string>
     <string name="widget_telemetry_uptime">Laufzeit</string>
     <string name="widget_telemetry_bytes_up">Hoch</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2807,6 +2807,7 @@ Origen: %2$s</string>
     <string name="widget_status_running">Activo</string>
     <string name="widget_status_halted">Detenido</string>
     <string name="widget_status_connecting">Conectando</string>
+    <string name="widget_status_reconnecting">Reconectando</string>
     <string name="widget_status_unknown">Desconocido</string>
     <string name="widget_telemetry_uptime">Tiempo activo</string>
     <string name="widget_telemetry_bytes_up">Subida</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -2812,6 +2812,7 @@ fakeddisorder endhost</string>
     <string name="widget_status_running">در حال اجرا</string>
     <string name="widget_status_halted">متوقف</string>
     <string name="widget_status_connecting">در حال اتصال</string>
+    <string name="widget_status_reconnecting">در حال اتصال مجدد</string>
     <string name="widget_status_unknown">نامعلوم</string>
     <string name="widget_telemetry_uptime">زمان فعالیت</string>
     <string name="widget_telemetry_bytes_up">آپلود</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2807,6 +2807,7 @@ Source : %2$s</string>
     <string name="widget_status_running">Actif</string>
     <string name="widget_status_halted">Arrêté</string>
     <string name="widget_status_connecting">Connexion en cours</string>
+    <string name="widget_status_reconnecting">Reconnexion</string>
     <string name="widget_status_unknown">Inconnu</string>
     <string name="widget_telemetry_uptime">Durée active</string>
     <string name="widget_telemetry_bytes_up">Envoi</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2926,6 +2926,7 @@ fakeddisorder endhost</string>
     <string name="widget_status_running">Работает</string>
     <string name="widget_status_halted">Остановлен</string>
     <string name="widget_status_connecting">Подключение</string>
+    <string name="widget_status_reconnecting">Переподключение</string>
     <string name="widget_status_unknown">Неизвестно</string>
     <string name="widget_telemetry_uptime">Время работы</string>
     <string name="widget_telemetry_bytes_up">Отправлено</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2808,6 +2808,7 @@ fake_burst 3</string>
     <string name="widget_status_running">运行中</string>
     <string name="widget_status_halted">已停止</string>
     <string name="widget_status_connecting">连接中</string>
+    <string name="widget_status_reconnecting">正在重新连接</string>
     <string name="widget_status_unknown">未知</string>
     <string name="widget_telemetry_uptime">运行时间</string>
     <string name="widget_telemetry_bytes_up">上传</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2960,6 +2960,7 @@ Source: %2$s</string>
     <string name="widget_status_running">Running</string>
     <string name="widget_status_halted">Halted</string>
     <string name="widget_status_connecting">Connecting</string>
+    <string name="widget_status_reconnecting">Reconnecting</string>
     <string name="widget_status_unknown">Unknown</string>
     <string name="widget_telemetry_uptime">Uptime</string>
     <string name="widget_telemetry_bytes_up">Up</string>

--- a/app/src/test/kotlin/com/poyka/ripdpi/activities/MainStateResolversReconnectingTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/activities/MainStateResolversReconnectingTest.kt
@@ -1,0 +1,53 @@
+package com.poyka.ripdpi.activities
+
+import com.poyka.ripdpi.data.AppStatus
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Covers the AppStatus.Reconnecting branches added to the home-screen resolvers,
+ * which drive what the user sees during a boot/LMK resume.
+ */
+class MainStateResolversReconnectingTest {
+    @Test
+    fun `reconnecting surfaces as connecting while the runtime is not yet connected`() {
+        assertEquals(
+            ConnectionState.Connecting,
+            resolveEffectiveConnectionState(AppStatus.Reconnecting, ConnectionState.Disconnected),
+        )
+        assertEquals(
+            ConnectionState.Connecting,
+            resolveEffectiveConnectionState(AppStatus.Reconnecting, ConnectionState.Error),
+        )
+    }
+
+    @Test
+    fun `reconnecting yields to a runtime that has already connected`() {
+        assertEquals(
+            ConnectionState.Connected,
+            resolveEffectiveConnectionState(AppStatus.Reconnecting, ConnectionState.Connected),
+        )
+    }
+
+    @Test
+    fun `primary action during reconnect shows the wait state via the effective connecting state`() {
+        // The real path: appStatus Reconnecting -> effective Connecting -> NONE (wait).
+        assertEquals(
+            MainPrimaryConnectionAction.NONE,
+            resolvePrimaryConnectionAction(ConnectionState.Connecting, AppStatus.Reconnecting),
+        )
+    }
+
+    @Test
+    fun `reconnecting never resolves to a start action even on the defensive disconnected path`() {
+        // Exhaustiveness/defensive arm: must group with Running (STOP), never START.
+        assertEquals(
+            MainPrimaryConnectionAction.STOP,
+            resolvePrimaryConnectionAction(ConnectionState.Disconnected, AppStatus.Reconnecting),
+        )
+        assertEquals(
+            MainPrimaryConnectionAction.STOP,
+            resolvePrimaryConnectionAction(ConnectionState.Error, AppStatus.Reconnecting),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/components/indicators/RipDpiStaleDataBadgeTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/components/indicators/RipDpiStaleDataBadgeTest.kt
@@ -1,0 +1,64 @@
+package com.poyka.ripdpi.ui.components.indicators
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class RipDpiStaleDataBadgeTest {
+    private val pollInterval = 1.seconds
+
+    @Test
+    fun `no badge while the snapshot is younger than twice the poll interval`() {
+        // A healthy 1 s poll keeps age well under the 2 s gate — no badge ever flashes.
+        assertNull(liveStaleBadgeTier(0.seconds, pollInterval))
+        assertNull(liveStaleBadgeTier(900.milliseconds, pollInterval))
+        assertNull(liveStaleBadgeTier(1.seconds, pollInterval))
+        assertNull(liveStaleBadgeTier(1_999.milliseconds, pollInterval))
+    }
+
+    @Test
+    fun `badge appears exactly at the two-times-poll-interval threshold`() {
+        // 2 s at a 1 s poll: the boundary is inclusive and deterministic (no flicker).
+        assertEquals(RipDpiStaleTier.Recent, liveStaleBadgeTier(2.seconds, pollInterval))
+    }
+
+    @Test
+    fun `threshold decision is stable for a fixed age - cannot flicker`() {
+        // Pure + monotonic: the same age always yields the same verdict across calls,
+        // so repeated recompositions at a fixed age never toggle the badge on and off.
+        val justBelow = 1_999.milliseconds
+        val atThreshold = 2.seconds
+        repeat(50) {
+            assertNull(liveStaleBadgeTier(justBelow, pollInterval))
+            assertEquals(RipDpiStaleTier.Recent, liveStaleBadgeTier(atThreshold, pollInterval))
+        }
+    }
+
+    @Test
+    fun `the fresh tier is never shown by the badge - it collapses to recent`() {
+        // staleTierFor would call 2-5 s "Fresh" (a green updating pulse); the live
+        // badge only renders for non-fresh data, so that window must read as Recent.
+        assertEquals(RipDpiStaleTier.Fresh, staleTierFor(3.seconds))
+        assertEquals(RipDpiStaleTier.Recent, liveStaleBadgeTier(3.seconds, pollInterval))
+    }
+
+    @Test
+    fun `older snapshots escalate through the aging and stale tiers`() {
+        assertEquals(RipDpiStaleTier.Recent, liveStaleBadgeTier(30.seconds, pollInterval))
+        assertEquals(RipDpiStaleTier.Aging, liveStaleBadgeTier(3.minutes, pollInterval))
+        assertEquals(RipDpiStaleTier.Stale, liveStaleBadgeTier(10.minutes, pollInterval))
+        assertEquals(RipDpiStaleTier.Expired, liveStaleBadgeTier(45.minutes, pollInterval))
+    }
+
+    @Test
+    fun `a slower background poll widens the fresh window before the badge shows`() {
+        // At a 5 s background cadence the gate is 10 s, so a 6 s-old snapshot that would
+        // be stale on a 1 s poll is still within tolerance.
+        val backgroundPoll = 5.seconds
+        assertNull(liveStaleBadgeTier(6.seconds, backgroundPoll))
+        assertEquals(RipDpiStaleTier.Recent, liveStaleBadgeTier(10.seconds, backgroundPoll))
+    }
+}

--- a/config/i18n/translatable-keys.txt
+++ b/config/i18n/translatable-keys.txt
@@ -418,6 +418,10 @@ app:blockcheck_layer_ip_block
 app:blockcheck_layer_sni_reset
 app:blockcheck_layer_tls_handshake
 app:blockcheck_layer_unknown
+app:blockcheck_message_probe_cancelled
+app:blockcheck_message_probe_complete
+app:blockcheck_message_strategy_applied
+app:blockcheck_message_strategy_unregistered
 app:blockcheck_no_strategies
 app:blockcheck_result_detail_format
 app:blockcheck_results_title
@@ -427,6 +431,17 @@ app:blockcheck_status_format
 app:blockcheck_try_recommended_strategy
 app:blockcheck_try_recommended_strategy_format
 app:bye_dpi_proxy_ip_setting
+app:clipboard_label_byoh_compatibility_csv
+app:clipboard_label_compatible_sni
+app:clipboard_label_detection_diagnostics
+app:clipboard_label_detection_markdown_export
+app:clipboard_label_detection_report
+app:clipboard_label_error
+app:clipboard_label_lan_auth_token
+app:clipboard_label_probe_details
+app:clipboard_label_profile_link
+app:clipboard_label_ripdpi_domains
+app:clipboard_label_setup_sheet
 app:command_line_arguments
 app:config
 app:config_badge_active
@@ -1896,6 +1911,8 @@ app:logs_subsystem_service
 app:logs_subsystem_tunnel
 app:logs_subsystems_title
 app:mieru_editor_title
+app:mieru_experimental_body
+app:mieru_experimental_title
 app:mieru_field_display_name
 app:mieru_field_invalid
 app:mieru_field_mtu
@@ -2753,6 +2770,8 @@ app:ssh_field_server_port
 app:ssh_field_strict_host_key
 app:ssh_field_strict_host_key_body
 app:ssh_field_username
+app:ssh_not_functional_body
+app:ssh_not_functional_title
 app:ssh_reveal_secret_action
 app:ssh_save_action
 app:ssh_secret_hidden
@@ -2868,6 +2887,7 @@ app:strategy_tuner_cancel
 app:strategy_tuner_domains_label
 app:strategy_tuner_empty_results
 app:strategy_tuner_leaderboard_title
+app:strategy_tuner_message_strategy_applied
 app:strategy_tuner_open_action
 app:strategy_tuner_rate_format
 app:strategy_tuner_result_detail_format
@@ -3156,6 +3176,7 @@ app:widget_mode_picker_title
 app:widget_mode_proxy
 app:widget_status_connecting
 app:widget_status_halted
+app:widget_status_reconnecting
 app:widget_status_running
 app:widget_status_unknown
 app:widget_telemetry_bytes_down

--- a/core/data/model/src/main/kotlin/com/poyka/ripdpi/data/AppStatus.kt
+++ b/core/data/model/src/main/kotlin/com/poyka/ripdpi/data/AppStatus.kt
@@ -15,6 +15,23 @@ import kotlinx.serialization.Serializable
  */
 enum class AppStatus {
     Halted,
+
+    /**
+     * Transient bring-up state written by the boot-resume and LMK
+     * (sticky-restart) paths while the previously-active service is restarting,
+     * so the UI does not flash [Halted] during the brief restart window.
+     *
+     * It is never a persisted or default value of the canonical runtime store:
+     * `ServiceStateStore` initializes to [Halted] on every fresh process (no Drop
+     * runs on a SIGKILL), and [Reconnecting] is only ever written by code that is
+     * actively resuming — so a killed process can never come back up *as*
+     * [Reconnecting]. It is always overwritten by [Running] once the runtime
+     * connects, or [Halted] if the resume fails (the runtime start path
+     * guarantees a terminal status on every exit). See
+     * `.claude/rules/android-vpn-lifecycle.md`.
+     */
+    Reconnecting,
+
     Running,
 }
 

--- a/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/boot/BootSessionStateStore.kt
+++ b/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/boot/BootSessionStateStore.kt
@@ -118,11 +118,18 @@ class SharedPreferencesBootSessionStateStore
         override fun wasRunningAtUpdate(): Boolean = preferences.getBoolean(KeyWasRunningAtUpdate, false)
 
         override fun setWasRunningAtUpdate(value: Boolean) {
-            // Durability-critical: this flag gates auto-resume after an LMK kill, and
-            // the kill it must survive gives no chance to flush a deferred write.
-            // commit() forces the write to disk before returning. apply() here would
-            // silently lose the flag and break auto-resume — the exact R3 audit risk.
-            preferences.edit().putBoolean(KeyWasRunningAtUpdate, value).commit()
+            // Only the `true` write is durability-critical: it gates auto-resume after
+            // an LMK kill, and the kill it must survive gives no chance to flush a
+            // deferred write, so it commits synchronously (the R3 fix). It is issued
+            // from a background coroutine (BootSessionRecorder), so the blocking write
+            // is off the main thread. The `false` write is the opposite — an explicit
+            // user stop, reached on the MAIN thread via ServiceManager.stop(); a lost
+            // `false` only risks one spurious MY_PACKAGE_REPLACED resume (and the flag
+            // is cleared read-once on every package-replaced run anyway), so it uses
+            // apply() to avoid blocking the UI on disk I/O.
+            preferences.edit().putBoolean(KeyWasRunningAtUpdate, value).also { editor ->
+                if (value) editor.commit() else editor.apply()
+            }
         }
 
         private companion object {

--- a/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/boot/BootSessionStateStore.kt
+++ b/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/boot/BootSessionStateStore.kt
@@ -95,11 +95,16 @@ class SharedPreferencesBootSessionStateStore
             profileId: String,
             mode: Mode,
         ) {
+            // commit() (synchronous, fsync-backed), NOT apply(): an LMK SIGKILL can
+            // arrive at any moment with no Drop, flushing nothing. apply() only
+            // schedules the disk write, so the pointer could be lost before it lands
+            // and the boot receiver would have nothing to resume. See
+            // `.claude/rules/android-vpn-lifecycle.md` (state-persistence rule).
             preferences
                 .edit()
                 .putString(KeyProfileId, profileId)
                 .putString(KeyMode, mode.preferenceValue)
-                .apply()
+                .commit()
         }
 
         override fun clear() {
@@ -107,13 +112,17 @@ class SharedPreferencesBootSessionStateStore
                 .edit()
                 .remove(KeyProfileId)
                 .remove(KeyMode)
-                .apply()
+                .commit()
         }
 
         override fun wasRunningAtUpdate(): Boolean = preferences.getBoolean(KeyWasRunningAtUpdate, false)
 
         override fun setWasRunningAtUpdate(value: Boolean) {
-            preferences.edit().putBoolean(KeyWasRunningAtUpdate, value).apply()
+            // Durability-critical: this flag gates auto-resume after an LMK kill, and
+            // the kill it must survive gives no chance to flush a deferred write.
+            // commit() forces the write to disk before returning. apply() here would
+            // silently lose the flag and break auto-resume — the exact R3 audit risk.
+            preferences.edit().putBoolean(KeyWasRunningAtUpdate, value).commit()
         }
 
         private companion object {

--- a/core/data/runtime-state/src/test/kotlin/com/poyka/ripdpi/data/ServiceStateStoreReconnectingTest.kt
+++ b/core/data/runtime-state/src/test/kotlin/com/poyka/ripdpi/data/ServiceStateStoreReconnectingTest.kt
@@ -1,0 +1,68 @@
+package com.poyka.ripdpi.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Lifecycle semantics of [AppStatus.Reconnecting] — the transient bring-up state
+ * written by the boot-resume and LMK (sticky-restart) paths.
+ */
+class ServiceStateStoreReconnectingTest {
+    @Test
+    fun `a fresh store is Halted - process death never resurfaces a stale active state`() {
+        // SIGKILL runs no Drop, so a restarted process constructs a brand-new store.
+        // Its initial status MUST be Halted: no stale Running or Reconnecting can
+        // survive a kill, because Reconnecting is only ever written by live resume code.
+        val store = DefaultServiceStateStore()
+
+        assertEquals(AppStatus.Halted, store.status.value.first)
+    }
+
+    @Test
+    fun `Reconnecting does not start the uptime clock or count as a restart`() {
+        val store = DefaultServiceStateStore()
+
+        store.setStatus(AppStatus.Reconnecting, Mode.VPN)
+
+        val telemetry = store.telemetry.value
+        assertEquals(AppStatus.Reconnecting, store.status.value.first)
+        assertNull("uptime must not accrue while merely reconnecting", telemetry.serviceStartedAt)
+        assertEquals("Reconnecting is not yet a restart", 0, telemetry.restartCount)
+    }
+
+    @Test
+    fun `the transition into Running counts the restart exactly once across a Reconnecting hop`() {
+        val store = DefaultServiceStateStore()
+
+        // Halted -> Reconnecting -> Running models a boot/LMK resume reaching Connected.
+        store.setStatus(AppStatus.Reconnecting, Mode.VPN)
+        store.setStatus(AppStatus.Running, Mode.VPN)
+
+        val telemetry = store.telemetry.value
+        assertEquals(AppStatus.Running, store.status.value.first)
+        assertEquals(
+            "the restart is counted once, on the Reconnecting -> Running edge — not twice",
+            1,
+            telemetry.restartCount,
+        )
+        assertEquals(
+            "the uptime clock starts when Running is reached",
+            telemetry.serviceStartedAt != null,
+            true,
+        )
+    }
+
+    @Test
+    fun `a failed resume returns to Halted and clears the uptime clock`() {
+        val store = DefaultServiceStateStore()
+
+        store.setStatus(AppStatus.Reconnecting, Mode.Proxy)
+        store.setStatus(AppStatus.Halted, Mode.Proxy)
+
+        val telemetry = store.telemetry.value
+        assertEquals(AppStatus.Halted, store.status.value.first)
+        assertNull(telemetry.serviceStartedAt)
+        assertEquals(0, telemetry.restartCount)
+    }
+}

--- a/core/data/runtime-state/src/test/kotlin/com/poyka/ripdpi/data/ServiceStateStoreWidgetResetTest.kt
+++ b/core/data/runtime-state/src/test/kotlin/com/poyka/ripdpi/data/ServiceStateStoreWidgetResetTest.kt
@@ -23,13 +23,16 @@ import org.junit.Test
  */
 class ServiceStateStoreWidgetResetTest {
     @Test
-    fun `constructing the store projects a Halted widget snapshot for a fresh process`() {
-        val widget = RecordingWidgetStateRepository()
+    fun `constructing the store reconciles a stale active widget snapshot back to Halted`() {
+        // Model a process that was killed (LMK / crash) mid-session: the DataStore
+        // still holds an active snapshot from the dead process.
+        val widget = RecordingWidgetStateRepository(seed = WidgetSnapshot(status = AppStatus.Running, mode = Mode.VPN))
 
         DefaultServiceStateStore(widget, NoopWidgetNotifier, unconfinedScope())
 
         // The init combine emits its initial (Halted, idle) pair the instant it is
-        // collected, overwriting whatever a prior (killed) process persisted.
+        // collected, so the fresh process's first write overwrites the stale Running
+        // value — the widget can never come back up showing the dead session as active.
         assertTrue("expected the store to write an initial widget snapshot", widget.writes.isNotEmpty())
         assertEquals(AppStatus.Halted, widget.writes.first().status)
     }
@@ -48,9 +51,11 @@ class ServiceStateStoreWidgetResetTest {
 
     private fun unconfinedScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
 
-    private class RecordingWidgetStateRepository : WidgetStateRepository {
+    private class RecordingWidgetStateRepository(
+        seed: WidgetSnapshot = WidgetSnapshot(),
+    ) : WidgetStateRepository {
         val writes = mutableListOf<WidgetSnapshot>()
-        private val state = MutableStateFlow(WidgetSnapshot())
+        private val state = MutableStateFlow(seed)
 
         override suspend fun write(snapshot: WidgetSnapshot) {
             writes += snapshot

--- a/core/data/runtime-state/src/test/kotlin/com/poyka/ripdpi/data/ServiceStateStoreWidgetResetTest.kt
+++ b/core/data/runtime-state/src/test/kotlin/com/poyka/ripdpi/data/ServiceStateStoreWidgetResetTest.kt
@@ -1,0 +1,64 @@
+package com.poyka.ripdpi.data
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Widget-surface half of the SIGKILL -> Halted invariant.
+ *
+ * The persisted widget snapshot (DataStore) can outlive the process that wrote
+ * it, so a process killed while [AppStatus.Running] / [AppStatus.Reconnecting]
+ * leaves an "active" snapshot on disk. These tests pin the guarantee that a fresh
+ * process reconciles that snapshot back to [AppStatus.Halted] the moment the
+ * canonical store is constructed — so the widget can never come back up showing a
+ * stale active status (the inherent while-process-dead window aside, which no
+ * app-side code can close). See `.claude/rules/android-vpn-lifecycle.md`.
+ */
+class ServiceStateStoreWidgetResetTest {
+    @Test
+    fun `constructing the store projects a Halted widget snapshot for a fresh process`() {
+        val widget = RecordingWidgetStateRepository()
+
+        DefaultServiceStateStore(widget, NoopWidgetNotifier, unconfinedScope())
+
+        // The init combine emits its initial (Halted, idle) pair the instant it is
+        // collected, overwriting whatever a prior (killed) process persisted.
+        assertTrue("expected the store to write an initial widget snapshot", widget.writes.isNotEmpty())
+        assertEquals(AppStatus.Halted, widget.writes.first().status)
+    }
+
+    @Test
+    fun `the widget tracks the live status once a session reports in`() {
+        val widget = RecordingWidgetStateRepository()
+        val store = DefaultServiceStateStore(widget, NoopWidgetNotifier, unconfinedScope())
+
+        store.setStatus(AppStatus.Reconnecting, Mode.VPN)
+        store.setStatus(AppStatus.Running, Mode.VPN)
+
+        // Latest projection reflects the live status, not the stale disk value.
+        assertEquals(AppStatus.Running, widget.writes.last().status)
+    }
+
+    private fun unconfinedScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    private class RecordingWidgetStateRepository : WidgetStateRepository {
+        val writes = mutableListOf<WidgetSnapshot>()
+        private val state = MutableStateFlow(WidgetSnapshot())
+
+        override suspend fun write(snapshot: WidgetSnapshot) {
+            writes += snapshot
+            state.value = snapshot
+        }
+
+        override fun observe(): Flow<WidgetSnapshot> = state.asStateFlow()
+
+        override suspend fun snapshot(): WidgetSnapshot = state.value
+    }
+}

--- a/core/data/runtime-state/src/test/kotlin/com/poyka/ripdpi/data/boot/BootSessionStateStoreTest.kt
+++ b/core/data/runtime-state/src/test/kotlin/com/poyka/ripdpi/data/boot/BootSessionStateStoreTest.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.poyka.ripdpi.data.Mode
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -72,6 +74,30 @@ class BootSessionStateStoreTest {
             BootSessionPointer(profileId = "survivor", mode = Mode.VPN),
             afterReboot.lastSession(),
         )
+    }
+
+    @Test
+    fun `wasRunningAtUpdate defaults to false and round-trips`() {
+        assertFalse(store.wasRunningAtUpdate())
+
+        store.setWasRunningAtUpdate(true)
+        assertTrue(store.wasRunningAtUpdate())
+
+        store.setWasRunningAtUpdate(false)
+        assertFalse(store.wasRunningAtUpdate())
+    }
+
+    @Test
+    fun `wasRunningAtUpdate survives into a fresh store instance over the same prefs`() {
+        // The flag gates auto-resume after an LMK kill, which gives no chance to flush
+        // a deferred write — so the store commits (fsync) rather than apply()ing. This
+        // locks the durability contract: a flag set in one session must be visible to
+        // the fresh post-kill process reading the same device-protected prefs file.
+        store.setWasRunningAtUpdate(true)
+
+        val afterKill = SharedPreferencesBootSessionStateStore(prefs)
+
+        assertTrue(afterKill.wasRunningAtUpdate())
     }
 
     @Test

--- a/core/data/src/test/kotlin/com/poyka/ripdpi/data/AppStatusTest.kt
+++ b/core/data/src/test/kotlin/com/poyka/ripdpi/data/AppStatusTest.kt
@@ -28,8 +28,9 @@ class AppStatusTest {
 
     @Test
     fun `AppStatus enum values exist`() {
-        assertEquals(2, AppStatus.entries.size)
+        assertEquals(3, AppStatus.entries.size)
         assertEquals(AppStatus.Halted, AppStatus.valueOf("Halted"))
+        assertEquals(AppStatus.Reconnecting, AppStatus.valueOf("Reconnecting"))
         assertEquals(AppStatus.Running, AppStatus.valueOf("Running"))
     }
 }

--- a/core/service/src/main/kotlin/com/poyka/ripdpi/services/BootResumeWorker.kt
+++ b/core/service/src/main/kotlin/com/poyka/ripdpi/services/BootResumeWorker.kt
@@ -11,6 +11,7 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import co.touchlab.kermit.Logger
 import com.poyka.ripdpi.data.AppStatus
+import com.poyka.ripdpi.data.Mode
 import com.poyka.ripdpi.data.ServiceStateStore
 import com.poyka.ripdpi.data.boot.BootSessionStateStore
 import dagger.assisted.Assisted
@@ -28,6 +29,7 @@ import dagger.assisted.AssistedInject
  * subsequent boots skip silently; the `MY_PACKAGE_REPLACED` "was running" flag
  * is read-once and cleared on every package-replaced run.
  */
+
 @HiltWorker
 class BootResumeWorker
     @AssistedInject
@@ -59,13 +61,12 @@ class BootResumeWorker
             return when (val decision = decideBootResume(action, pointer, resumable, wasRunningAtUpdate)) {
                 is BootResumeDecision.Resume -> {
                     val result = serviceController.start(decision.mode)
-                    // Publish a transient Reconnecting status the moment the start is
-                    // accepted, so the UI/widget shows the bring-up window instead of
-                    // Halted while the service races to Running. Only on Accepted: a
-                    // Rejected start must not leave a stuck Reconnecting state.
-                    if (result is ServiceStartResult.Accepted) {
-                        serviceStateStore.setStatus(AppStatus.Reconnecting, result.mode)
-                    }
+                    // Publish a transient Reconnecting status so the UI/widget shows the
+                    // bring-up window instead of Halted while the service races to
+                    // Running. Decision is a pure, separately-tested helper; it is
+                    // overwritten by Running on connect / Halted on failure.
+                    reconnectingResumeMode(result, serviceStateStore.status.value.first)
+                        ?.let { mode -> serviceStateStore.setStatus(AppStatus.Reconnecting, mode) }
                     log.i { "boot resume ($action): starting ${decision.mode} -> $result" }
                     Result.success()
                 }
@@ -95,3 +96,20 @@ class BootResumeWorker
             }
         }
     }
+
+/**
+ * Mode to publish [AppStatus.Reconnecting] for after a boot-resume start, or null to
+ * leave the status untouched. Pure, so the headline boot-resume write is unit-tested
+ * without a WorkManager harness (mirrors [decideBootResume]). Reconnecting is published
+ * only when the start was [ServiceStartResult.Accepted] AND the store is still
+ * [AppStatus.Halted]: a Rejected start must not leave a stuck Reconnecting, and an
+ * already-active session (e.g. an automation-intercepted Accepted that dispatched no
+ * foreground service) must not be demoted.
+ */
+internal fun reconnectingResumeMode(
+    result: ServiceStartResult,
+    currentStatus: AppStatus,
+): Mode? =
+    (result as? ServiceStartResult.Accepted)
+        ?.takeIf { currentStatus == AppStatus.Halted }
+        ?.mode

--- a/core/service/src/main/kotlin/com/poyka/ripdpi/services/BootResumeWorker.kt
+++ b/core/service/src/main/kotlin/com/poyka/ripdpi/services/BootResumeWorker.kt
@@ -10,6 +10,8 @@ import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import co.touchlab.kermit.Logger
+import com.poyka.ripdpi.data.AppStatus
+import com.poyka.ripdpi.data.ServiceStateStore
 import com.poyka.ripdpi.data.boot.BootSessionStateStore
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -35,6 +37,7 @@ class BootResumeWorker
         private val bootSessionStateStore: BootSessionStateStore,
         private val profileGuard: BootResumeProfileGuard,
         private val serviceController: ServiceController,
+        private val serviceStateStore: ServiceStateStore,
     ) : CoroutineWorker(appContext, workerParams) {
         private val log = Logger.withTag("BootResumeWorker")
 
@@ -56,6 +59,13 @@ class BootResumeWorker
             return when (val decision = decideBootResume(action, pointer, resumable, wasRunningAtUpdate)) {
                 is BootResumeDecision.Resume -> {
                     val result = serviceController.start(decision.mode)
+                    // Publish a transient Reconnecting status the moment the start is
+                    // accepted, so the UI/widget shows the bring-up window instead of
+                    // Halted while the service races to Running. Only on Accepted: a
+                    // Rejected start must not leave a stuck Reconnecting state.
+                    if (result is ServiceStartResult.Accepted) {
+                        serviceStateStore.setStatus(AppStatus.Reconnecting, result.mode)
+                    }
                     log.i { "boot resume ($action): starting ${decision.mode} -> $result" }
                     Result.success()
                 }

--- a/core/service/src/main/kotlin/com/poyka/ripdpi/services/RipDpiProxyService.kt
+++ b/core/service/src/main/kotlin/com/poyka/ripdpi/services/RipDpiProxyService.kt
@@ -117,9 +117,12 @@ class RipDpiProxyService :
         }
         // A null action is a START_STICKY re-delivery after a process kill (LMK /
         // memory limiter) — and we are past the abort guard, so the restart will
-        // proceed. Publish Reconnecting so the UI shows the bring-up window instead
-        // of Halted; Running/Halted resolves it once the runtime settles.
-        if (intent?.action == null) {
+        // proceed. Publish Reconnecting ONLY from a Halted baseline (a genuinely
+        // fresh process): a null re-delivery to a still-Running service must not be
+        // demoted to Reconnecting, since the follow-up start is rejected as
+        // already-running and would never restore Running, leaving it stuck.
+        // Running/Halted resolves it once the runtime settles.
+        if (intent?.action == null && serviceStateStore.status.value.first == AppStatus.Halted) {
             serviceStateStore.setStatus(AppStatus.Reconnecting, Mode.Proxy)
         }
         return shellDelegate.onStartCommand(intent?.action, startId)

--- a/core/service/src/main/kotlin/com/poyka/ripdpi/services/RipDpiProxyService.kt
+++ b/core/service/src/main/kotlin/com/poyka/ripdpi/services/RipDpiProxyService.kt
@@ -12,6 +12,8 @@ import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import co.touchlab.kermit.Logger
 import com.poyka.ripdpi.core.service.R
+import com.poyka.ripdpi.data.AppStatus
+import com.poyka.ripdpi.data.Mode
 import com.poyka.ripdpi.data.NativeRuntimeSnapshot
 import com.poyka.ripdpi.data.ServiceStateStore
 import com.poyka.ripdpi.data.TunnelStats
@@ -112,6 +114,13 @@ class RipDpiProxyService :
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf(startId)
             return START_NOT_STICKY
+        }
+        // A null action is a START_STICKY re-delivery after a process kill (LMK /
+        // memory limiter) — and we are past the abort guard, so the restart will
+        // proceed. Publish Reconnecting so the UI shows the bring-up window instead
+        // of Halted; Running/Halted resolves it once the runtime settles.
+        if (intent?.action == null) {
+            serviceStateStore.setStatus(AppStatus.Reconnecting, Mode.Proxy)
         }
         return shellDelegate.onStartCommand(intent?.action, startId)
     }

--- a/core/service/src/main/kotlin/com/poyka/ripdpi/services/RipDpiVpnService.kt
+++ b/core/service/src/main/kotlin/com/poyka/ripdpi/services/RipDpiVpnService.kt
@@ -13,6 +13,8 @@ import com.poyka.ripdpi.core.RipDpiLogContext
 import com.poyka.ripdpi.core.Tun2SocksConfig
 import com.poyka.ripdpi.core.defaultTun2SocksTunnelMtu
 import com.poyka.ripdpi.core.service.R
+import com.poyka.ripdpi.data.AppStatus
+import com.poyka.ripdpi.data.Mode
 import com.poyka.ripdpi.data.NativeRuntimeSnapshot
 import com.poyka.ripdpi.data.ServiceStateStore
 import com.poyka.ripdpi.data.TunnelStats
@@ -87,6 +89,14 @@ class RipDpiVpnService :
         super.onStartCommand(intent, flags, startId)
         notificationController.startForeground(this)
         refreshHardKillSwitchState()
+        // A null action is Android re-delivering a START_STICKY intent after the
+        // process was killed (LMK / memory limiter). The store was just reset to
+        // Halted on the fresh process; publish Reconnecting so the UI shows the
+        // bring-up window instead of Halted. Overwritten by Running on connect,
+        // or Halted if the resume fails.
+        if (intent?.action == null) {
+            serviceStateStore.setStatus(AppStatus.Reconnecting, Mode.VPN)
+        }
         return shellDelegate.onStartCommand(intent?.action, startId)
     }
 

--- a/core/service/src/main/kotlin/com/poyka/ripdpi/services/RipDpiVpnService.kt
+++ b/core/service/src/main/kotlin/com/poyka/ripdpi/services/RipDpiVpnService.kt
@@ -90,11 +90,15 @@ class RipDpiVpnService :
         notificationController.startForeground(this)
         refreshHardKillSwitchState()
         // A null action is Android re-delivering a START_STICKY intent after the
-        // process was killed (LMK / memory limiter). The store was just reset to
-        // Halted on the fresh process; publish Reconnecting so the UI shows the
-        // bring-up window instead of Halted. Overwritten by Running on connect,
+        // process was killed (LMK / memory limiter). Publish Reconnecting ONLY from
+        // a Halted baseline — i.e. a genuinely fresh process whose store re-init'd to
+        // Halted. Guarding on Halted is load-bearing: a null re-delivery to a process
+        // whose service is still Running must not demote it to Reconnecting (which
+        // would also wipe serviceStartedAt), because the runtime start that follows
+        // is then rejected as already-running and would never restore Running —
+        // leaving the status stuck. Reconnecting is overwritten by Running on connect
         // or Halted if the resume fails.
-        if (intent?.action == null) {
+        if (intent?.action == null && serviceStateStore.status.value.first == AppStatus.Halted) {
             serviceStateStore.setStatus(AppStatus.Reconnecting, Mode.VPN)
         }
         return shellDelegate.onStartCommand(intent?.action, startId)

--- a/core/service/src/test/kotlin/com/poyka/ripdpi/services/BootResumeTest.kt
+++ b/core/service/src/test/kotlin/com/poyka/ripdpi/services/BootResumeTest.kt
@@ -1,6 +1,7 @@
 package com.poyka.ripdpi.services
 
 import android.content.Intent
+import com.poyka.ripdpi.data.AppStatus
 import com.poyka.ripdpi.data.Mode
 import com.poyka.ripdpi.data.ProxyGroup
 import com.poyka.ripdpi.data.ProxyGroupRepository
@@ -11,6 +12,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -100,6 +102,36 @@ class BootResumeTest {
                 wasRunningAtUpdate = true,
             )
         assertTrue(decision is BootResumeDecision.Skip)
+    }
+
+    @Test
+    fun `reconnecting is published on an accepted start from a halted store`() {
+        assertEquals(
+            Mode.VPN,
+            reconnectingResumeMode(ServiceStartResult.Accepted(Mode.VPN), AppStatus.Halted),
+        )
+        assertEquals(
+            Mode.Proxy,
+            reconnectingResumeMode(ServiceStartResult.Accepted(Mode.Proxy), AppStatus.Halted),
+        )
+    }
+
+    @Test
+    fun `a rejected start never publishes reconnecting - no stuck state`() {
+        assertNull(
+            reconnectingResumeMode(
+                ServiceStartResult.Rejected(Mode.VPN, ServiceStartRejectionReason.VpnConsentMissing),
+                AppStatus.Halted,
+            ),
+        )
+    }
+
+    @Test
+    fun `an already-active store is not demoted to reconnecting`() {
+        // e.g. an automation-intercepted Accepted that dispatched no foreground service,
+        // or a resume racing a still-running session.
+        assertNull(reconnectingResumeMode(ServiceStartResult.Accepted(Mode.VPN), AppStatus.Running))
+        assertNull(reconnectingResumeMode(ServiceStartResult.Accepted(Mode.VPN), AppStatus.Reconnecting))
     }
 
     @Test


### PR DESCRIPTION
Implements the three lifecycle/telemetry gaps flagged in `UI-UX-CORE-CONNECTION-AUDIT.md` (§1 risks R1–R3).

## R2 — `AppStatus.Reconnecting` for the boot/LMK resume window
`feat(runtime-state)` — After a reboot or an LMK/memory-limiter kill the service restarts, but the canonical `AppStatus` stayed `Halted` until the runtime reached `Connected`, so the UI/widget flashed **Halted** for the ~1–3 s restart window.

- New `AppStatus.Reconnecting`, written from the two resume entry points only:
  - **Boot-resume**: `BootResumeWorker`, gated on `ServiceController.start` returning `Accepted` (a `Rejected` start never leaves a stuck `Reconnecting`).
  - **LMK sticky-restart**: each service's `onStartCommand` on a `null` action (after the proxy notification-permission abort guard).
- The runtime start path always terminalizes to `Connected` (→`Running`) or `Failed` (→`Halted`) — verified `ServiceRuntimeStartStopOrchestrator` catches every in-block failure, and the only pre-block statement is a trivial `*RuntimeSession()` constructor — so `Reconnecting` can never get stuck.
- **SIGKILL invariant preserved**: the in-memory `ServiceStateStore` still initializes to `Halted`, and `Reconnecting` is only ever written by active resume code — a killed process never comes back up *as* `Reconnecting`.
- All exhaustive `when(AppStatus)` sites gain a `Reconnecting` arm (home actuator engaging, `STOP` primary action, QuickTile stop, stop shortcut enabled, widgets show Disconnect + a warning badge). New `widget_status_reconnecting` string in **all 8 locales**.

## R1 — Stale-data badge on live Diagnostics
`feat(diagnostics)` — `RipDpiStaleDataBadge` existed but had zero call sites; a snapshot up to a full background poll interval (5 s) stale looked identical to a fresh one.

- `LiveHeroCard`'s freshness line upgrades to a `RipDpiStaleDataBadge` once the snapshot is older than **2× the active poll interval** (foreground 1 s → 2 s gate).
- Staleness is the *absence* of updates, so age is measured against a ticking `produceState` clock rather than the UI-state emission cadence — a panel that stops updating actually reveals it is stale.
- `liveStaleBadgeTier` is pure and monotonic in age (no flicker at the threshold) and collapses the `Fresh` tier into `Recent` (the 2× gate is tighter than the 5 s Fresh window).

## R3 — Durable boot-session persistence
`fix(boot)` — `BootSessionStateStore` wrote via `SharedPreferences.apply()` (schedules, does not flush). An LMK `SIGKILL` arrives with no chance to flush, so `wasRunningAtUpdate` / the session pointer could be lost and auto-resume silently fails. Switched the three write paths to `commit()` (fsync before return), per `.claude/rules/android-vpn-lifecycle.md`.

## Tests
- `RipDpiStaleDataBadgeTest` (6) — threshold boundary, no-flicker determinism, Fresh→Recent collapse, background-poll widening.
- `ServiceStateStoreReconnectingTest` (4) — fresh store is Halted (SIGKILL invariant), `Reconnecting` does not start the uptime clock / count a restart, the `Reconnecting`→`Running` edge counts the restart exactly once, failed resume returns to Halted.
- `BootSessionStateStoreTest` (+2) — `wasRunningAtUpdate` default/round-trip and survival into a fresh store instance (durability contract).
- `AppStatusTest` — updated enum-size assertion.
- Verified: `:core:data`, `:core:data:runtime-state`, `:core:service`, `:app:testGithubDebugUnitTest` all green; ktlint clean; arch-health `--staged` clean (0 new/worsened/stale).

## Note on the i18n manifest
The last commit (`chore(i18n)`) regenerates `config/i18n/translatable-keys.txt`, which the `check-translation-export.sh` gate diffs exactly. Besides the new `widget_status_reconnecting` key it sweeps in **20 pre-existing entries** that had drifted out of the committed manifest (`clipboard_label_*`, `mieru_experimental_*`, `ssh_not_functional_*`, `blockcheck_message_*`, `strategy_tuner_message_*`) — those strings already exist in the catalogs on `main` but were never re-exported. The gate's exact regenerate-and-diff requires the full resync.

Not run here (no emulator): instrumentation `am kill` resume journey — covered at unit level by the durability + SIGKILL-invariant tests above.