### PR TITLE
fix(proxy-runtime): TLS feedback propagation + verify 3 audit Rust-correctness findings

### DIFF
--- a/docs/tasks/issues/epic-june-2026-audit-remediation.md
+++ b/docs/tasks/issues/epic-june-2026-audit-remediation.md
@@ -40,7 +40,15 @@ Child tasks (this epic is `parent:` for each):
 **Medium — Rust correctness**
 - `fix-panic-in-drop-exit-ip-cap-guard`
 - `fix-socks5-core-panic-and-credential-truncation`
-- `restore-discarded-adaptive-routing-feedback`
+- ✅ `restore-discarded-adaptive-routing-feedback` — **Landed 2026-06-14.** The TLS branch of
+  `record_failure_feedback` (`ripdpi-proxy-runtime/.../routing/failure/feedback.rs`) was the last
+  feedback call still discarding its result with `let _ =`; switched to `?` for parity with its
+  sibling calls and the UDP-path fix. Honest scope: the wrapper is infallible, so the signal
+  already reached the direct-path learner — this is error-propagation consistency **plus** the
+  regression-lock test `tls_post_client_hello_failure_drives_learner_state` (asserts a TLS
+  post-client-hello failure → TCP success emits `TCP_POST_CLIENT_HELLO_FAILURE_TCP_OK`), the
+  parity coverage the routing/failure module lacked vs the UDP path. `cargo nextest -p
+  ripdpi-proxy-runtime --locked`: 233/233; `clippy -D warnings`: clean.
 - `annotate-and-harden-async-cancel-safety`
 - `recover-monitor-coordinator-worker-panic`
 

--- a/docs/tasks/issues/epic-june-2026-audit-remediation.md
+++ b/docs/tasks/issues/epic-june-2026-audit-remediation.md
@@ -38,8 +38,18 @@ Child tasks (this epic is `parent:` for each):
 - `redact-raw-bssid-in-detection-findings` — privacy violation in `LocationSignalsChecker`.
 
 **Medium — Rust correctness**
-- `fix-panic-in-drop-exit-ip-cap-guard`
-- `fix-socks5-core-panic-and-credential-truncation`
+- ✅ `fix-panic-in-drop-exit-ip-cap-guard` — **Verified resolved at HEAD 2026-06-14 (no change needed).**
+  `ripdpi-proxy-runtime/src/exit_ip_cap.rs` `Drop` is panic-free: locks via
+  `unwrap_or_else(std::sync::PoisonError::into_inner)` and decrements with `saturating_sub(1)`;
+  test `guard_drops_cleanly_when_mutex_is_poisoned` covers it. `cargo nextest -p
+  ripdpi-proxy-runtime --locked`: 233/233.
+- ✅ `fix-socks5-core-panic-and-credential-truncation` — **Verified resolved at HEAD 2026-06-14
+  (no change needed; landed in f23d15f3c / da297e25c).** `socks4::ReplyError::as_u8` returns
+  `Option<u8>` (no `panic!`/unreachable on the parse path); SOCKS4 domain length is bounds-checked
+  (→ typed error, no buffer-overflow panic); SOCKS5 `use_password_auth` rejects >255-byte
+  credentials instead of truncating. Tests: `domain_too_long_returns_error`,
+  `use_password_auth_rejects_oversized_username`/`_password`, `oversized_credential_writes_no_bytes`.
+  `cargo nextest -p ripdpi-socks5-core --locked`: 27/27.
 - ✅ `restore-discarded-adaptive-routing-feedback` — **Landed 2026-06-14.** The TLS branch of
   `record_failure_feedback` (`ripdpi-proxy-runtime/.../routing/failure/feedback.rs`) was the last
   feedback call still discarding its result with `let _ =`; switched to `?` for parity with its
@@ -50,7 +60,12 @@ Child tasks (this epic is `parent:` for each):
   parity coverage the routing/failure module lacked vs the UDP path. `cargo nextest -p
   ripdpi-proxy-runtime --locked`: 233/233; `clippy -D warnings`: clean.
 - `annotate-and-harden-async-cancel-safety`
-- `recover-monitor-coordinator-worker-panic`
+- ✅ `recover-monitor-coordinator-worker-panic` — **Verified resolved at HEAD 2026-06-14 (no change
+  needed).** `ripdpi-monitor-engine/src/engine/runtime/panic_recovery.rs` classifies a worker's
+  `thread::Result` `Err` into a `Panicked` outcome and `handle_panicked_runner` builds synthetic
+  recorded steps so one worker panic is contained + diagnosable rather than killing the scan; test
+  `parallel_runner_panic_is_isolated_and_scan_completes_with_siblings`. `cargo nextest -p
+  ripdpi-monitor-engine --locked`: 156/156.
 
 **Medium — JNI / unsafe**
 - `harden-jni-callback-thread-attach-and-null-sentinels`

