### PR TITLE
fix(relay-core): close SOCKS5 handle_connect cancel orphan + annotate async cancel-safety

### DIFF
--- a/docs/tasks/issues/annotate-and-harden-async-cancel-safety.md
+++ b/docs/tasks/issues/annotate-and-harden-async-cancel-safety.md
@@ -1,7 +1,7 @@
 ---
 title: "Annotate and harden async cancel-safety in relay-core and tunnel-core"
 type: task
-status: todo
+status: in-review
 area: rust-native
 priority: medium
 owner: unassigned
@@ -9,7 +9,7 @@ parent: epic-june-2026-audit-remediation
 blocks: []
 blocked_by: []
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-14
 source_wiki_pages: []
 linked_task: null
 ---
@@ -33,12 +33,46 @@ Key sites:
 
 ## Acceptance criteria
 
-- [ ] PR confirms current state at each cited site.
-- [ ] `handle_connect` no longer sends a success reply that a cancel can orphan (restructured or documented + protected); inline comment corrected.
-- [ ] `handle_udp_associate` `select!` is `biased;` with `control_closed` first.
-- [ ] Every async fn listed carries a `# Cancel safety:` rustdoc block.
-- [ ] `async-cancel-safety` sub-agent re-run reports no un-annotated `.await` site in the two crates.
-- [ ] `cargo nextest run -p ripdpi-relay-core -p ripdpi-tunnel-core --locked` green; clippy clean.
+- [x] PR confirms current state at each cited site. (Verified at HEAD `d3bdbf1b6`; line numbers drifted from the 2026-06-10 audit and were re-located.)
+- [x] `handle_connect` no longer sends a success reply that a cancel can orphan (restructured + protected); inline comment corrected.
+- [x] `handle_udp_associate` `select!` is `biased;` with the teardown arms first.
+- [x] Every async fn listed carries a `# Cancel safety:` rustdoc block.
+- [x] `async-cancel-safety` sub-agent re-run reports no un-annotated `.await` site in the two crates. (Plus an independent adversarial re-audit: 4/4 safety claims HOLD, 0 refuted.)
+- [x] `cargo nextest run -p ripdpi-relay-core -p ripdpi-tunnel-core --locked` green (295 passed, 1 ignored env-flaky QUIC e2e); clippy `-D warnings` clean; rustfmt clean.
+
+## Implementation notes (2026-06-14)
+
+The orphan fix could not be local to `connect.rs`: the cancellation that orphaned
+the client was the outer drop-on-cancel `select!` in `runtime/session.rs`, which
+dropped the whole `handle_client` future at any `.await` — including the window
+between `write_reply(0x00)` and `copy_bidirectional`. Fix:
+
+1. **Thread the session `CancellationToken` into the handlers.** `runtime/session.rs`
+   now awaits `handle_client(..., cancel)` directly (the drop-on-cancel `select!`
+   is removed). `handle_client` owns cancellation: it races `cancel` around the
+   pre-reply negotiation (abandon-by-drop is safe — no reply written) and passes
+   the token to both sub-handlers.
+2. **`handle_connect`** dials upstream under a `cancel` race (pre-reply, drop-safe),
+   then writes the success reply and enters `select! { cancel.cancelled() =>
+   graceful client.shutdown(), copy_bidirectional }`. No externally-observable
+   drop point sits between the reply and the relay, so a confirmed `CONNECT`
+   always implies the relay started; on shutdown the client sees a graceful FIN.
+3. **`handle_udp_associate`** loop `select!` is now `biased;` with `cancel.cancelled()`
+   as **arm 0** and control-EOF as **arm 1**. Deviation from the original "control_closed
+   as arm 0" wording: because the outer drop-on-cancel was removed, this loop is the
+   sole place shutdown is observed for the UDP path, so `cancel` must lead. Both
+   teardown arms precede the recv arms, fully closing the starvation hazard.
+4. **`splice`/`run_with_proxy`** (tunnel-core): buffer-loss-on-cancel hazard is
+   DOCUMENTED only, per the scope decision — `cancel` fires only at session
+   GC/teardown, never mid-stream; the drain rewrite stays deferred.
+5. **New regression test** `relay_runtime_stop_drains_pre_reply_sessions_within_grace_window`
+   (`src/tests/shutdown_drain.rs`): a slowloris client that never sends the greeting
+   still drains within the grace window, locking the pre-reply cancellation path the
+   redesign introduced.
+
+`tokio-util` already provides `CancellationToken` at HEAD; no `Cargo.toml`/lock
+change. The only handler callers are `runtime/session.rs` and `socks/auth.rs`, so
+the signature change is contained.
 
 ## Risks / open questions
 

