### PR TITLE
docs(tasks): close both HIGH audit findings (relay drain + BSSID redaction) — verified at HEAD

### DIFF
--- a/docs/tasks/issues/epic-june-2026-audit-remediation.md
+++ b/docs/tasks/issues/epic-june-2026-audit-remediation.md
@@ -34,7 +34,18 @@ The audit confirmed the codebase is in good structural health but surfaced a P0 
 Child tasks (this epic is `parent:` for each):
 
 **High**
-- `fix-relay-core-session-leak-on-shutdown` — P0 spawned-session leak in `ripdpi-relay-core`.
+- ✅ `fix-relay-core-session-leak-on-shutdown` — P0 spawned-session leak in `ripdpi-relay-core`.
+  **Resolved — verified at HEAD 2026-06-14 (no code change needed; already landed).**
+  Shutdown path is fully wired: `RelayRuntime::stop()` → `RuntimeState::request_stop()` cancels
+  the parent `shutdown_token` (`runtime/state.rs`); every session is spawned on a `TaskTracker`
+  with a child cancel token and a biased `tokio::select!` on `cancel.cancelled()`
+  (`runtime/session.rs::spawn_socks_session`, the sole spawn site via the accept loop in
+  `runtime/listener.rs`); `RelayRuntime::run()` joins via `drain_sessions(SESSION_DRAIN_GRACE = 5s)`
+  and records an error if the grace window is exceeded (`runtime.rs`). Reproduce-before-fix test
+  `tests/shutdown_drain.rs::relay_runtime_stop_drains_in_flight_sessions_within_grace_window`
+  (3 idle SOCKS5 sessions over a real Shadowsocks loopback backend; asserts `run()` returns
+  in-window, `active_sessions()==0`, and client fds are released). Evidence: `cargo nextest run -p
+  ripdpi-relay-core --locked` → 87/87 passed incl. that test.
 - `redact-raw-bssid-in-detection-findings` — privacy violation in `LocationSignalsChecker`.
 
 **Medium — Rust correctness**

--- a/docs/tasks/issues/epic-june-2026-audit-remediation.md
+++ b/docs/tasks/issues/epic-june-2026-audit-remediation.md
@@ -46,7 +46,19 @@ Child tasks (this epic is `parent:` for each):
   (3 idle SOCKS5 sessions over a real Shadowsocks loopback backend; asserts `run()` returns
   in-window, `active_sessions()==0`, and client fds are released). Evidence: `cargo nextest run -p
   ripdpi-relay-core --locked` → 87/87 passed incl. that test.
-- `redact-raw-bssid-in-detection-findings` — privacy violation in `LocationSignalsChecker`.
+- ✅ `redact-raw-bssid-in-detection-findings` — privacy violation in `LocationSignalsChecker`.
+  **Resolved — verified at HEAD 2026-06-14 (no code change needed; already landed).**
+  `LocationSignalsChecker.evaluate()` emits only a presence flag — `BSSID: present` /
+  `BSSID: unavailable` / `BSSID: permission not granted` — never the raw value, with an inline
+  comment citing `.claude/rules/network-fingerprint-privacy.md`; the raw `bssid` field feeds only
+  `isUsableBssid()`. Regression test `LocationSignalsCheckerTest.raw BSSID never appears in a
+  Finding string` asserts no Finding contains the raw BSSID (any encoding) and that a usable BSSID
+  surfaces as `BSSID: present`; `placeholder BSSID is reported as unavailable` covers the sentinel.
+  Adjacent-checker sweep (all 22 checkers): no other checker interpolates a raw BSSID/SSID/MAC into
+  a Finding; `BeaconDbClient` surfaces only fixed status strings (`exact match` / `lookup failed
+  <code>` / …) — AP MACs go only into the outbound geolocate request body, never a Finding; no raw
+  BSSID is logged anywhere. Evidence: `:core:detection:testDebugUnitTest --tests
+  *LocationSignalsCheckerTest` → BUILD SUCCESSFUL.
 
 **Medium — Rust correctness**
 - `fix-panic-in-drop-exit-ip-cap-guard`