--- a/native/rust/crates/ripdpi-proxy-runtime/src/runtime/routing/failure/feedback.rs
+++ b/native/rust/crates/ripdpi-proxy-runtime/src/runtime/routing/failure/feedback.rs
@@ -26,7 +26,15 @@ pub(super) fn record_failure_feedback(
 
     if matches!(failure.class, RuntimeFailureClass::TlsAlert | RuntimeFailureClass::TlsHandshakeFailure) {
         let targets = preferred_targets_for_transport(state, target, host, RuntimeTransportProtocol::Tcp);
-        let _ = note_direct_path_tls_post_client_hello_failure(state, host, &targets);
+        // The learner update is the side effect of this call (the wrapper is
+        // currently infallible, so the TLS post-client-hello failure already
+        // reaches the learner). Propagate its result with `?` to match the
+        // sibling adaptive calls below and the UDP-path feedback — the last
+        // feedback call still using `let _ =` — so that if the wrapper ever
+        // becomes fallible the error surfaces instead of being silently dropped.
+        // The recorded failure lets a later TCP success emit
+        // `TCP_POST_CLIENT_HELLO_FAILURE_TCP_OK`.
+        note_direct_path_tls_post_client_hello_failure(state, host, &targets)?;
     }
     if let Some(payload) = payload {
         note_adaptive_tcp_failure(state, target, route.group_index, host, payload)?;
@@ -34,4 +42,105 @@ pub(super) fn record_failure_feedback(
     note_adaptive_fake_ttl_failure(state, target, route.group_index, host)?;
     state.note_evolver_failure(failure.class);
     Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::adaptive::note_direct_path_tcp_success;
+    use crate::runtime::config::RuntimeConfig;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+
+    /// Telemetry sink that captures the direct-path learner's state-transition
+    /// signals so the test can assert the TLS post-client-hello failure feedback
+    /// reaches the learner.
+    #[derive(Default)]
+    struct RecordingLearnerSink {
+        signals: std::sync::Mutex<Vec<&'static str>>,
+    }
+
+    impl RecordingLearnerSink {
+        fn events(&self) -> Vec<&'static str> {
+            self.signals.lock().expect("learner signals lock").clone()
+        }
+    }
+
+    impl ripdpi_proxy_runtime_adapter::model::runtime_api::RuntimeTelemetrySink for RecordingLearnerSink {
+        fn on_listener_started(&self, _bind_addr: SocketAddr, _max_clients: usize, _group_count: usize) {}
+        fn on_listener_stopped(&self) {}
+        fn on_client_accepted(&self) {}
+        fn on_client_finished(&self) {}
+        fn on_client_error(&self, _error: &io::Error) {}
+        fn on_route_selected(
+            &self,
+            _target: SocketAddr,
+            _group_index: usize,
+            _host: Option<&str>,
+            _phase: &'static str,
+        ) {
+        }
+        fn on_failure_classified(
+            &self,
+            _target: SocketAddr,
+            _failure: &crate::runtime::failure::RuntimeClassifiedFailure,
+            _host: Option<&str>,
+        ) {
+        }
+        fn on_route_advanced(
+            &self,
+            _target: SocketAddr,
+            _from_group: usize,
+            _to_group: usize,
+            _trigger: u32,
+            _host: Option<&str>,
+        ) {
+        }
+        fn on_host_autolearn_state(
+            &self,
+            _enabled: bool,
+            _learned_host_count: usize,
+            _penalized_host_count: usize,
+            _blocked_host_count: usize,
+            _last_block_signal: Option<&str>,
+            _last_block_provider: Option<&str>,
+        ) {
+        }
+        fn on_host_autolearn_event(&self, _action: &'static str, _host: Option<&str>, _group_index: Option<usize>) {}
+        fn on_direct_path_learning_signal(
+            &self,
+            _authority: &str,
+            _ip_set_digest: &str,
+            event: &'static str,
+            _strategy_family: Option<&str>,
+        ) {
+            self.signals.lock().expect("learner signals lock").push(event);
+        }
+    }
+
+    /// Wiring lock: a TLS post-client-hello failure must drive the direct-path
+    /// learner's negative state so a subsequent direct-path TCP success emits
+    /// `TCP_POST_CLIENT_HELLO_FAILURE_TCP_OK`. The TLS branch of
+    /// `record_failure_feedback` was the last feedback call still using `let _ =`
+    /// instead of `?`; because that wrapper is infallible the signal already
+    /// reached the learner, so this test guards the wiring contract going forward,
+    /// at parity with the UDP path's
+    /// `udp_path_failure_drives_quic_blocked_learner_state`.
+    #[test]
+    fn tls_post_client_hello_failure_drives_learner_state() {
+        let sink = Arc::new(RecordingLearnerSink::default());
+        let state = RuntimeState::test_with_telemetry(RuntimeConfig::default(), Some(sink.clone()));
+        let host = Some("example.com");
+        let targets = [SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 443)];
+
+        note_direct_path_tls_post_client_hello_failure(&state, host, &targets)
+            .expect("record tls post-client-hello failure");
+        note_direct_path_tcp_success(&state, host, &targets, Some("tlsrec_split")).expect("record tcp success");
+
+        assert!(
+            sink.events().contains(&"TCP_POST_CLIENT_HELLO_FAILURE_TCP_OK"),
+            "TLS post-client-hello failure must drive the learner's negative state; got {:?}",
+            sink.events()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Addresses the four **Medium — Rust correctness** findings in `epic-june-2026-audit-remediation`. Each was confirmed at its cited site at HEAD first. **3 of 4 were already implemented + tested on `main`**; one had a genuine (if modest) actionable kernel, which is fixed here.

### Finding 3 — discarded adaptive-routing feedback — ✅ fixed (1 commit)
`record_failure_feedback` (`ripdpi-proxy-runtime/.../routing/failure/feedback.rs`) handled the TLS-alert / TLS-handshake-failure branch with `let _ = note_direct_path_tls_post_client_hello_failure(...)` — the **last feedback call still discarding its result**, where the 3 sibling calls and the UDP-path feedback all use `?`.
- **Honest scope:** the wrapper is **infallible**, so the TLS failure signal *already* reached the direct-path learner — this is **error-propagation consistency**, not a behavioral bug fix.
- Added the **regression-lock test** `tls_post_client_hello_failure_drives_learner_state` (a TLS post-client-hello failure → TCP success must emit `TCP_POST_CLIENT_HELLO_FAILURE_TCP_OK`) — the parity coverage the `routing/failure` module lacked vs the UDP path's existing `udp_path_failure_drives_quic_blocked_learner_state`.
- `cargo nextest -p ripdpi-proxy-runtime --locked`: **233/233**; `cargo clippy -p ripdpi-proxy-runtime --all-targets --locked -- -D warnings`: **clean**.

### Findings 1, 2, 4 — verified already resolved at HEAD — ✅ (1 commit, epic record)
- **Panic in Drop (exit-ip cap):** `exit_ip_cap.rs` `Drop` is panic-free (`unwrap_or_else(PoisonError::into_inner)` + `saturating_sub`); test `guard_drops_cleanly_when_mutex_is_poisoned`.
- **SOCKS5-core panics + credential truncation** (landed f23d15f3c/da297e25c): `socks4::ReplyError::as_u8 → Option<u8>` (no parse-path panic); SOCKS4 domain length bounds-checked → typed error; SOCKS5 `use_password_auth` rejects >255-byte creds instead of truncating; tests `domain_too_long_returns_error`, `use_password_auth_rejects_oversized_username/_password`, `oversized_credential_writes_no_bytes`. `ripdpi-socks5-core`: **27/27**.
- **Monitor-coordinator worker panic recovery:** `engine/runtime/panic_recovery.rs` converts a worker `thread::Result` `Err` into a contained `Panicked` outcome with synthetic recorded steps; test `parallel_runner_panic_is_isolated_and_scan_completes_with_siblings`. `ripdpi-monitor-engine`: **156/156**.

### Verification
- Per-crate `cargo nextest … --locked` green for all three affected crates; `clippy -D warnings` clean on the changed crate; all lefthook gates green (incl. `rust-format`, `rust-clippy`).
- **Independent adversarial review** (separate Opus agent, native-verifier + async-cancel-safety lens): **APPROVE, 0 blocking issues** — confirmed the `?` change is sync (no cancel-safety impact), the test's assertion is non-vacuous (event fires iff the TLS failure was recorded), and independently re-confirmed the other three findings resolved. Its one note (don't overstate Finding 3 as a behavioral fix) was applied to the code comments and this description.

Two atomic commits (the code fix; the verified-resolved records). The named child task files don't exist as standalone docs, so status is recorded in the epic. **Do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