--- a/native/rust/crates/ripdpi-relay-core/src/runtime/session.rs
+++ b/native/rust/crates/ripdpi-relay-core/src/runtime/session.rs
@@ -19,20 +19,15 @@ pub(super) fn spawn_socks_session(runtime: Arc<RelayRuntime>, backend: Arc<Relay
             local_socks_host: runtime.config.common.local_socks_host.clone(),
             backend_kind: runtime.config.kind_id().to_string(),
         };
-        // Race the session against shutdown. On cancel the `handle_client`
-        // future is dropped at its current `.await` (cancel-safe — at worst a
-        // half-finished `copy_bidirectional` loses in-flight bytes, acceptable
-        // on shutdown); the SOCKS5 success reply is already fully written
-        // before `copy_bidirectional` begins, so no half-sent reply is
-        // stranded.
-        tokio::select! {
-            biased;
-            () = cancel.cancelled() => {}
-            result = handle_client(stream, backend, socks_config, runtime.as_ref()) => {
-                if let Err(error) = result {
-                    runtime.state.record_error(error.to_string());
-                }
-            }
+        // `handle_client` owns the shutdown token and honors it at the right
+        // boundaries: it abandons pre-reply negotiation by drop, but once a
+        // SOCKS5 success reply is on the wire it switches to a *graceful* cancel
+        // (FIN, not an abrupt drop), so shutdown can never strand a confirmed
+        // CONNECT/ASSOCIATE on a relay that never started. We therefore await it
+        // directly instead of racing it against `cancel` here — a drop-on-cancel
+        // `select!` at this layer is exactly what created that orphan window.
+        if let Err(error) = handle_client(stream, backend, socks_config, runtime.as_ref(), cancel).await {
+            runtime.state.record_error(error.to_string());
         }
         runtime.state.finish_session();
     });

--- a/native/rust/crates/ripdpi-relay-core/src/socks/auth.rs
+++ b/native/rust/crates/ripdpi-relay-core/src/socks/auth.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
+use tokio_util::sync::CancellationToken;
 
 use crate::backend::RelayBackend;
 use crate::socks::connect::handle_connect;
@@ -12,33 +13,59 @@ use crate::socks::target::RelayTargetAddr;
 use crate::socks::telemetry::{SocksSessionConfig, SocksTelemetry};
 use crate::socks::udp::handle_udp_associate;
 
+/// Negotiate the SOCKS5 method, parse the request, and dispatch the command.
+///
+/// # Cancel safety
+///
+/// Cancel-safe. `cancel` is the session's shutdown token (a child of the runtime
+/// shutdown token), and this function owns every cancellation point — the caller
+/// (`runtime/session.rs`) no longer wraps the call in a drop-on-cancel `select!`.
+///
+/// - The **pre-reply** phase (method negotiation, request header, target parse)
+///   is raced against `cancel` and abandoned by drop on shutdown. `negotiate_no_auth`
+///   is itself NOT cancel-safe in isolation (read greeting → write method choice),
+///   but it runs only inside this `select!`: a cancel drops it before *or* after the
+///   method reply with no protocol reply for the command yet on the wire, so the
+///   client merely sees the connection close — never a torn command exchange.
+/// - The **post-reply** phase is delegated to [`handle_connect`] /
+///   [`handle_udp_associate`], each of which threads `cancel` through and keeps its
+///   own success-reply→relay window atomic.
 pub(crate) async fn handle_client<T>(
     mut client: TcpStream,
     backend: Arc<RelayBackend>,
     config: SocksSessionConfig,
     telemetry: &T,
+    cancel: CancellationToken,
 ) -> io::Result<()>
 where
     T: SocksTelemetry + ?Sized,
 {
-    // NOT cancel-safe: reads the method greeting, writes the method selection,
-    // then drives the full SOCKS5 command exchange; cancellation mid-write
-    // leaves the client in an undefined protocol state.
-    negotiate_no_auth(&mut client).await?;
+    // Pre-reply negotiation, raced against shutdown. Abandoning it by drop is
+    // safe: no SOCKS5 command reply has been written, so the client just sees
+    // the connection close — no false success, no torn command state.
+    let negotiation = async {
+        negotiate_no_auth(&mut client).await?;
 
-    let mut request_header = [0u8; 4];
-    client.read_exact(&mut request_header).await?;
-    if request_header[0] != 0x05 {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "unsupported SOCKS5 request"));
-    }
+        let mut request_header = [0u8; 4];
+        client.read_exact(&mut request_header).await?;
+        if request_header[0] != 0x05 {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "unsupported SOCKS5 request"));
+        }
 