@@ -73,7 +85,7 @@ Child tasks (this epic is `parent:` for each):
 
 ## Ship definition
 
-- Both `high` tasks landed with tests (relay shutdown drains within a bounded timeout; no raw BSSID reachable in any serialized `Finding`/log).
+- ✅ Both `high` tasks landed with tests (relay shutdown drains within a bounded timeout; no raw BSSID reachable in any serialized `Finding`/log). **Met — verified at HEAD 2026-06-14; see the High child entries above for evidence.**
 - All `medium` Rust correctness tasks landed or explicitly deferred with rationale in their work log.
 - Architecture tasks either landed or moved to `NATIVE_RUST.md`-documented backlog with a CI growth guard.
 - This epic flips to `done` (file deleted) when every child is `done`/`dropped`.


### PR DESCRIPTION
## Summary

Closes the two **HIGH** findings in `epic-june-2026-audit-remediation`. Both were **verified resolved at HEAD (`origin/main` @ #153)** — the fixes had already landed in earlier work, so this PR records the close-out with code+test evidence rather than re-implementing. (The two named child task files don't exist as standalone docs, so status is recorded in the epic per "don't create new ones".)

### Finding 1 — P0 relay session leak (`ripdpi-relay-core`) — ✅ resolved
The shutdown drain is fully wired (the async-cancel-safety note was correct):
- `RelayRuntime::stop()` → `RuntimeState::request_stop()` cancels the parent `shutdown_token`.
- Every session is spawned on a `TaskTracker` with a **child** cancel token and a biased `select!` on `cancel.cancelled()` (`spawn_socks_session`); the accept loop is the **sole** spawn site (no bypass).
- `RelayRuntime::run()` joins via `drain_sessions(SESSION_DRAIN_GRACE = 5s)` and records an error if the window is exceeded.
- Reproduce-before-fix test `shutdown_drain::relay_runtime_stop_drains_in_flight_sessions_within_grace_window` (3 idle SOCKS5 sessions over a real Shadowsocks loopback; asserts `run()` returns in-window, `active_sessions()==0`, client fds released).
- **`cargo nextest run -p ripdpi-relay-core --locked` → 87/87 passed.**

### Finding 2 — raw BSSID in detection Finding (`LocationSignalsChecker`) — ✅ resolved
- `evaluate()` emits only a presence flag (`BSSID: present` / `unavailable` / `permission not granted`), never the raw value, with an inline comment citing `network-fingerprint-privacy.md`; the raw `bssid` feeds only `isUsableBssid()`.
- Regression test `LocationSignalsCheckerTest."raw BSSID never appears in a Finding string"` (+ placeholder→unavailable).
- **Adjacent-checker sweep (all 22 checkers):** no other checker interpolates a raw BSSID/SSID/MAC into a Finding; `BeaconDbClient` summaries are fixed status strings (AP MACs go only into the outbound geolocate request body, never a Finding); no raw BSSID is logged anywhere.
- **`:core:detection:testDebugUnitTest --tests *LocationSignalsCheckerTest` → BUILD SUCCESSFUL.**

### Why no code change
Each finding's code path + regression test already exist on `main` and match the epic's ship definition ("relay shutdown drains within a bounded timeout; no raw BSSID reachable in any serialized Finding/log"). Manufacturing edits would add risk with no benefit. The drain test and the BSSID test were read in full and executed green as part of this verification. An automated probe initially over-reported a phantom "not yet implemented" SSH banner during an adjacent audit; unrelated here, but a reminder that the verification is code-grounded, not claim-grounded.

Two atomic commits (one per finding) update the epic's High lane + ship definition. **Do not merge — Integration runner lands it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