-    let command = request_header[1];
-    let target = read_target(&mut client, request_header[3]).await?;
+        let command = request_header[1];
+        let target = read_target(&mut client, request_header[3]).await?;
+        Ok::<_, io::Error>((command, target))
+    };
+    let (command, target) = tokio::select! {
+        biased;
+        () = cancel.cancelled() => return Ok(()),
+        result = negotiation => result?,
+    };
     telemetry.record_target(target.to_string());
 
     match command {
-        0x01 => handle_connect(client, backend, target, telemetry).await,
-        0x03 => handle_udp_associate(client, backend, config, telemetry).await,
+        0x01 => handle_connect(client, backend, target, telemetry, cancel).await,
+        0x03 => handle_udp_associate(client, backend, config, telemetry, cancel).await,
         _ => {
             write_reply(&mut client, 0x07, SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0))).await?;
             Err(io::Error::new(io::ErrorKind::Unsupported, format!("SOCKS5 command {command:#x} is not supported")))
@@ -50,8 +77,16 @@ where
 /// negotiation. Replies `[0x05, 0x00]` (NO AUTH) when the client offers
 /// method `0x00`; replies `[0x05, 0xFF]` (NO ACCEPTABLE METHODS) and returns
 /// an error otherwise, as required by RFC 1928 §3.
-// NOT cancel-safe: reads the greeting then writes the server's method choice;
-// cancellation between the read and write leaves the client without a reply.
+///
+/// # Cancel safety
+///
+/// NOT cancel-safe in isolation: it reads the greeting then writes the server's
+/// method choice; a cancel between the read and the write leaves the client
+/// without a method reply. The sole caller, [`handle_client`], drives it inside
+/// a `select!` whose other arm is shutdown — abandoning it by drop is then safe
+/// because no SOCKS5 *command* reply has been written, so the client simply sees
+/// the connection close. Do not call it under a cancellation scope that expects
+/// a clean handshake after a partial run.
 async fn negotiate_no_auth<S>(stream: &mut S) -> io::Result<()>
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -77,6 +112,15 @@ where
     }
 }
 
+/// Reads the SOCKS5 target address (IPv4 / domain / IPv6) following the request
+/// header, per RFC 1928 §4.
+///
+/// # Cancel safety
+///
+/// Cancel-safe. Every `.await` is a pure `read_exact` into a local buffer; the
+/// function writes nothing to the stream, so a cancel at any point only abandons
+/// a partial read of bytes that are discarded with the dropped future. No
+/// observable protocol state is left behind.
 pub(crate) async fn read_target<S>(stream: &mut S, address_type: u8) -> io::Result<RelayTargetAddr>
 where
     S: AsyncRead + AsyncWrite + Unpin,

--- a/native/rust/crates/ripdpi-relay-core/src/socks/connect.rs
+++ b/native/rust/crates/ripdpi-relay-core/src/socks/connect.rs
@@ -3,8 +3,9 @@ use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Instant;
 
-use tokio::io::copy_bidirectional;
+use tokio::io::{AsyncWriteExt, copy_bidirectional};
 use tokio::net::TcpStream;
+use tokio_util::sync::CancellationToken;
 
 use crate::backend::RelayBackend;
 use crate::socks::reply::write_reply;
@@ -12,21 +13,48 @@ use crate::socks::target::RelayTargetAddr;
 use crate::socks::telemetry::SocksTelemetry;
 use crate::telemetry::TcpConnectObservation;
 
-/// cancel-safe: the function either completes or is cancelled at an `.await`
-/// point. RTT measurement uses wall-clock `Instant`, so a mid-cancel drop
-/// loses at most one in-flight sample. The quality observation is emitted
-/// synchronously before the first `.await` after the connect result is known.
+/// Drive a SOCKS5 `CONNECT`: dial the upstream, send the reply, then relay.
+///
+/// # Cancel safety
+///
+/// Cancel-safe. `cancel` is the session's shutdown token (a child of the
+/// runtime shutdown token); this function — not the caller's `select!` — owns
+/// every cancellation point, which is what keeps the success reply atomic with
+/// the start of relaying:
+///
+/// - **Before the success reply** (upstream dial): the dial is raced against
+///   `cancel` and abandoned by drop on shutdown. No SOCKS5 reply has been
+///   written yet, so an abandoned dial closes the client connection with no
+///   reply — never a confirmed `CONNECT` on a socket that never relayed.
+/// - **Success reply → relay** is atomic: `write_reply(0x00)` and the entry
+///   into the cancel-aware copy are separated by no externally-cancellable
+///   drop point (the historic outer `select!` that dropped the whole future
+///   here was removed — see `runtime/session.rs`). Once `REP=0x00` is on the
+///   wire the only cancellation observed is *inside* the copy `select!`.
+/// - **During relay**: a `cancel` win gracefully shuts the client write half
+///   (FIN) and returns `Ok(())`. A confirmed `CONNECT` followed by an ordinary
+///   connection close is a legitimate end-of-session from the client's view.
+///
+/// RTT measurement uses wall-clock `Instant`, so a mid-cancel drop of the dial
+/// loses at most one in-flight quality sample; the observation is emitted
+/// synchronously, with no `.await` between the `Instant` read and emission.
 pub(crate) async fn handle_connect<T>(
     mut client: TcpStream,
     backend: Arc<RelayBackend>,
     target: RelayTargetAddr,
     telemetry: &T,
+    cancel: CancellationToken,
 ) -> io::Result<()>
 where
     T: SocksTelemetry + ?Sized,
 {
     let connect_start = Instant::now();
-    let upstream_result = backend.connect_tcp(&target).await;
+    // Pre-reply: abandoning the dial by drop is safe — no reply is on the wire.
+    let upstream_result = tokio::select! {
+        biased;
+        () = cancel.cancelled() => return Ok(()),
+        result = backend.connect_tcp(&target) => result,
+    };
     let rtt_ms = connect_start.elapsed().as_millis() as u64;
 
     let mut upstream = match upstream_result {
@@ -42,7 +70,20 @@ where
         }
     };
 
+    // Atomic from the client's view: the success reply and the entry into the
+    // cancel-aware relay are not separated by any drop point a canceller can
+    // observe. A confirmed `CONNECT` therefore always implies the relay started.
     write_reply(&mut client, 0x00, SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0))).await?;
-    let _ = copy_bidirectional(&mut client, &mut upstream).await?;
-    Ok(())
+    tokio::select! {
+        biased;
+        () = cancel.cancelled() => {
+            // Graceful close: signal FIN on the client write half so the peer
+            // sees an ordinary end-of-session rather than a reset. Sending FIN
+            // does not wait on the peer reading, so this cannot stall the drain
+            // grace window; any error is ignored since the socket is closing.
+            let _ = client.shutdown().await;
+            Ok(())
+        }
+        result = copy_bidirectional(&mut client, &mut upstream) => result.map(|_| ()),
+    }
 }

--- a/native/rust/crates/ripdpi-relay-core/src/socks/udp.rs
+++ b/native/rust/crates/ripdpi-relay-core/src/socks/udp.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use tokio::io::AsyncReadExt;
 use tokio::net::{TcpStream, UdpSocket};
+use tokio_util::sync::CancellationToken;
 
 use crate::backend::RelayBackend;
 use crate::socks::reply::write_reply;
@@ -12,11 +13,33 @@ use crate::socks::{decode_udp_frame, encode_udp_frame};
 
 const UDP_BUFFER_SIZE: usize = 65_536;
 
+/// Drive a SOCKS5 `UDP ASSOCIATE`: bind the relay socket, reply, then pump
+/// datagrams in both directions until the control connection or `cancel` ends
+/// the session.
+///
+/// # Cancel safety
+///
+/// Cancel-safe. `cancel` is the session's shutdown token. The relay loop's
+/// `select!` is `biased` with the two teardown arms first — `cancel.cancelled()`
+/// (arm 0) and the control-connection EOF (arm 1) — so sustained upstream UDP
+/// on the recv arms can never starve teardown (the original fairness hazard).
+/// `cancel` leads `control_closed` because the historic outer `select!` that
+/// dropped this future on shutdown was removed (see `runtime/session.rs`); this
+/// loop is now the sole place shutdown is observed, so it must lead. Teardown is
+/// at the `select!` boundary only: once a recv arm has been selected, its body
+/// runs a follow-on message-atomic `send_to().await` (relay→client or
+/// client→relay), so a cancel that arrives while that send is parked is deferred
+/// by at most that one datagram before the next loop iteration observes it — a
+/// bounded, single-datagram delay on already-lossy UDP, never an indefinite
+/// stall. The success reply (`REP=0x00`) and the first loop poll are separated by
+/// no externally-cancellable drop point, so a confirmed `ASSOCIATE` always enters
+/// the pump.
 pub(crate) async fn handle_udp_associate<T>(
     mut client: TcpStream,
     backend: Arc<RelayBackend>,
     config: SocksSessionConfig,
     telemetry: &T,
+    cancel: CancellationToken,
 ) -> io::Result<()>
 where
     T: SocksTelemetry + ?Sized,
@@ -53,6 +76,8 @@ where
 
     loop {
         tokio::select! {
+            biased;
+            () = cancel.cancelled() => break,
             _ = &mut control_closed => break,
             recv = udp_socket.recv_from(&mut udp_buffer) => {
                 let (received, source) = recv?;

--- a/native/rust/crates/ripdpi-relay-core/src/tests/shutdown_drain.rs
+++ b/native/rust/crates/ripdpi-relay-core/src/tests/shutdown_drain.rs
@@ -88,6 +88,77 @@ pub(super) async fn relay_runtime_stop_drains_in_flight_sessions_within_grace_wi
     }
 }
 
+/// Pre-reply drain: a client that connects but never sends the SOCKS5 greeting
+/// parks the session inside `handle_client`'s pre-reply negotiation
+/// (`negotiate_no_auth`'s `read_exact`). After the cancel-token redesign — which
+/// removed the outer drop-on-cancel `select!` in `spawn_socks_session` and moved
+/// cancellation *into* `handle_client` — shutdown must still unwind such a
+/// pre-reply session within the bounded drain grace window. This locks the
+/// regression the redesign could plausibly introduce: a slowloris connect that
+/// never produces a reply must drain exactly like one parked in
+/// `copy_bidirectional`.
+#[tokio::test]
+pub(super) async fn relay_runtime_stop_drains_pre_reply_sessions_within_grace_window() {
+    const SESSION_COUNT: usize = 3;
+
+    let fixture = ShadowsocksLoopback::start("aes-256-gcm", "secret").await.expect("start shadowsocks fixture");
+
+    let socks_port = {
+        let probe = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind probe listener");
+        probe.local_addr().expect("probe addr").port()
+    };
+
+    let mut config = sample_config("shadowsocks");
+    config.common.server = "127.0.0.1".to_string();
+    config.common.server_port = i32::from(fixture.port());
+    config.common.local_socks_host = "127.0.0.1".to_string();
+    config.common.local_socks_port = i32::from(socks_port);
+    shadowsocks_config_mut(&mut config).method = "aes-256-gcm".to_string();
+
+    let runtime = RelayRuntime::new(config);
+    let run_handle = tokio::spawn(Arc::clone(&runtime).run());
+
+    let socks_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), socks_port);
+    wait_until(Duration::from_secs(5), || runtime.telemetry().listener_address.is_some())
+        .await
+        .expect("relay listener must bind");
+
+    // Connect SESSION_COUNT clients that send *nothing* — each session parks in
+    // the pre-reply `read_exact` of `negotiate_no_auth`, before any SOCKS5 reply.
+    let mut clients = Vec::with_capacity(SESSION_COUNT);
+    for _ in 0..SESSION_COUNT {
+        let client = tokio::net::TcpStream::connect(socks_addr).await.expect("connect slowloris client");
+        clients.push(client);
+    }
+
+    // The sessions register as active even though no byte was ever sent.
+    wait_until(Duration::from_secs(5), || runtime.telemetry().active_sessions == SESSION_COUNT as u64)
+        .await
+        .expect("pre-reply sessions must register as active");
+
+    runtime.stop();
+    let run_result = tokio::time::timeout(Duration::from_secs(10), run_handle)
+        .await
+        .expect("run() must return within the bounded drain window after stop()")
+        .expect("run task must not panic");
+    run_result.expect("run() returns Ok after a clean stop");
+
+    assert_eq!(
+        0,
+        runtime.telemetry().active_sessions,
+        "pre-reply sessions must drain to zero after stop() — the cancel token reaches negotiate_no_auth",
+    );
+
+    // The relay closed the client half: a read observes EOF/reset, not a hang.
+    for mut client in clients {
+        let mut byte = [0_u8; 1];
+        let read = tokio::time::timeout(Duration::from_secs(5), client.read(&mut byte))
+            .await
+            .expect("client read must not hang after pre-reply drain");
+        assert!(matches!(read, Ok(0) | Err(_)), "relay must close the client half on pre-reply drain (got {read:?})",);
+    }
+}
+
 /// Drive a SOCKS5 no-auth greeting + CONNECT handshake against `client`,
 /// targeting `target`, and read back the 10-byte success reply.
 async fn socks5_connect(client: &mut tokio::net::TcpStream, target: SocketAddr) -> io::Result<()> {

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/worker.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/worker.rs
@@ -13,6 +13,19 @@ use super::association_state::{UdpAssociation, now_millis};
 use super::event_handling::UdpEvent;
 use spawn::spawn_udp_worker;
 
+/// Build a UDP association: open the SOCKS5 UDP session and spawn its pump
+/// worker.
+///
+/// # Cancel safety
+///
+/// NOT cancel-safe. It awaits [`UdpSession::connect`] (itself a non-cancel-safe
+/// multi-step SOCKS5 setup) and then spawns the worker. Dropping this future
+/// before it returns leaves the half-built session to its `Drop` (fds close)
+/// and never registers an association, so no caller-visible association is
+/// created from a torn setup. Its caller in `io_loop` awaits it to completion on
+/// the association-setup path and does not place it under a `select!`/`timeout`;
+/// the long-lived cancellation point is the spawned worker's own loop, which
+/// honors `cancel`.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn create_udp_association(
     proxy_addr: SocketAddr,

--- a/native/rust/crates/ripdpi-tunnel-core/src/session/socks5/connect.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/session/socks5/connect.rs
@@ -14,6 +14,15 @@ use super::TargetAddr;
 /// - IPv4:   `[0x05, 0x01, 0x00, 0x01, a, b, c, d, ph, pl]`
 /// - IPv6:   `[0x05, 0x01, 0x00, 0x04, <16 bytes>, ph, pl]`
 /// - Domain: `[0x05, 0x01, 0x00, 0x03, len, <domain bytes>, ph, pl]`
+///
+/// # Cancel safety
+///
+/// NOT cancel-safe. It writes the CONNECT request then reads the reply header
+/// and bound-address fields; dropping the future between the write and the full
+/// read leaves the proxy stream mid-CONNECT (partially consumed reply), which a
+/// subsequent reuse would mis-parse. The only caller, `TcpSession::run_with_proxy`,
+/// awaits it to completion *before* entering the `cancel`-aware splice `select!`,
+/// so it is never cancelled mid-exchange. Do not call it inside a `select!`/`timeout`.
 pub async fn connect<S>(stream: &mut S, target: &TargetAddr) -> io::Result<()>
 where
     S: AsyncRead + AsyncWrite + Unpin,

--- a/native/rust/crates/ripdpi-tunnel-core/src/session/tcp.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/session/tcp.rs
@@ -42,6 +42,13 @@ impl TcpSession {
     /// - Issues a SOCKS5 CONNECT request to `target`.
     /// - Bidirectionally splices `local` ↔ proxy until EOF on both sides or
     ///   until `cancel` is signalled (in which case the function returns `Ok(())`).
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe at the `cancel`-token boundary it exposes (see
+    /// [`Self::run_with_proxy`]); it forwards to `run_with_connector`. Dropping
+    /// the returned future outright (rather than signalling `cancel`) inherits
+    /// the underlying [`splice`] buffer-loss caveat documented there.
     pub async fn run<L>(&self, local: &mut L, cancel: CancellationToken) -> io::Result<()>
     where
         L: AsyncRead + AsyncWrite + Unpin,
@@ -49,6 +56,14 @@ impl TcpSession {
         self.run_with_connector(local, cancel, TcpStream::connect).await
     }
 
+    /// # Cancel safety
+    ///
+    /// Cancel-safe at the `cancel`-token boundary. Connecting to the proxy and
+    /// the SOCKS5 handshake/CONNECT run *before* the `cancel`-aware splice in
+    /// [`Self::run_with_proxy`]; abandoning the future by drop during connect or
+    /// handshake leaves only a half-open proxy socket that the drop closes — no
+    /// local-visible state. Signalling `cancel` after CONNECT is the intended
+    /// teardown path.
     async fn run_with_connector<L, C, F, P>(
         &self,
         local: &mut L,
@@ -67,6 +82,21 @@ impl TcpSession {
         self.run_with_proxy(local, cancel, &mut proxy).await
     }
 
+    /// # Cancel safety
+    ///
+    /// Cancel-safe at the `cancel` boundary, with one documented buffer-loss
+    /// caveat. The SOCKS5 handshake + CONNECT run to completion *before* the
+    /// relay loop (a torn handshake cannot leak into the splice). The relay is a
+    /// `select!` of [`splice`] against `cancel.cancelled()`: a `cancel` win drops
+    /// the in-flight `splice` future and returns `Ok(())`.
+    ///
+    /// Dropping `splice` mid-copy discards any bytes that `tokio::io::copy` has
+    /// read into its internal buffer but not yet written, and skips the EOF
+    /// half-close shutdown. This is bounded: `cancel` is the session token, fired
+    /// only at session GC/teardown (`SessionRegistry` reaping an idle or closed
+    /// session), never mid-stream on a live transfer — so a still-flowing session
+    /// is not torn here. The drain rewrite is deferred until a test demonstrates
+    /// observable loss; see the task `annotate-and-harden-async-cancel-safety`.
     async fn run_with_proxy<L, P>(&self, local: &mut L, cancel: CancellationToken, proxy: &mut P) -> io::Result<()>
     where
         L: AsyncRead + AsyncWrite + Unpin,
@@ -133,6 +163,17 @@ impl TcpSession {
 /// When one read side returns EOF, the opposite write side is shut down (half-close),
 /// matching RFC 1928 §6 session semantics.  The function returns only when both
 /// directions have finished.
+///
+/// # Cancel safety
+///
+/// NOT cancel-safe. Each direction is a `tokio::io::copy` that buffers up to one
+/// read chunk internally; if this future is dropped mid-copy (e.g. the
+/// `select!` in [`TcpSession::run_with_proxy`] takes its `cancel` arm), bytes
+/// already read into that buffer but not yet written are lost, and the EOF
+/// half-close `shutdown` is skipped. Callers that must not lose in-flight bytes
+/// MUST drive `splice` to completion rather than dropping it; the only in-tree
+/// caller only drops it at session GC/teardown, where the loss is acceptable
+/// (see [`TcpSession::run_with_proxy`]).
 pub async fn splice<L, P>(local: &mut L, proxy: &mut P) -> io::Result<(u64, u64)>
 where
     L: AsyncRead + AsyncWrite + Unpin,

--- a/native/rust/crates/ripdpi-tunnel-core/src/session/udp.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/session/udp.rs
@@ -38,6 +38,17 @@ impl UdpSession {
     /// fallback when no JNI protect callback is registered (`None` on the
     /// Android callback path and in tests). See
     /// `.claude/rules/vpnservice-protect-invariant.md`.
+    ///
+    /// # Cancel safety
+    ///
+    /// NOT cancel-safe. The association is a multi-step sequence — connect the
+    /// control TCP socket, SOCKS5 handshake, `ASSOCIATE`, then bind/connect the
+    /// relay UDP socket — with no rollback. Dropping the future partway leaves a
+    /// half-built association (e.g. a control connection past handshake but with
+    /// no usable relay socket); the dropped values close their fds, but the proxy
+    /// may briefly see a torn `ASSOCIATE`. The only caller, `create_udp_association`,
+    /// awaits it to completion before the association is registered or used, so it
+    /// is never cancelled mid-setup. Do not call it inside a `select!`/`timeout`.
     pub async fn connect(proxy_addr: SocketAddr, auth: Auth, protect_path: Option<&str>) -> io::Result<Self> {
         // Control connection: create the socket, protect it, *then* connect.
         let ctrl_socket = match proxy_addr {
@@ -73,6 +84,13 @@ impl UdpSession {
     }
 
     /// Send a UDP datagram through the established SOCKS5 relay.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe. The single `.await` is one `UdpSocket::send`, which is
+    /// message-atomic: it either queues the whole datagram or none of it. A
+    /// cancel before completion sends nothing and leaves no partial datagram and
+    /// no torn relay state. The frame is built synchronously before the await.
     pub async fn send_to(&self, dst: SocketAddr, payload: &[u8]) -> io::Result<()> {
         let frame = encode_udp_frame(dst, payload);
         let _ = self.udp.send(&frame).await?;
@@ -85,6 +103,16 @@ impl UdpSession {
     ///
     /// Returns `Ok(Some((payload, from)))` on success, `Ok(None)` if
     /// cancelled or timed out, `Err` on I/O failure.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe. The `recv` arm is one message-atomic `UdpSocket::recv`
+    /// followed by a synchronous decode (no `.await` between consuming the
+    /// datagram and returning it), so dropping this future never consumes-then-
+    /// loses a datagram. The `cancel`/`timeout` arms are pure timers. The
+    /// internal `select!` is intentionally unbiased: recv, timeout, and cancel
+    /// are mutually exclusive single-shot outcomes with no teardown arm to
+    /// protect from starvation.
     pub async fn recv_from(&self, cancel: CancellationToken) -> io::Result<Option<(Vec<u8>, SocketAddr)>> {
         let mut buf = vec![0u8; 65535];
 
@@ -107,6 +135,13 @@ impl UdpSession {
     }
 
     /// Convenience helper: send one datagram and wait for one reply.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe. It is the message-atomic [`Self::send_to`] followed by the
+    /// `cancel`/timeout-aware [`Self::recv_from`]; a cancel before the send
+    /// transmits nothing, and a cancel during the wait is handled by `recv_from`
+    /// returning `Ok(None)`. No partial datagram or torn relay state results.
     pub async fn relay_once(
         &self,
         dst: SocketAddr,


### PR DESCRIPTION
## Summary

Closes the async cancel-safety findings from the 2026-06-10 audit in `ripdpi-relay-core` and `ripdpi-tunnel-core` (task `annotate-and-harden-async-cancel-safety`). Two correctness fixes + a full annotation sweep. All sites re-confirmed at HEAD `d3bdbf1b6` (line numbers had drifted from the audit).

### 1. Orphan fix — `handle_connect` (relay-core)
The outer drop-on-cancel `select!` in `spawn_socks_session` dropped the whole `handle_client` future at any `.await`, including the window between the SOCKS5 success reply (`REP=0x00`) and `copy_bidirectional` — leaving a client with a **confirmed CONNECT on a relay that never ran**.

Fix: thread the session `CancellationToken` into `handle_client` → `handle_connect`/`handle_udp_associate` and **remove** the outer drop-on-cancel race. `handle_connect` now dials upstream under a cancel race (pre-reply, drop-safe), then writes the success reply and enters `select! { cancel => graceful client.shutdown(), copy_bidirectional }`. No externally-observable drop point separates the reply from the relay start; on shutdown the client gets a graceful FIN. The incorrect inline "cancel-safe" comment is replaced with an accurate `# Cancel safety:` block.

### 2. Starvation fix — `handle_udp_associate` (relay-core)
The relay-loop `select!` is now `biased;` with the teardown arms first: `cancel.cancelled()` (arm 0) and control-EOF (arm 1), ahead of the two recv arms. Sustained upstream UDP can no longer starve teardown. `cancel` leads `control_closed` (vs the audit's original "control_closed first" wording) precisely because removing the outer drop-on-cancel makes this loop the sole shutdown observer for the UDP path — both teardown arms still precede the recv arms.

### 3. Buffer-loss hazard — `splice`/`run_with_proxy` (tunnel-core)
Documented only, per the task scope decision: `tokio::io::copy`'s internal buffer is dropped and the FIN half-close skipped on cancel, but `cancel` fires only at session GC/teardown, never mid-stream. The drain rewrite stays deferred until a test shows observable loss.

### 4. Annotation sweep
`# Cancel safety:` rustdoc added to every audit-listed async fn across both crates, with evidence-based classifications.

## Verification
- `cargo nextest run -p ripdpi-relay-core -p ripdpi-tunnel-core --locked`: **295 passed, 1 skipped** (the `#[ignore]`'d env-flaky QUIC e2e).
- `cargo clippy … -D warnings`: clean. `cargo fmt --check`: clean. Full lefthook gate (workspace clippy, arch-delta, native-contracts, no-secrets) passed on both commits.
- New regression test `relay_runtime_stop_drains_pre_reply_sessions_within_grace_window`: a slowloris client that never sends the greeting still drains within the grace window — locks the pre-reply cancellation path.
- **`async-cancel-safety` re-audit**: PASS on all 5 acceptance checks, 0 un-annotated `.await` sites, 0 bugs.
- **Independent adversarial re-audit** (fresh agent, refute-first): all 4 safety claims (orphan / biased teardown / pre-reply / drain) **HOLD, 0 refuted**.

## Notes
`tokio-util` already provides `CancellationToken` at HEAD — no `Cargo.toml`/lock change. The only handler callers are `runtime/session.rs` and `socks/auth.rs`, so the signature change is contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)