### PR TITLE
refactor(app): decompose Blockcheck/Detection/Backup god ViewModels

### DIFF
--- a/app/src/main/kotlin/com/poyka/ripdpi/backup/BackupExportCoordinator.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/backup/BackupExportCoordinator.kt
@@ -1,0 +1,118 @@
+package com.poyka.ripdpi.backup
+
+import com.poyka.ripdpi.data.backup.BackupExportResult
+import com.poyka.ripdpi.data.backup.BackupExportUseCase
+import com.poyka.ripdpi.data.backup.BackupVariant
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.io.OutputStream
+
+/**
+ * Owns the two write-to-[OutputStream] export workflows: a normal SAF export and a
+ * fresh redacted-SHARE export. Both flip the matching in-flight flag on [updateState]
+ * BEFORE emitting their terminal one-shot effect, guard against reentrancy by reading
+ * the live state via [currentState], and always close the destination stream.
+ *
+ * The coordinator owns no state holder of its own: it mutates the single
+ * [BackupRestoreUiState] the ViewModel owns through the injected [updateState] lambda,
+ * and reads it through [currentState] (== `_uiState.value`) so all coordinators share
+ * one source of truth.
+ */
+internal class BackupExportCoordinator(
+    private val scope: CoroutineScope,
+    private val exportUseCase: BackupExportUseCase,
+    private val appVersion: String,
+    private val exportDisabledByPolicy: () -> Boolean,
+    private val currentState: () -> BackupRestoreUiState,
+    private val updateState: ((BackupRestoreUiState) -> BackupRestoreUiState) -> Unit,
+    private val emitExportEffect: (BackupExportEffect) -> Unit,
+    private val emitShareEffect: (BackupShareEffect) -> Unit,
+) {
+    /**
+     * Streams a backup of [variant] into the stream produced by [openOutput].
+     *
+     * [openOutput] returns the SAF destination stream (or `null` if the picker was
+     * cancelled). On a write failure the screen-supplied [onWriteFailed] runs so the
+     * partial document can be removed; on success it is left in place. The stream is
+     * always closed here once writing finishes.
+     */
+    fun export(
+        variant: BackupVariant,
+        openOutput: () -> OutputStream?,
+        onWriteFailed: () -> Unit,
+    ) {
+        if (currentState().exporting || exportDisabledByPolicy()) return
+        updateState { it.copy(exporting = true) }
+        scope.launch {
+            val output = openOutput()
+            if (output == null) {
+                updateState { it.copy(exporting = false) }
+                emitExportEffect(BackupExportEffect.Cancelled)
+                return@launch
+            }
+            val result =
+                output.use { stream ->
+                    exportUseCase.export(
+                        variant = variant,
+                        output = stream,
+                        appVersion = appVersion,
+                    )
+                }
+            updateState { it.copy(exporting = false) }
+            emitExportEffect(
+                when (result) {
+                    is BackupExportResult.Success -> {
+                        BackupExportEffect.Success(
+                            variant = result.variant,
+                            byteCount = result.byteCount,
+                            offerShare = result.variant == BackupVariant.SHARE,
+                        )
+                    }
+
+                    is BackupExportResult.WriteFailed -> {
+                        onWriteFailed()
+                        BackupExportEffect.WriteFailed
+                    }
+                },
+            )
+        }
+    }
+
+    /**
+     * Writes a FRESH [BackupVariant.SHARE] backup into the stream produced by
+     * [openOutput] (a cache-dir file the screen then hands to the share sheet).
+     *
+     * SHARE is forced regardless of any export-variant choice: a redacted backup is
+     * the only thing safe to spray through ACTION_SEND. On success
+     * [BackupShareEffect.Ready] is emitted so the screen can launch the chooser; on a
+     * write failure [BackupShareEffect.Failed] is emitted and the screen deletes the
+     * (possibly partial) temp file. The stream is always closed here.
+     */
+    fun prepareShareBackup(openOutput: () -> OutputStream?) {
+        if (currentState().sharing || exportDisabledByPolicy()) return
+        updateState { it.copy(sharing = true) }
+        scope.launch {
+            val output = openOutput()
+            if (output == null) {
+                updateState { it.copy(sharing = false) }
+                emitShareEffect(BackupShareEffect.Failed)
+                return@launch
+            }
+            val result =
+                output.use { stream ->
+                    exportUseCase.export(
+                        variant = BackupVariant.SHARE,
+                        output = stream,
+                        appVersion = appVersion,
+                    )
+                }
+            updateState { it.copy(sharing = false) }
+            emitShareEffect(
+                when (result) {
+                    is BackupExportResult.Success -> BackupShareEffect.Ready
+                    is BackupExportResult.WriteFailed -> BackupShareEffect.Failed
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/poyka/ripdpi/backup/BackupImportCoordinator.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/backup/BackupImportCoordinator.kt
@@ -1,0 +1,159 @@
+package com.poyka.ripdpi.backup
+
+import com.poyka.ripdpi.data.backup.BackupPreviewResult
+import com.poyka.ripdpi.data.backup.BackupRestoreUseCase
+import com.poyka.ripdpi.data.backup.RestoreResult
+import com.poyka.ripdpi.data.backup.RestoreSelection
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.InputStream
+
+/**
+ * Owns the import-preview, selection editing, and confirmed-restore workflows.
+ *
+ * Reads the picked stream on [ioDispatcher], parses/restores on [defaultDispatcher]
+ * (both default to the exact dispatchers the ViewModel used historically, so
+ * production behavior is unchanged; tests inject test dispatchers). The coordinator
+ * mutates the single ViewModel-owned [BackupRestoreUiState] via [updateState] and
+ * reads it via [currentState], flipping the in-flight flag BEFORE emitting any
+ * terminal effect.
+ */
+internal class BackupImportCoordinator(
+    private val scope: CoroutineScope,
+    private val restoreUseCase: BackupRestoreUseCase,
+    private val currentState: () -> BackupRestoreUiState,
+    private val updateState: ((BackupRestoreUiState) -> BackupRestoreUiState) -> Unit,
+    private val emitRestoreEffect: (BackupRestoreEffect) -> Unit,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
+) {
+    /**
+     * Reads the picked backup file via [openInput] and computes a preview WITHOUT
+     * touching any live store. On success the preview sheet is shown; a newer schema
+     * or malformed JSON surfaces a one-shot effect and no preview.
+     *
+     * [openInput] returns the SAF source stream (or `null` if cancelled). The stream
+     * is fully read and closed here.
+     */
+    fun openImport(openInput: () -> InputStream?) {
+        if (currentState().importing || currentState().restoring) return
+        updateState { it.copy(importing = true) }
+        scope.launch {
+            val json =
+                withContext(ioDispatcher) {
+                    runCatching { openInput()?.use { it.readBytes().toString(Charsets.UTF_8) } }.getOrNull()
+                }
+            if (json == null) {
+                // Cancelled picker or unreadable stream: no preview, no effect noise.
+                updateState { it.copy(importing = false) }
+                return@launch
+            }
+            when (val result = withContext(defaultDispatcher) { restoreUseCase.preview(json) }) {
+                is BackupPreviewResult.Ready -> {
+                    updateState {
+                        it.copy(
+                            importing = false,
+                            importPreview =
+                                BackupImportPreview(
+                                    json = json,
+                                    preview = result.preview,
+                                    // Default: restore only the categories that
+                                    // actually carry content; never silently flip
+                                    // an empty category on.
+                                    selection =
+                                        RestoreSelection(
+                                            profilesAndGroups = result.preview.canRestoreProfilesAndGroups,
+                                            routes = result.preview.ruleCount > 0,
+                                            settings = result.preview.settingCount > 0,
+                                        ),
+                                ),
+                        )
+                    }
+                }
+
+                is BackupPreviewResult.UnsupportedVersion -> {
+                    updateState { it.copy(importing = false) }
+                    emitRestoreEffect(
+                        BackupRestoreEffect.UnsupportedVersion(result.found, result.supported),
+                    )
+                }
+
+                is BackupPreviewResult.Malformed -> {
+                    updateState { it.copy(importing = false) }
+                    emitRestoreEffect(BackupRestoreEffect.Malformed)
+                }
+            }
+        }
+    }
+
+    /** Toggles one restore category in the active preview. */
+    fun setProfilesAndGroupsSelected(selected: Boolean) = updateSelection { it.copy(profilesAndGroups = selected) }
+
+    fun setRoutesSelected(selected: Boolean) = updateSelection { it.copy(routes = selected) }
+
+    fun setSettingsSelected(selected: Boolean) = updateSelection { it.copy(settings = selected) }
+
+    private fun updateSelection(transform: (RestoreSelection) -> RestoreSelection) {
+        updateState { state ->
+            val preview = state.importPreview ?: return@updateState state
+            state.copy(importPreview = preview.copy(selection = transform(preview.selection)))
+        }
+    }
+
+    /** Dismisses the import-preview sheet without restoring. */
+    fun cancelImport() {
+        updateState { it.copy(importPreview = null) }
+    }
+
+    /**
+     * Applies the staged restore for the active preview's selection. On success the
+     * [BackupRestoreEffect.Restored] effect is emitted; the screen restarts the
+     * process. Malformed JSON or a newer schema aborts without touching live data
+     * (the use case re-validates from the same bytes).
+     */
+    fun confirmRestore() {
+        val state = currentState()
+        val preview = state.importPreview
+        when {
+            preview == null || state.restoring -> {
+            }
+
+            !preview.selection.any -> {
+                emitRestoreEffect(BackupRestoreEffect.NothingSelected)
+            }
+
+            else -> {
+                updateState { it.copy(restoring = true) }
+                scope.launch {
+                    val result =
+                        withContext(defaultDispatcher) {
+                            restoreUseCase.restore(preview.json, preview.selection)
+                        }
+                    updateState { it.copy(restoring = false, importPreview = null) }
+                    emitRestoreEffect(
+                        when (result) {
+                            is RestoreResult.Success -> {
+                                BackupRestoreEffect.Restored
+                            }
+
+                            is RestoreResult.UnsupportedVersion -> {
+                                BackupRestoreEffect.UnsupportedVersion(result.found, result.supported)
+                            }
+
+                            is RestoreResult.Aborted -> {
+                                BackupRestoreEffect.Malformed
+                            }
+
+                            RestoreResult.NothingSelected -> {
+                                BackupRestoreEffect.NothingSelected
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/poyka/ripdpi/backup/BackupResetCoordinator.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/backup/BackupResetCoordinator.kt
@@ -1,0 +1,61 @@
+package com.poyka.ripdpi.backup
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Owns the typed-confirmation "reset all settings" workflow: dialog visibility, the
+ * confirmation-token input, and the gated wipe.
+ *
+ * The wipe runs on [defaultDispatcher] (defaulting to the dispatcher the ViewModel
+ * used historically), then flips `resetting` off and hides the dialog in the SAME
+ * update BEFORE emitting [BackupResetEffect.Wiped] — state-then-effect ordering, so
+ * the screen never restarts the process before the state settles. The typed-token
+ * gate is read from the live [BackupRestoreUiState] via [currentState] (the
+ * `resetConfirmationMatches` computed property stays on the state object).
+ */
+internal class BackupResetCoordinator(
+    private val scope: CoroutineScope,
+    private val resetAllSettingsUseCase: ResetAllSettingsUseCase,
+    private val currentState: () -> BackupRestoreUiState,
+    private val updateState: ((BackupRestoreUiState) -> BackupRestoreUiState) -> Unit,
+    private val emitResetEffect: (BackupResetEffect) -> Unit,
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
+) {
+    /**
+     * Shows or hides the typed-confirmation reset dialog, always resetting the typed
+     * input. Hiding it has NO side effect on any store: cancellation up to the confirm
+     * step is completely free of consequences. Ignored mid-wipe.
+     */
+    fun setResetDialogVisible(visible: Boolean) {
+        if (currentState().resetting) return
+        updateState { it.copy(resetDialogVisible = visible, resetConfirmationInput = "") }
+    }
+
+    /** Updates the typed confirmation token as the user types. */
+    fun onResetConfirmationInputChange(input: String) {
+        updateState { it.copy(resetConfirmationInput = input) }
+    }
+
+    /**
+     * Performs the wipe — but ONLY if the typed token matches exactly. Records the
+     * one-shot reset telemetry event first (inside the use case), then wipes every
+     * user store and emits [BackupResetEffect.Wiped] so the screen restarts the
+     * process. A mismatched token is a no-op.
+     */
+    fun confirmReset() {
+        val state = currentState()
+        if (state.resetting || !state.resetConfirmationMatches) return
+        updateState { it.copy(resetting = true) }
+        scope.launch {
+            withContext(defaultDispatcher) { resetAllSettingsUseCase.reset() }
+            updateState {
+                it.copy(resetting = false, resetDialogVisible = false, resetConfirmationInput = "")
+            }
+            emitResetEffect(BackupResetEffect.Wiped)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/poyka/ripdpi/backup/BackupRestoreUiModels.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/backup/BackupRestoreUiModels.kt
@@ -1,0 +1,117 @@
+package com.poyka.ripdpi.backup
+
+import com.poyka.ripdpi.data.backup.BackupPreview
+import com.poyka.ripdpi.data.backup.BackupVariant
+import com.poyka.ripdpi.data.backup.RestoreSelection
+
+/**
+ * One-shot effect surfaced after an export attempt; the screen renders it as a
+ * snackbar and (for SHARE only) an optional follow-up share action, then clears it.
+ */
+sealed interface BackupExportEffect {
+    /**
+     * Export succeeded. [byteCount] is the number of JSON bytes written; [offerShare]
+     * is `true` only for [BackupVariant.SHARE] (FULL backups are never offered an
+     * inline share, to avoid spraying credentials through a share sheet).
+     */
+    data class Success(
+        val variant: BackupVariant,
+        val byteCount: Long,
+        val offerShare: Boolean,
+    ) : BackupExportEffect
+
+    /** The destination write failed. The screen also deletes any partial file. */
+    data object WriteFailed : BackupExportEffect
+
+    /** The user cancelled the SAF picker (or document creation returned no Uri). */
+    data object Cancelled : BackupExportEffect
+}
+
+/**
+ * One-shot effect surfaced after a "share redacted backup" attempt. The screen
+ * launches the share sheet on [Ready] and cleans up the temp cache file on every
+ * terminal outcome.
+ */
+sealed interface BackupShareEffect {
+    /** A fresh SHARE backup was written to the cache file and is ready to share. */
+    data object Ready : BackupShareEffect
+
+    /** Writing the temp SHARE backup failed; nothing is shared. */
+    data object Failed : BackupShareEffect
+}
+
+/**
+ * One-shot effect surfaced after an import / restore attempt.
+ */
+sealed interface BackupRestoreEffect {
+    /**
+     * The restore committed. The screen restarts the process (ProcessPhoenix) so
+     * all DataStore / Room observers reinitialize against the restored state.
+     */
+    data object Restored : BackupRestoreEffect
+
+    /** The chosen file's schema version is newer than this app supports. */
+    data class UnsupportedVersion(
+        val found: Int,
+        val supported: Int,
+    ) : BackupRestoreEffect
+
+    /** The file was malformed, unreadable, or failed an integrity check. */
+    data object Malformed : BackupRestoreEffect
+
+    /** The user picked a file but selected no categories to restore. */
+    data object NothingSelected : BackupRestoreEffect
+}
+
+/**
+ * One-shot effect surfaced after a confirmed "reset all settings" wipe completes.
+ */
+sealed interface BackupResetEffect {
+    /**
+     * The wipe committed. The screen restarts the process (ProcessPhoenix) so the
+     * app comes back up clean, at onboarding.
+     */
+    data object Wiped : BackupResetEffect
+}
+
+/**
+ * The stable, non-localized token the user must type to confirm a destructive reset.
+ * It is deliberately NOT translated: a fixed token is unambiguous across locales and
+ * keeps the typed-confirmation gate testable.
+ */
+const val ResetConfirmationToken: String = "RESET"
+
+/**
+ * Live preview of a chosen backup file, shown BEFORE any write. Carries the parsed
+ * JSON so the subsequent restore re-uses the exact bytes the user previewed.
+ */
+data class BackupImportPreview(
+    val json: String,
+    val preview: BackupPreview,
+    val selection: RestoreSelection,
+)
+
+/** Immutable render state for the Backup & Restore screen. */
+data class BackupRestoreUiState(
+    val exporting: Boolean = false,
+    val exportDisabledByPolicy: Boolean = false,
+    val importing: Boolean = false,
+    val restoring: Boolean = false,
+    /** True while a fresh SHARE backup is being written to the cache for sharing. */
+    val sharing: Boolean = false,
+    /** Non-null while the import-preview sheet is visible. */
+    val importPreview: BackupImportPreview? = null,
+    /** True while the typed-confirmation reset dialog is visible. */
+    val resetDialogVisible: Boolean = false,
+    /** The text the user has typed into the reset-confirmation field so far. */
+    val resetConfirmationInput: String = "",
+    /** True while the wipe is in flight (dialog buttons disabled). */
+    val resetting: Boolean = false,
+) {
+    /**
+     * `true` once the user has typed the exact, case-sensitive confirmation token.
+     * The reset confirm action stays disabled until this flips to `true`.
+     */
+    val resetConfirmationMatches: Boolean
+        get() = resetConfirmationInput == ResetConfirmationToken
+}

--- a/app/src/main/kotlin/com/poyka/ripdpi/backup/BackupRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/backup/BackupRestoreViewModel.kt
@@ -2,16 +2,10 @@ package com.poyka.ripdpi.backup
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.poyka.ripdpi.data.backup.BackupExportResult
 import com.poyka.ripdpi.data.backup.BackupExportUseCase
-import com.poyka.ripdpi.data.backup.BackupPreview
-import com.poyka.ripdpi.data.backup.BackupPreviewResult
 import com.poyka.ripdpi.data.backup.BackupRestoreUseCase
 import com.poyka.ripdpi.data.backup.BackupVariant
-import com.poyka.ripdpi.data.backup.RestoreResult
-import com.poyka.ripdpi.data.backup.RestoreSelection
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,135 +14,21 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.io.InputStream
 import java.io.OutputStream
 import javax.inject.Inject
 import javax.inject.Named
 
-/**
- * One-shot effect surfaced after an export attempt; the screen renders it as a
- * snackbar and (for SHARE only) an optional follow-up share action, then clears it.
- */
-sealed interface BackupExportEffect {
-    /**
-     * Export succeeded. [byteCount] is the number of JSON bytes written; [offerShare]
-     * is `true` only for [BackupVariant.SHARE] (FULL backups are never offered an
-     * inline share, to avoid spraying credentials through a share sheet).
-     */
-    data class Success(
-        val variant: BackupVariant,
-        val byteCount: Long,
-        val offerShare: Boolean,
-    ) : BackupExportEffect
-
-    /** The destination write failed. The screen also deletes any partial file. */
-    data object WriteFailed : BackupExportEffect
-
-    /** The user cancelled the SAF picker (or document creation returned no Uri). */
-    data object Cancelled : BackupExportEffect
-}
-
-/**
- * One-shot effect surfaced after a "share redacted backup" attempt. The screen
- * launches the share sheet on [Ready] and cleans up the temp cache file on every
- * terminal outcome.
- */
-sealed interface BackupShareEffect {
-    /** A fresh SHARE backup was written to the cache file and is ready to share. */
-    data object Ready : BackupShareEffect
-
-    /** Writing the temp SHARE backup failed; nothing is shared. */
-    data object Failed : BackupShareEffect
-}
-
-/**
- * One-shot effect surfaced after an import / restore attempt.
- */
-sealed interface BackupRestoreEffect {
-    /**
-     * The restore committed. The screen restarts the process (ProcessPhoenix) so
-     * all DataStore / Room observers reinitialize against the restored state.
-     */
-    data object Restored : BackupRestoreEffect
-
-    /** The chosen file's schema version is newer than this app supports. */
-    data class UnsupportedVersion(
-        val found: Int,
-        val supported: Int,
-    ) : BackupRestoreEffect
-
-    /** The file was malformed, unreadable, or failed an integrity check. */
-    data object Malformed : BackupRestoreEffect
-
-    /** The user picked a file but selected no categories to restore. */
-    data object NothingSelected : BackupRestoreEffect
-}
-
-/**
- * One-shot effect surfaced after a confirmed "reset all settings" wipe completes.
- */
-sealed interface BackupResetEffect {
-    /**
-     * The wipe committed. The screen restarts the process (ProcessPhoenix) so the
-     * app comes back up clean, at onboarding.
-     */
-    data object Wiped : BackupResetEffect
-}
-
-/**
- * The stable, non-localized token the user must type to confirm a destructive reset.
- * It is deliberately NOT translated: a fixed token is unambiguous across locales and
- * keeps the typed-confirmation gate testable.
- */
-const val ResetConfirmationToken: String = "RESET"
-
-/**
- * Live preview of a chosen backup file, shown BEFORE any write. Carries the parsed
- * JSON so the subsequent restore re-uses the exact bytes the user previewed.
- */
-data class BackupImportPreview(
-    val json: String,
-    val preview: BackupPreview,
-    val selection: RestoreSelection,
-)
-
-/** Immutable render state for the Backup & Restore screen. */
-data class BackupRestoreUiState(
-    val exporting: Boolean = false,
-    val exportDisabledByPolicy: Boolean = false,
-    val importing: Boolean = false,
-    val restoring: Boolean = false,
-    /** True while a fresh SHARE backup is being written to the cache for sharing. */
-    val sharing: Boolean = false,
-    /** Non-null while the import-preview sheet is visible. */
-    val importPreview: BackupImportPreview? = null,
-    /** True while the typed-confirmation reset dialog is visible. */
-    val resetDialogVisible: Boolean = false,
-    /** The text the user has typed into the reset-confirmation field so far. */
-    val resetConfirmationInput: String = "",
-    /** True while the wipe is in flight (dialog buttons disabled). */
-    val resetting: Boolean = false,
-) {
-    /**
-     * `true` once the user has typed the exact, case-sensitive confirmation token.
-     * The reset confirm action stays disabled until this flips to `true`.
-     */
-    val resetConfirmationMatches: Boolean
-        get() = resetConfirmationInput == ResetConfirmationToken
-}
-
 @HiltViewModel
 class BackupRestoreViewModel
     @Inject
     constructor(
-        private val exportUseCase: BackupExportUseCase,
-        private val restoreUseCase: BackupRestoreUseCase,
+        exportUseCase: BackupExportUseCase,
+        restoreUseCase: BackupRestoreUseCase,
         private val exportPolicy: BackupExportPolicy,
         private val shareReminderPreferences: BackupShareReminderPreferences,
-        private val resetAllSettingsUseCase: ResetAllSettingsUseCase,
-        @param:Named("appVersionName") private val appVersion: String,
+        resetAllSettingsUseCase: ResetAllSettingsUseCase,
+        @param:Named("appVersionName") appVersion: String,
     ) : ViewModel() {
         private val _uiState =
             MutableStateFlow(
@@ -178,6 +58,36 @@ class BackupRestoreViewModel
             MutableSharedFlow<BackupResetEffect>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
         val resetEffects: SharedFlow<BackupResetEffect> = _resetEffects.asSharedFlow()
 
+        private val exportCoordinator =
+            BackupExportCoordinator(
+                scope = viewModelScope,
+                exportUseCase = exportUseCase,
+                appVersion = appVersion,
+                exportDisabledByPolicy = { _uiState.value.exportDisabledByPolicy },
+                currentState = _uiState::value,
+                updateState = _uiState::update,
+                emitExportEffect = _effects::tryEmit,
+                emitShareEffect = _shareEffects::tryEmit,
+            )
+
+        private val importCoordinator =
+            BackupImportCoordinator(
+                scope = viewModelScope,
+                restoreUseCase = restoreUseCase,
+                currentState = _uiState::value,
+                updateState = _uiState::update,
+                emitRestoreEffect = _restoreEffects::tryEmit,
+            )
+
+        private val resetCoordinator =
+            BackupResetCoordinator(
+                scope = viewModelScope,
+                resetAllSettingsUseCase = resetAllSettingsUseCase,
+                currentState = _uiState::value,
+                updateState = _uiState::update,
+                emitResetEffect = _resetEffects::tryEmit,
+            )
+
         /** Re-evaluates the MDM suppression knob (called on screen resume). */
         fun refreshPolicy() {
             _uiState.update { it.copy(exportDisabledByPolicy = exportPolicy.isExportDisabledByPolicy()) }
@@ -195,43 +105,7 @@ class BackupRestoreViewModel
             variant: BackupVariant,
             openOutput: () -> OutputStream?,
             onWriteFailed: () -> Unit,
-        ) {
-            if (_uiState.value.exporting || _uiState.value.exportDisabledByPolicy) return
-            _uiState.update { it.copy(exporting = true) }
-            viewModelScope.launch {
-                val output = openOutput()
-                if (output == null) {
-                    _uiState.update { it.copy(exporting = false) }
-                    _effects.tryEmit(BackupExportEffect.Cancelled)
-                    return@launch
-                }
-                val result =
-                    output.use { stream ->
-                        exportUseCase.export(
-                            variant = variant,
-                            output = stream,
-                            appVersion = appVersion,
-                        )
-                    }
-                _uiState.update { it.copy(exporting = false) }
-                _effects.tryEmit(
-                    when (result) {
-                        is BackupExportResult.Success -> {
-                            BackupExportEffect.Success(
-                                variant = result.variant,
-                                byteCount = result.byteCount,
-                                offerShare = result.variant == BackupVariant.SHARE,
-                            )
-                        }
-
-                        is BackupExportResult.WriteFailed -> {
-                            onWriteFailed()
-                            BackupExportEffect.WriteFailed
-                        }
-                    },
-                )
-            }
-        }
+        ) = exportCoordinator.export(variant, openOutput, onWriteFailed)
 
         /**
          * Writes a FRESH [BackupVariant.SHARE] backup into the stream produced by
@@ -243,33 +117,7 @@ class BackupRestoreViewModel
          * on a write failure [BackupShareEffect.Failed] is emitted and the screen
          * deletes the (possibly partial) temp file. The stream is always closed here.
          */
-        fun prepareShareBackup(openOutput: () -> OutputStream?) {
-            if (_uiState.value.sharing || _uiState.value.exportDisabledByPolicy) return
-            _uiState.update { it.copy(sharing = true) }
-            viewModelScope.launch {
-                val output = openOutput()
-                if (output == null) {
-                    _uiState.update { it.copy(sharing = false) }
-                    _shareEffects.tryEmit(BackupShareEffect.Failed)
-                    return@launch
-                }
-                val result =
-                    output.use { stream ->
-                        exportUseCase.export(
-                            variant = BackupVariant.SHARE,
-                            output = stream,
-                            appVersion = appVersion,
-                        )
-                    }
-                _uiState.update { it.copy(sharing = false) }
-                _shareEffects.tryEmit(
-                    when (result) {
-                        is BackupExportResult.Success -> BackupShareEffect.Ready
-                        is BackupExportResult.WriteFailed -> BackupShareEffect.Failed
-                    },
-                )
-            }
-        }
+        fun prepareShareBackup(openOutput: () -> OutputStream?) = exportCoordinator.prepareShareBackup(openOutput)
 
         /**
          * Returns `true` when the one-time "SHARE is redacted but not zero-knowledge"
@@ -290,75 +138,17 @@ class BackupRestoreViewModel
          * [openInput] returns the SAF source stream (or `null` if cancelled). The
          * stream is fully read and closed here.
          */
-        fun openImport(openInput: () -> InputStream?) {
-            if (_uiState.value.importing || _uiState.value.restoring) return
-            _uiState.update { it.copy(importing = true) }
-            viewModelScope.launch {
-                val json =
-                    withContext(Dispatchers.IO) {
-                        runCatching { openInput()?.use { it.readBytes().toString(Charsets.UTF_8) } }.getOrNull()
-                    }
-                if (json == null) {
-                    // Cancelled picker or unreadable stream: no preview, no effect noise.
-                    _uiState.update { it.copy(importing = false) }
-                    return@launch
-                }
-                when (val result = withContext(Dispatchers.Default) { restoreUseCase.preview(json) }) {
-                    is BackupPreviewResult.Ready -> {
-                        _uiState.update {
-                            it.copy(
-                                importing = false,
-                                importPreview =
-                                    BackupImportPreview(
-                                        json = json,
-                                        preview = result.preview,
-                                        // Default: restore only the categories that
-                                        // actually carry content; never silently flip
-                                        // an empty category on.
-                                        selection =
-                                            RestoreSelection(
-                                                profilesAndGroups = result.preview.canRestoreProfilesAndGroups,
-                                                routes = result.preview.ruleCount > 0,
-                                                settings = result.preview.settingCount > 0,
-                                            ),
-                                    ),
-                            )
-                        }
-                    }
-
-                    is BackupPreviewResult.UnsupportedVersion -> {
-                        _uiState.update { it.copy(importing = false) }
-                        _restoreEffects.tryEmit(
-                            BackupRestoreEffect.UnsupportedVersion(result.found, result.supported),
-                        )
-                    }
-
-                    is BackupPreviewResult.Malformed -> {
-                        _uiState.update { it.copy(importing = false) }
-                        _restoreEffects.tryEmit(BackupRestoreEffect.Malformed)
-                    }
-                }
-            }
-        }
+        fun openImport(openInput: () -> InputStream?) = importCoordinator.openImport(openInput)
 
         /** Toggles one restore category in the active preview. */
-        fun setProfilesAndGroupsSelected(selected: Boolean) = updateSelection { it.copy(profilesAndGroups = selected) }
+        fun setProfilesAndGroupsSelected(selected: Boolean) = importCoordinator.setProfilesAndGroupsSelected(selected)
 
-        fun setRoutesSelected(selected: Boolean) = updateSelection { it.copy(routes = selected) }
+        fun setRoutesSelected(selected: Boolean) = importCoordinator.setRoutesSelected(selected)
 
-        fun setSettingsSelected(selected: Boolean) = updateSelection { it.copy(settings = selected) }
-
-        private fun updateSelection(transform: (RestoreSelection) -> RestoreSelection) {
-            _uiState.update { state ->
-                val preview = state.importPreview ?: return@update state
-                state.copy(importPreview = preview.copy(selection = transform(preview.selection)))
-            }
-        }
+        fun setSettingsSelected(selected: Boolean) = importCoordinator.setSettingsSelected(selected)
 
         /** Dismisses the import-preview sheet without restoring. */
-        fun cancelImport() {
-            _uiState.update { it.copy(importPreview = null) }
-        }
+        fun cancelImport() = importCoordinator.cancelImport()
 
         /**
          * Applies the staged restore for the active preview's selection. On success
@@ -366,48 +156,7 @@ class BackupRestoreViewModel
          * the process. Malformed JSON or a newer schema aborts without touching live
          * data (the use case re-validates from the same bytes).
          */
-        fun confirmRestore() {
-            val state = _uiState.value
-            val preview = state.importPreview
-            when {
-                preview == null || state.restoring -> {
-                }
-
-                !preview.selection.any -> {
-                    _restoreEffects.tryEmit(BackupRestoreEffect.NothingSelected)
-                }
-
-                else -> {
-                    _uiState.update { it.copy(restoring = true) }
-                    viewModelScope.launch {
-                        val result =
-                            withContext(Dispatchers.Default) {
-                                restoreUseCase.restore(preview.json, preview.selection)
-                            }
-                        _uiState.update { it.copy(restoring = false, importPreview = null) }
-                        _restoreEffects.tryEmit(
-                            when (result) {
-                                is RestoreResult.Success -> {
-                                    BackupRestoreEffect.Restored
-                                }
-
-                                is RestoreResult.UnsupportedVersion -> {
-                                    BackupRestoreEffect.UnsupportedVersion(result.found, result.supported)
-                                }
-
-                                is RestoreResult.Aborted -> {
-                                    BackupRestoreEffect.Malformed
-                                }
-
-                                RestoreResult.NothingSelected -> {
-                                    BackupRestoreEffect.NothingSelected
-                                }
-                            },
-                        )
-                    }
-                }
-            }
-        }
+        fun confirmRestore() = importCoordinator.confirmRestore()
 
         // -- Reset all settings ---------------------------------------------------
 
@@ -416,15 +165,10 @@ class BackupRestoreViewModel
          * typed input. Hiding it has NO side effect on any store: cancellation up to
          * the confirm step is completely free of consequences. Ignored mid-wipe.
          */
-        fun setResetDialogVisible(visible: Boolean) {
-            if (_uiState.value.resetting) return
-            _uiState.update { it.copy(resetDialogVisible = visible, resetConfirmationInput = "") }
-        }
+        fun setResetDialogVisible(visible: Boolean) = resetCoordinator.setResetDialogVisible(visible)
 
         /** Updates the typed confirmation token as the user types. */
-        fun onResetConfirmationInputChange(input: String) {
-            _uiState.update { it.copy(resetConfirmationInput = input) }
-        }
+        fun onResetConfirmationInputChange(input: String) = resetCoordinator.onResetConfirmationInputChange(input)
 
         /**
          * Performs the wipe — but ONLY if the typed token matches exactly. Records
@@ -432,16 +176,5 @@ class BackupRestoreViewModel
          * every user store and emits [BackupResetEffect.Wiped] so the screen restarts
          * the process. A mismatched token is a no-op.
          */
-        fun confirmReset() {
-            val state = _uiState.value
-            if (state.resetting || !state.resetConfirmationMatches) return
-            _uiState.update { it.copy(resetting = true) }
-            viewModelScope.launch {
-                withContext(Dispatchers.Default) { resetAllSettingsUseCase.reset() }
-                _uiState.update {
-                    it.copy(resetting = false, resetDialogVisible = false, resetConfirmationInput = "")
-                }
-                _resetEffects.tryEmit(BackupResetEffect.Wiped)
-            }
-        }
+        fun confirmReset() = resetCoordinator.confirmReset()
     }

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckProbeOrchestrator.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckProbeOrchestrator.kt
@@ -1,0 +1,250 @@
+package com.poyka.ripdpi.ui.screens.blockcheck
+
+import com.poyka.ripdpi.R
+import com.poyka.ripdpi.core.detection.BlockLayer
+import com.poyka.ripdpi.core.detection.BlockLayerDiagnosis
+import com.poyka.ripdpi.core.detection.BlockLayerDiagnosisMapper
+import com.poyka.ripdpi.core.detection.BypassStrategyClass
+import com.poyka.ripdpi.core.detection.EvidenceConfidence
+import com.poyka.ripdpi.core.detection.dpi.DpiProbeError
+import com.poyka.ripdpi.diagnostics.RankedStrategyProbeResult
+import com.poyka.ripdpi.diagnostics.StrategyProbeCandidate
+import com.poyka.ripdpi.diagnostics.StrategyProbeCandidateProvider
+import com.poyka.ripdpi.diagnostics.StrategyProbeConfig
+import com.poyka.ripdpi.diagnostics.StrategyProbeFailureKind
+import com.poyka.ripdpi.diagnostics.StrategyProbeRankingAccumulator
+import com.poyka.ripdpi.diagnostics.StrategyProbeResult
+import com.poyka.ripdpi.diagnostics.StrategyProbeService
+import com.poyka.ripdpi.diagnostics.dpi.AttemptStatus
+import com.poyka.ripdpi.diagnostics.dpi.DomainReachabilityResult
+import com.poyka.ripdpi.diagnostics.dpi.DomainVerdict
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+internal const val BlockcheckDiagnosisMaxDomains = 3
+
+/**
+ * Owns the two-phase blockcheck pipeline: a diagnosis pass followed by a streamed
+ * strategy-probe pass with incremental ranking and recommendation recompute.
+ *
+ * [run] is a cold flow: it first emits a clean [BlockcheckRunState.Running] snapshot
+ * carrying the diagnosis, then one snapshot per probe result with the rolling ranking
+ * and recommendation, then a terminal [BlockcheckRunState.Complete] snapshot.
+ */
+class BlockcheckProbeOrchestrator
+    @Inject
+    constructor(
+        private val probeService: StrategyProbeService,
+        private val candidateProvider: StrategyProbeCandidateProvider,
+        private val diagnosisRunner: BlockcheckDiagnosisRunner,
+    ) {
+        suspend fun listCandidates(): List<StrategyProbeCandidate> = candidateProvider.listCandidates()
+
+        suspend fun diagnose(domains: List<String>): List<BlockcheckSiteDiagnosis> {
+            val diagnosisDomains = domains.take(BlockcheckDiagnosisMaxDomains)
+            return runCatching { diagnosisRunner.diagnose(diagnosisDomains) }
+                .getOrElse { error ->
+                    if (error is CancellationException) {
+                        throw error
+                    }
+                    emptyList()
+                }
+        }
+
+        fun run(
+            domains: List<String>,
+            candidates: List<StrategyProbeCandidate>,
+        ): Flow<BlockcheckUiState> =
+            flow {
+                val diagnoses = diagnose(domains)
+                emit(
+                    BlockcheckUiState(
+                        runState = BlockcheckRunState.Running,
+                        domains = domains,
+                        diagnoses = diagnoses,
+                        recommendedStrategyId = diagnoses.recommendedCandidate(candidates)?.id,
+                        recommendedStrategyLabel = diagnoses.recommendedCandidate(candidates)?.label,
+                        totalExpectedResults = candidates.size * domains.size,
+                    ),
+                )
+                var collected = persistentListOf<StrategyProbeResult>()
+                val rankingAccumulator = StrategyProbeRankingAccumulator()
+                val config = StrategyProbeConfig(testDomains = domains, maxStrategies = candidates.size)
+                probeService.run(config).collect { result ->
+                    collected = collected.add(result)
+                    rankingAccumulator.add(result)
+                    val ranked = rankingAccumulator.rankedStrategies()
+                    emit(
+                        BlockcheckUiState(
+                            runState = BlockcheckRunState.Running,
+                            domains = domains,
+                            results = collected,
+                            rankedStrategies = ranked,
+                            diagnoses = diagnoses,
+                            recommendedStrategyId =
+                                diagnoses
+                                    .recommendedCandidate(candidates = candidates, rankedStrategies = ranked)
+                                    ?.id,
+                            recommendedStrategyLabel =
+                                diagnoses
+                                    .recommendedCandidate(candidates = candidates, rankedStrategies = ranked)
+                                    ?.label,
+                            totalExpectedResults = candidates.size * domains.size,
+                        ),
+                    )
+                }
+                val ranked = rankingAccumulator.rankedStrategies()
+                val finalDiagnoses =
+                    if (diagnoses.isEmpty()) {
+                        diagnoseFromStrategyResults(collected)
+                    } else {
+                        diagnoses
+                    }
+                emit(
+                    BlockcheckUiState(
+                        runState = BlockcheckRunState.Complete,
+                        domains = domains,
+                        results = collected,
+                        rankedStrategies = ranked,
+                        diagnoses = finalDiagnoses,
+                        recommendedStrategyId =
+                            finalDiagnoses
+                                .recommendedCandidate(candidates = candidates, rankedStrategies = ranked)
+                                ?.id,
+                        recommendedStrategyLabel =
+                            finalDiagnoses
+                                .recommendedCandidate(candidates = candidates, rankedStrategies = ranked)
+                                ?.label,
+                        totalExpectedResults = candidates.size * domains.size,
+                        messageRes = R.string.blockcheck_message_probe_complete,
+                    ),
+                )
+            }
+    }
+
+internal fun diagnoseReachability(result: DomainReachabilityResult): BlockcheckSiteDiagnosis? {
+    val diagnosis =
+        when (result.verdict) {
+            DomainVerdict.OK -> null
+
+            DomainVerdict.DNS_FAIL,
+            DomainVerdict.FAKE_IP,
+            -> BlockLayerDiagnosisMapper.fromDpiError(DpiProbeError.DnsFail)
+
+            DomainVerdict.ISP_PAGE -> BlockLayerDiagnosisMapper.forHttpBlockpage()
+
+            DomainVerdict.TCP16_BAND,
+            DomainVerdict.TLS_VERSION_BLOCK,
+            -> BlockLayerDiagnosisMapper.forTlsVersionBlock()
+
+            DomainVerdict.BLOCKED,
+            DomainVerdict.UNREACHABLE,
+            -> result.firstProbeDiagnosis()
+        } ?: return null
+    return BlockcheckSiteDiagnosis(
+        domain = result.domain,
+        diagnosis = diagnosis,
+        probeVerdict = result.verdict.name,
+    )
+}
+
+private fun DomainReachabilityResult.firstProbeDiagnosis(): BlockLayerDiagnosis =
+    listOf(tls13, tls12, http)
+        .firstNotNullOfOrNull { attempt ->
+            BlockLayerDiagnosisMapper.fromDpiError(attempt.error)
+                ?: attempt.status.toDiagnosis()
+        } ?: BlockLayerDiagnosisMapper.forUnknownBlocked()
+
+private fun AttemptStatus.toDiagnosis(): BlockLayerDiagnosis? =
+    when (this) {
+        AttemptStatus.BLOCKED,
+        AttemptStatus.REDIR_SUSPICIOUS,
+        AttemptStatus.ISP_PAGE,
+        -> BlockLayerDiagnosisMapper.forHttpBlockpage()
+
+        AttemptStatus.TCP16_BAND_TIMEOUT -> BlockLayerDiagnosisMapper.forTlsVersionBlock()
+
+        AttemptStatus.OK,
+        AttemptStatus.REDIR_OK,
+        AttemptStatus.FAKE_IP,
+        AttemptStatus.ERROR,
+        -> null
+    }
+
+private fun diagnoseFromStrategyResults(results: List<StrategyProbeResult>): List<BlockcheckSiteDiagnosis> =
+    results
+        .asSequence()
+        .filter { result -> !result.success }
+        .groupBy(StrategyProbeResult::domain)
+        .mapNotNull { (domain, domainResults) ->
+            val diagnosis =
+                when {
+                    domainResults.any { it.dnsTampered || it.failureKind == StrategyProbeFailureKind.DnsTampered } -> {
+                        BlockLayerDiagnosisMapper.forDnsTampering()
+                    }
+
+                    domainResults.any { it.failureKind == StrategyProbeFailureKind.Timeout } -> {
+                        BlockLayerDiagnosis(
+                            layer = BlockLayer.IP_BLOCK,
+                            bypassClass = BypassStrategyClass.FAKE_PACKET_TTL,
+                            confidence = EvidenceConfidence.LOW,
+                            reasonCode = "strategy_probe_timeout",
+                        )
+                    }
+
+                    domainResults.any { it.failureKind == StrategyProbeFailureKind.ConnectionFailed } -> {
+                        BlockLayerDiagnosisMapper.forUnknownBlocked()
+                    }
+
+                    else -> {
+                        null
+                    }
+                } ?: return@mapNotNull null
+            BlockcheckSiteDiagnosis(domain = domain, diagnosis = diagnosis)
+        }
+
+private fun List<BlockcheckSiteDiagnosis>.recommendedCandidate(
+    candidates: List<StrategyProbeCandidate>,
+    rankedStrategies: List<RankedStrategyProbeResult> = emptyList(),
+): StrategyProbeCandidate? {
+    val recommendation = firstOrNull()?.diagnosis?.bypassClass ?: return rankedStrategies.bestCandidate(candidates)
+    return rankedStrategies
+        .mapNotNull { ranked -> candidates.firstOrNull { candidate -> candidate.id == ranked.strategyId } }
+        .firstOrNull { candidate -> candidate.matches(recommendation) }
+        ?: candidates.firstOrNull { candidate -> candidate.matches(recommendation) }
+        ?: rankedStrategies.bestCandidate(candidates)
+}
+
+private fun List<RankedStrategyProbeResult>.bestCandidate(
+    candidates: List<StrategyProbeCandidate>,
+): StrategyProbeCandidate? =
+    firstOrNull()?.strategyId?.let { strategyId -> candidates.firstOrNull { it.id == strategyId } }
+
+private fun StrategyProbeCandidate.matches(recommendation: BypassStrategyClass): Boolean {
+    val haystack = "$id $label ${configDsl.orEmpty()}".lowercase()
+    return when (recommendation) {
+        BypassStrategyClass.ENCRYPTED_DNS -> {
+            false
+        }
+
+        BypassStrategyClass.TLS_RECORD_SPLIT -> {
+            haystack.contains("tlsrec") || haystack.contains("split")
+        }
+
+        BypassStrategyClass.FAKE_PACKET_TTL -> {
+            haystack.contains("fake") || haystack.contains("oob") ||
+                haystack.contains("ttl")
+        }
+
+        BypassStrategyClass.HOST_HEADER_SPLIT -> {
+            haystack.contains("host") || haystack.contains("split_host")
+        }
+
+        BypassStrategyClass.STRATEGY_PROBE_WINNER -> {
+            true
+        }
+    }
+}

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckRecommendationRepository.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckRecommendationRepository.kt
@@ -1,0 +1,73 @@
+package com.poyka.ripdpi.ui.screens.blockcheck
+
+import com.poyka.ripdpi.data.AppSettingsRepository
+import com.poyka.ripdpi.data.setRawStrategyChainDsl
+import com.poyka.ripdpi.diagnostics.StrategyProbeCandidate
+import com.poyka.ripdpi.diagnostics.toStrategyActivationYaml
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import javax.inject.Inject
+
+/** Outcome of applying a strategy recommendation to the persisted app settings. */
+sealed interface BlockcheckApplyOutcome {
+    data object Applied : BlockcheckApplyOutcome
+
+    data object Unregistered : BlockcheckApplyOutcome
+
+    data class ReloadFailed(
+        val message: String,
+    ) : BlockcheckApplyOutcome
+}
+
+/** Persists a chosen strategy candidate and reloads the native config. UI-state free. */
+interface BlockcheckRecommendationRepository {
+    suspend fun applyStrategy(
+        strategyId: String,
+        candidates: List<StrategyProbeCandidate>,
+    ): BlockcheckApplyOutcome
+}
+
+class DefaultBlockcheckRecommendationRepository
+    @Inject
+    constructor(
+        private val appSettingsRepository: AppSettingsRepository,
+        private val reloader: BlockcheckStrategyReloader,
+    ) : BlockcheckRecommendationRepository {
+        override suspend fun applyStrategy(
+            strategyId: String,
+            candidates: List<StrategyProbeCandidate>,
+        ): BlockcheckApplyOutcome {
+            val candidate =
+                candidates.firstOrNull { it.id == strategyId }
+                    ?: return BlockcheckApplyOutcome.Unregistered
+            appSettingsRepository.update {
+                strategyChainYaml = candidate.toStrategyActivationYaml()
+                candidate.configDsl?.let(::setRawStrategyChainDsl)
+            }
+            val reloadError = reloader.reloadConfig()
+            return if (reloadError == null) {
+                BlockcheckApplyOutcome.Applied
+            } else {
+                BlockcheckApplyOutcome.ReloadFailed(reloadError)
+            }
+        }
+    }
+
+@Module
+@InstallIn(ViewModelComponent::class)
+abstract class BlockcheckRecommendationModule {
+    @Binds
+    abstract fun bindBlockcheckRecommendationRepository(
+        repository: DefaultBlockcheckRecommendationRepository,
+    ): BlockcheckRecommendationRepository
+}
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object BlockcheckStrategyReloaderModule {
+    @Provides
+    fun provideBlockcheckStrategyReloader(): BlockcheckStrategyReloader = NativeBlockcheckStrategyReloader()
+}

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckReport.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckReport.kt
@@ -1,0 +1,76 @@
+package com.poyka.ripdpi.ui.screens.blockcheck
+
+import com.poyka.ripdpi.diagnostics.RankedStrategyProbeResult
+import com.poyka.ripdpi.diagnostics.StrategyProbeResult
+import com.poyka.ripdpi.serialization.RipDpiPrettyDefaultsJson
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+private val BlockcheckReportJson = RipDpiPrettyDefaultsJson
+
+fun encodeBlockcheckReport(state: BlockcheckUiState): String {
+    val payload =
+        JsonObject(
+            mapOf(
+                "state" to JsonPrimitive(state.runState.name.lowercase()),
+                "domains" to JsonArray(state.domains.map(::JsonPrimitive)),
+                "diagnoses" to JsonArray(state.diagnoses.map(::encodeDiagnosis)),
+                "recommended_strategy_id" to JsonPrimitive(state.recommendedStrategyId),
+                "results" to JsonArray(state.results.map(::encodeProbeResult)),
+                "ranked_strategies" to JsonArray(state.rankedStrategies.map(::encodeRankedStrategy)),
+            ),
+        )
+    return BlockcheckReportJson.encodeToString(JsonObject.serializer(), payload)
+}
+
+private fun encodeDiagnosis(diagnosis: BlockcheckSiteDiagnosis): JsonObject =
+    JsonObject(
+        mapOf(
+            "domain" to JsonPrimitive(diagnosis.domain),
+            "layer" to
+                JsonPrimitive(
+                    diagnosis.diagnosis.layer.name
+                        .lowercase(),
+                ),
+            "bypass_class" to
+                JsonPrimitive(
+                    diagnosis.diagnosis.bypassClass.name
+                        .lowercase(),
+                ),
+            "confidence" to
+                JsonPrimitive(
+                    diagnosis.diagnosis.confidence.name
+                        .lowercase(),
+                ),
+            "reason_code" to JsonPrimitive(diagnosis.diagnosis.reasonCode),
+            "probe_verdict" to JsonPrimitive(diagnosis.probeVerdict),
+        ),
+    )
+
+private fun encodeProbeResult(result: StrategyProbeResult): JsonObject =
+    JsonObject(
+        mapOf(
+            "strategy_id" to JsonPrimitive(result.strategyId),
+            "strategy_label" to JsonPrimitive(result.strategyLabel),
+            "domain" to JsonPrimitive(result.domain),
+            "success" to JsonPrimitive(result.success),
+            "latency_ms" to JsonPrimitive(result.latencyMs),
+            "dns_tampered" to JsonPrimitive(result.dnsTampered),
+            "failure_kind" to JsonPrimitive(result.failureKind?.name),
+            "error" to JsonPrimitive(result.error),
+        ),
+    )
+
+private fun encodeRankedStrategy(result: RankedStrategyProbeResult): JsonObject =
+    JsonObject(
+        mapOf(
+            "strategy_id" to JsonPrimitive(result.strategyId),
+            "strategy_label" to JsonPrimitive(result.strategyLabel),
+            "total" to JsonPrimitive(result.total),
+            "successes" to JsonPrimitive(result.successes),
+            "success_rate" to JsonPrimitive(result.successRate),
+            "average_latency_ms" to JsonPrimitive(result.averageLatencyMs),
+            "dns_tampered_count" to JsonPrimitive(result.dnsTamperedCount),
+        ),
+    )

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckViewModel.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckViewModel.kt
@@ -4,34 +4,18 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.poyka.ripdpi.R
-import com.poyka.ripdpi.core.detection.BlockLayer
 import com.poyka.ripdpi.core.detection.BlockLayerDiagnosis
-import com.poyka.ripdpi.core.detection.BlockLayerDiagnosisMapper
-import com.poyka.ripdpi.core.detection.BypassStrategyClass
-import com.poyka.ripdpi.core.detection.EvidenceConfidence
-import com.poyka.ripdpi.data.AppSettingsRepository
-import com.poyka.ripdpi.data.setRawStrategyChainDsl
 import com.poyka.ripdpi.diagnostics.RankedStrategyProbeResult
 import com.poyka.ripdpi.diagnostics.StrategyProbeCandidate
-import com.poyka.ripdpi.diagnostics.StrategyProbeCandidateProvider
-import com.poyka.ripdpi.diagnostics.StrategyProbeConfig
 import com.poyka.ripdpi.diagnostics.StrategyProbeFailureKind
-import com.poyka.ripdpi.diagnostics.StrategyProbeRankingAccumulator
 import com.poyka.ripdpi.diagnostics.StrategyProbeResult
-import com.poyka.ripdpi.diagnostics.StrategyProbeService
-import com.poyka.ripdpi.diagnostics.dpi.AttemptStatus
-import com.poyka.ripdpi.diagnostics.dpi.DomainReachabilityResult
 import com.poyka.ripdpi.diagnostics.dpi.DomainReachabilityScanner
-import com.poyka.ripdpi.diagnostics.dpi.DomainVerdict
-import com.poyka.ripdpi.diagnostics.toStrategyActivationYaml
-import com.poyka.ripdpi.serialization.RipDpiPrettyDefaultsJson
 import com.poyka.ripdpi.services.NativeStrategyConfigRuntime
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,9 +24,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import javax.inject.Inject
 import kotlin.math.min
 
@@ -54,8 +35,6 @@ private val DefaultBlockcheckDomains =
         "twitter.com",
         "www.instagram.com",
     )
-
-private const val BlockcheckDiagnosisMaxDomains = 3
 
 enum class BlockcheckRunState {
     Idle,
@@ -103,17 +82,14 @@ data class BlockcheckUiState(
 class BlockcheckViewModel
     @Inject
     constructor(
-        private val probeService: StrategyProbeService,
-        private val candidateProvider: StrategyProbeCandidateProvider,
-        private val appSettingsRepository: AppSettingsRepository,
-        private val diagnosisRunner: BlockcheckDiagnosisRunner,
+        private val orchestrator: BlockcheckProbeOrchestrator,
+        private val recommendationRepository: BlockcheckRecommendationRepository,
     ) : ViewModel() {
         private val mutableUiState = MutableStateFlow(BlockcheckUiState())
         val uiState: StateFlow<BlockcheckUiState> = mutableUiState.asStateFlow()
 
         private var probeJob: Job? = null
         private var lastCandidates: List<StrategyProbeCandidate> = emptyList()
-        internal var strategyReloader: BlockcheckStrategyReloader? = null
 
         fun updateDomainsText(value: String) {
             val domains =
@@ -132,7 +108,7 @@ class BlockcheckViewModel
             probeJob?.cancel()
             probeJob =
                 viewModelScope.launch {
-                    val candidateResult = runCatching { candidateProvider.listCandidates() }
+                    val candidateResult = runCatching { orchestrator.listCandidates() }
                     candidateResult
                         .onFailure { error ->
                             mutableUiState.update {
@@ -149,8 +125,18 @@ class BlockcheckViewModel
                                     )
                                 return@launch
                             }
-                            collectDiagnosis(domains, candidates)
-                            collectProbe(domains, candidates)
+                            orchestrator
+                                .run(domains, candidates)
+                                .catch { error ->
+                                    if (error is CancellationException) {
+                                        throw error
+                                    }
+                                    mutableUiState.update { state ->
+                                        state.copy(runState = BlockcheckRunState.Error, message = error.userMessage())
+                                    }
+                                }.collect { snapshot ->
+                                    mutableUiState.value = snapshot
+                                }
                         }
                 }
         }
@@ -177,125 +163,36 @@ class BlockcheckViewModel
 
         private fun applyStrategy(strategyId: String) {
             viewModelScope.launch {
-                val candidate = lastCandidates.firstOrNull { it.id == strategyId }
-                if (candidate == null) {
-                    mutableUiState.update { it.copy(messageRes = R.string.blockcheck_message_strategy_unregistered) }
-                    return@launch
-                }
-                appSettingsRepository.update {
-                    strategyChainYaml = candidate.toStrategyActivationYaml()
-                    candidate.configDsl?.let(::setRawStrategyChainDsl)
-                }
-                val reloadError =
-                    (strategyReloader ?: NativeBlockcheckStrategyReloader()).reloadConfig()
-                mutableUiState.update { state ->
-                    state.copy(
-                        message = reloadError,
-                        messageRes = if (reloadError == null) R.string.blockcheck_message_strategy_applied else null,
-                        runState = if (reloadError == null) state.runState else BlockcheckRunState.Error,
-                    )
+                when (val outcome = recommendationRepository.applyStrategy(strategyId, lastCandidates)) {
+                    BlockcheckApplyOutcome.Unregistered -> {
+                        mutableUiState.update {
+                            it.copy(messageRes = R.string.blockcheck_message_strategy_unregistered)
+                        }
+                    }
+
+                    BlockcheckApplyOutcome.Applied -> {
+                        mutableUiState.update { state ->
+                            state.copy(
+                                message = null,
+                                messageRes = R.string.blockcheck_message_strategy_applied,
+                            )
+                        }
+                    }
+
+                    is BlockcheckApplyOutcome.ReloadFailed -> {
+                        mutableUiState.update { state ->
+                            state.copy(
+                                message = outcome.message,
+                                messageRes = null,
+                                runState = BlockcheckRunState.Error,
+                            )
+                        }
+                    }
                 }
             }
         }
 
         fun exportReport(): String = encodeBlockcheckReport(uiState.value)
-
-        private suspend fun collectDiagnosis(
-            domains: List<String>,
-            candidates: List<StrategyProbeCandidate>,
-        ) {
-            val diagnosisDomains = domains.take(BlockcheckDiagnosisMaxDomains)
-            val diagnoses =
-                runCatching { diagnosisRunner.diagnose(diagnosisDomains) }
-                    .getOrElse { error ->
-                        if (error is CancellationException) {
-                            throw error
-                        }
-                        emptyList()
-                    }
-            mutableUiState.update { state ->
-                state.copy(
-                    domains = domains,
-                    diagnoses = diagnoses,
-                    recommendedStrategyId = diagnoses.recommendedCandidate(candidates)?.id,
-                    recommendedStrategyLabel = diagnoses.recommendedCandidate(candidates)?.label,
-                )
-            }
-        }
-
-        private suspend fun collectProbe(
-            domains: List<String>,
-            candidates: List<StrategyProbeCandidate>,
-        ) {
-            var collected = persistentListOf<StrategyProbeResult>()
-            val rankingAccumulator = StrategyProbeRankingAccumulator()
-            mutableUiState.value =
-                BlockcheckUiState(
-                    runState = BlockcheckRunState.Running,
-                    domains = domains,
-                    diagnoses = mutableUiState.value.diagnoses,
-                    recommendedStrategyId = mutableUiState.value.recommendedStrategyId,
-                    recommendedStrategyLabel = mutableUiState.value.recommendedStrategyLabel,
-                    totalExpectedResults = candidates.size * domains.size,
-                )
-            val config = StrategyProbeConfig(testDomains = domains, maxStrategies = candidates.size)
-            probeService
-                .run(config)
-                .catch { error ->
-                    if (error is CancellationException) {
-                        throw error
-                    }
-                    mutableUiState.update { state ->
-                        state.copy(runState = BlockcheckRunState.Error, message = error.userMessage())
-                    }
-                }.collect { result ->
-                    collected = collected.add(result)
-                    rankingAccumulator.add(result)
-                    mutableUiState.update { state ->
-                        state.copy(
-                            results = collected,
-                            rankedStrategies = rankingAccumulator.rankedStrategies(),
-                            recommendedStrategyId =
-                                state.diagnoses
-                                    .recommendedCandidate(
-                                        candidates = candidates,
-                                        rankedStrategies = rankingAccumulator.rankedStrategies(),
-                                    )?.id,
-                            recommendedStrategyLabel =
-                                state.diagnoses
-                                    .recommendedCandidate(
-                                        candidates = candidates,
-                                        rankedStrategies = rankingAccumulator.rankedStrategies(),
-                                    )?.label,
-                        )
-                    }
-                }
-            mutableUiState.update { state ->
-                val diagnoses =
-                    if (state.diagnoses.isEmpty()) {
-                        diagnoseFromStrategyResults(state.results)
-                    } else {
-                        state.diagnoses
-                    }
-                state.copy(
-                    runState = BlockcheckRunState.Complete,
-                    messageRes = R.string.blockcheck_message_probe_complete,
-                    diagnoses = diagnoses,
-                    recommendedStrategyId =
-                        diagnoses
-                            .recommendedCandidate(
-                                candidates = candidates,
-                                rankedStrategies = state.rankedStrategies,
-                            )?.id,
-                    recommendedStrategyLabel =
-                        diagnoses
-                            .recommendedCandidate(
-                                candidates = candidates,
-                                rankedStrategies = state.rankedStrategies,
-                            )?.label,
-                )
-            }
-        }
     }
 
 interface BlockcheckDiagnosisRunner {
@@ -331,196 +228,4 @@ class NativeBlockcheckStrategyReloader : BlockcheckStrategyReloader {
     override fun reloadConfig(): String? = runtime.reloadConfig()
 }
 
-private val BlockcheckReportJson = RipDpiPrettyDefaultsJson
-
-fun encodeBlockcheckReport(state: BlockcheckUiState): String {
-    val payload =
-        JsonObject(
-            mapOf(
-                "state" to JsonPrimitive(state.runState.name.lowercase()),
-                "domains" to JsonArray(state.domains.map(::JsonPrimitive)),
-                "diagnoses" to JsonArray(state.diagnoses.map(::encodeDiagnosis)),
-                "recommended_strategy_id" to JsonPrimitive(state.recommendedStrategyId),
-                "results" to JsonArray(state.results.map(::encodeProbeResult)),
-                "ranked_strategies" to JsonArray(state.rankedStrategies.map(::encodeRankedStrategy)),
-            ),
-        )
-    return BlockcheckReportJson.encodeToString(JsonObject.serializer(), payload)
-}
-
-private fun encodeDiagnosis(diagnosis: BlockcheckSiteDiagnosis): JsonObject =
-    JsonObject(
-        mapOf(
-            "domain" to JsonPrimitive(diagnosis.domain),
-            "layer" to
-                JsonPrimitive(
-                    diagnosis.diagnosis.layer.name
-                        .lowercase(),
-                ),
-            "bypass_class" to
-                JsonPrimitive(
-                    diagnosis.diagnosis.bypassClass.name
-                        .lowercase(),
-                ),
-            "confidence" to
-                JsonPrimitive(
-                    diagnosis.diagnosis.confidence.name
-                        .lowercase(),
-                ),
-            "reason_code" to JsonPrimitive(diagnosis.diagnosis.reasonCode),
-            "probe_verdict" to JsonPrimitive(diagnosis.probeVerdict),
-        ),
-    )
-
-private fun encodeProbeResult(result: StrategyProbeResult): JsonObject =
-    JsonObject(
-        mapOf(
-            "strategy_id" to JsonPrimitive(result.strategyId),
-            "strategy_label" to JsonPrimitive(result.strategyLabel),
-            "domain" to JsonPrimitive(result.domain),
-            "success" to JsonPrimitive(result.success),
-            "latency_ms" to JsonPrimitive(result.latencyMs),
-            "dns_tampered" to JsonPrimitive(result.dnsTampered),
-            "failure_kind" to JsonPrimitive(result.failureKind?.name),
-            "error" to JsonPrimitive(result.error),
-        ),
-    )
-
-private fun encodeRankedStrategy(result: RankedStrategyProbeResult): JsonObject =
-    JsonObject(
-        mapOf(
-            "strategy_id" to JsonPrimitive(result.strategyId),
-            "strategy_label" to JsonPrimitive(result.strategyLabel),
-            "total" to JsonPrimitive(result.total),
-            "successes" to JsonPrimitive(result.successes),
-            "success_rate" to JsonPrimitive(result.successRate),
-            "average_latency_ms" to JsonPrimitive(result.averageLatencyMs),
-            "dns_tampered_count" to JsonPrimitive(result.dnsTamperedCount),
-        ),
-    )
-
 private fun Throwable.userMessage(): String = localizedMessage ?: javaClass.simpleName
-
-private fun diagnoseReachability(result: DomainReachabilityResult): BlockcheckSiteDiagnosis? {
-    val diagnosis =
-        when (result.verdict) {
-            DomainVerdict.OK -> null
-
-            DomainVerdict.DNS_FAIL,
-            DomainVerdict.FAKE_IP,
-            -> BlockLayerDiagnosisMapper.fromDpiError(com.poyka.ripdpi.core.detection.dpi.DpiProbeError.DnsFail)
-
-            DomainVerdict.ISP_PAGE -> BlockLayerDiagnosisMapper.forHttpBlockpage()
-
-            DomainVerdict.TCP16_BAND,
-            DomainVerdict.TLS_VERSION_BLOCK,
-            -> BlockLayerDiagnosisMapper.forTlsVersionBlock()
-
-            DomainVerdict.BLOCKED,
-            DomainVerdict.UNREACHABLE,
-            -> result.firstProbeDiagnosis()
-        } ?: return null
-    return BlockcheckSiteDiagnosis(
-        domain = result.domain,
-        diagnosis = diagnosis,
-        probeVerdict = result.verdict.name,
-    )
-}
-
-private fun DomainReachabilityResult.firstProbeDiagnosis(): BlockLayerDiagnosis =
-    listOf(tls13, tls12, http)
-        .firstNotNullOfOrNull { attempt ->
-            BlockLayerDiagnosisMapper.fromDpiError(attempt.error)
-                ?: attempt.status.toDiagnosis()
-        } ?: BlockLayerDiagnosisMapper.forUnknownBlocked()
-
-private fun AttemptStatus.toDiagnosis(): BlockLayerDiagnosis? =
-    when (this) {
-        AttemptStatus.BLOCKED,
-        AttemptStatus.REDIR_SUSPICIOUS,
-        AttemptStatus.ISP_PAGE,
-        -> BlockLayerDiagnosisMapper.forHttpBlockpage()
-
-        AttemptStatus.TCP16_BAND_TIMEOUT -> BlockLayerDiagnosisMapper.forTlsVersionBlock()
-
-        AttemptStatus.OK,
-        AttemptStatus.REDIR_OK,
-        AttemptStatus.FAKE_IP,
-        AttemptStatus.ERROR,
-        -> null
-    }
-
-private fun diagnoseFromStrategyResults(results: List<StrategyProbeResult>): List<BlockcheckSiteDiagnosis> =
-    results
-        .asSequence()
-        .filter { result -> !result.success }
-        .groupBy(StrategyProbeResult::domain)
-        .mapNotNull { (domain, domainResults) ->
-            val diagnosis =
-                when {
-                    domainResults.any { it.dnsTampered || it.failureKind == StrategyProbeFailureKind.DnsTampered } -> {
-                        BlockLayerDiagnosisMapper.forDnsTampering()
-                    }
-
-                    domainResults.any { it.failureKind == StrategyProbeFailureKind.Timeout } -> {
-                        BlockLayerDiagnosis(
-                            layer = BlockLayer.IP_BLOCK,
-                            bypassClass = BypassStrategyClass.FAKE_PACKET_TTL,
-                            confidence = EvidenceConfidence.LOW,
-                            reasonCode = "strategy_probe_timeout",
-                        )
-                    }
-
-                    domainResults.any { it.failureKind == StrategyProbeFailureKind.ConnectionFailed } -> {
-                        BlockLayerDiagnosisMapper.forUnknownBlocked()
-                    }
-
-                    else -> {
-                        null
-                    }
-                } ?: return@mapNotNull null
-            BlockcheckSiteDiagnosis(domain = domain, diagnosis = diagnosis)
-        }
-
-private fun List<BlockcheckSiteDiagnosis>.recommendedCandidate(
-    candidates: List<StrategyProbeCandidate>,
-    rankedStrategies: List<RankedStrategyProbeResult> = emptyList(),
-): StrategyProbeCandidate? {
-    val recommendation = firstOrNull()?.diagnosis?.bypassClass ?: return rankedStrategies.bestCandidate(candidates)
-    return rankedStrategies
-        .mapNotNull { ranked -> candidates.firstOrNull { candidate -> candidate.id == ranked.strategyId } }
-        .firstOrNull { candidate -> candidate.matches(recommendation) }
-        ?: candidates.firstOrNull { candidate -> candidate.matches(recommendation) }
-        ?: rankedStrategies.bestCandidate(candidates)
-}
-
-private fun List<RankedStrategyProbeResult>.bestCandidate(
-    candidates: List<StrategyProbeCandidate>,
-): StrategyProbeCandidate? =
-    firstOrNull()?.strategyId?.let { strategyId -> candidates.firstOrNull { it.id == strategyId } }
-
-private fun StrategyProbeCandidate.matches(recommendation: BypassStrategyClass): Boolean {
-    val haystack = "$id $label ${configDsl.orEmpty()}".lowercase()
-    return when (recommendation) {
-        BypassStrategyClass.ENCRYPTED_DNS -> {
-            false
-        }
-
-        BypassStrategyClass.TLS_RECORD_SPLIT -> {
-            haystack.contains("tlsrec") || haystack.contains("split")
-        }
-
-        BypassStrategyClass.FAKE_PACKET_TTL -> {
-            haystack.contains("fake") || haystack.contains("oob") ||
-                haystack.contains("ttl")
-        }
-
-        BypassStrategyClass.HOST_HEADER_SPLIT -> {
-            haystack.contains("host") || haystack.contains("split_host")
-        }
-
-        BypassStrategyClass.STRATEGY_PROBE_WINNER -> {
-            true
-        }
-    }
-}

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionAuxStateOwner.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionAuxStateOwner.kt
@@ -1,0 +1,205 @@
+package com.poyka.ripdpi.ui.screens.detection
+
+import com.poyka.ripdpi.core.detection.DetectionCheckResult
+import com.poyka.ripdpi.core.detection.DetectionHistoryEntry
+import com.poyka.ripdpi.core.detection.DetectionHistoryRepository
+import com.poyka.ripdpi.core.detection.DetectionReportFormatter
+import com.poyka.ripdpi.core.detection.community.CommunityStatsRepository
+import com.poyka.ripdpi.core.detection.debug.DetectionDebugFormatter
+import com.poyka.ripdpi.core.detection.ui.DetectionColorVisionMode
+import com.poyka.ripdpi.data.AppSettingsRepository
+import com.poyka.ripdpi.data.NetworkFingerprintProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the non-run auxiliary state for the detection screen: observed detection settings, history,
+ * community stats, onboarding, and settings-write callbacks.
+ *
+ * Mutates the screen state exclusively through the shared [DetectionCheckStateReducer], on [scope]
+ * (the host VM's `viewModelScope`). The settings-write callbacks are exposed as the same
+ * `(T) -> Unit` properties the screen consumes via property access.
+ */
+internal class DetectionAuxStateOwner(
+    private val scope: CoroutineScope,
+    private val reducer: DetectionCheckStateReducer,
+    private val appSettingsRepository: AppSettingsRepository,
+    private val networkFingerprintProvider: NetworkFingerprintProvider,
+    private val historyStore: DetectionHistoryRepository,
+    private val communityStatsRepository: CommunityStatsRepository,
+    private val detectionCheckPreferences: DetectionCheckPreferenceStore,
+) {
+    fun observeDetectionSettings() {
+        scope.launch {
+            appSettingsRepository.settings.collect { settings ->
+                val privacyModeEnabled = settings.detectionCheckPrivacyModeEnabled
+                val debugModeEnabled = settings.detectionCheckDebugModeEnabled
+                val colorVisionMode =
+                    DetectionColorVisionMode.fromWire(settings.detectionCheckColorVisionMode)
+                reducer.mutate { state ->
+                    state.copy(
+                        privacyModeEnabled = privacyModeEnabled,
+                        cdnPullingEnabled = settings.detectionCheckCdnPullingEnabled,
+                        debugModeEnabled = debugModeEnabled,
+                        tlsKeylogPath = settings.detectionDiagnosticTlsKeylogPath,
+                        colorVisionMode = colorVisionMode,
+                        redGreenAltEnabled = settings.redGreenStatusAltEnabled,
+                        reportText =
+                            state.result?.let { result ->
+                                DetectionReportFormatter.format(
+                                    result = result,
+                                    privacyModeEnabled = privacyModeEnabled,
+                                )
+                            } ?: state.reportText,
+                        debugReportText =
+                            state.result
+                                ?.takeIf { debugModeEnabled }
+                                ?.let { result ->
+                                    DetectionDebugFormatter.format(
+                                        result = result,
+                                        settings = DetectionResultPresenter.debugSettings(settings),
+                                        privacyModeEnabled = privacyModeEnabled,
+                                    )
+                                },
+                    )
+                }
+            }
+        }
+    }
+
+    fun loadHistory() {
+        scope.launch {
+            val history = historyStore.loadLatest()
+            reducer.mutate { it.copy(history = history) }
+        }
+    }
+
+    fun loadCommunityState() {
+        scope.launch {
+            val stats = communityStatsRepository.loadCachedOrLocal()
+            if (stats != null) {
+                reducer.mutate { it.copy(communityStats = stats) }
+            }
+        }
+    }
+
+    fun refreshCommunityStats() {
+        scope.launch {
+            reducer.mutate { it.copy(communityStatsLoading = true, communityStatsError = null) }
+            try {
+                val refreshResult = communityStatsRepository.refresh()
+                val localStats = refreshResult.localStats
+                reducer.mutate { it.copy(communityStats = localStats) }
+
+                val remoteStats = refreshResult.remoteStats
+                if (remoteStats != null) {
+                    reducer.mutate { it.copy(communityStats = remoteStats) }
+                } else if (reducer.value.communityStats == null) {
+                    reducer.mutate {
+                        it.copy(communityStatsError = refreshResult.remoteError?.message)
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Exception,
+            ) {
+                // Defensive UI fallback: refresh chains may throw IOException (cache I/O,
+                // settings flow), JSON parsing errors, or runtime exceptions; surface any
+                // failure as an error state instead of crashing the VM.
+                if (reducer.value.communityStats == null) {
+                    reducer.mutate { it.copy(communityStatsError = e.message) }
+                }
+            } finally {
+                reducer.mutate { it.copy(communityStatsLoading = false) }
+            }
+        }
+    }
+
+    fun reloadCommunityStats() {
+        refreshCommunityStats()
+    }
+
+    fun dismissOnboarding() {
+        detectionCheckPreferences.markOnboardingShown()
+        reducer.mutate { it.copy(showOnboarding = false) }
+    }
+
+    fun applyAllFixes() {
+        scope.launch {
+            appSettingsRepository.update {
+                applyDetectionFixes(reducer.value.suggestedFixes)
+            }
+            reducer.mutate { it.copy(suggestedFixes = emptyList()) }
+        }
+    }
+
+    suspend fun saveToHistory(
+        result: DetectionCheckResult,
+        score: Int,
+    ) {
+        val entry =
+            DetectionHistoryEntry(
+                networkFingerprint = networkFingerprintProvider.capture()?.scopeKey() ?: "unknown",
+                networkSummary =
+                    networkFingerprintProvider.capture()?.summary()?.let {
+                        "${it.transport}/${it.identityKind}"
+                    } ?: result.geoIp.findings
+                        .firstOrNull { it.description.startsWith("ISP:") }
+                        ?.description
+                        ?.removePrefix("ISP: ") ?: "Unknown",
+                timestamp = System.currentTimeMillis(),
+                verdict = result.verdict.name,
+                stealthScore = score,
+                evidenceCount =
+                    result.geoIp.evidence.size +
+                        result.directSigns.evidence.size +
+                        result.indirectSigns.evidence.size +
+                        result.locationSignals.evidence.size +
+                        result.bypassResult.evidence.size,
+            )
+        historyStore.save(entry)
+        loadHistory()
+    }
+
+    val setPrivacyModeEnabled: (Boolean) -> Unit = { enabled ->
+        scope.launch {
+            appSettingsRepository.update {
+                detectionCheckPrivacyModeEnabled = enabled
+            }
+        }
+    }
+
+    val setCdnPullingEnabled: (Boolean) -> Unit = { enabled ->
+        scope.launch {
+            appSettingsRepository.update {
+                detectionCheckCdnPullingEnabled = enabled
+            }
+        }
+    }
+
+    val setDebugModeEnabled: (Boolean) -> Unit = { enabled ->
+        scope.launch {
+            appSettingsRepository.update {
+                detectionCheckDebugModeEnabled = enabled
+            }
+        }
+    }
+
+    val setColorVisionMode: (DetectionColorVisionMode) -> Unit = { mode ->
+        scope.launch {
+            appSettingsRepository.update {
+                detectionCheckColorVisionMode = mode.wireValue
+            }
+        }
+    }
+
+    val unlockProtanopiaVariant: () -> Unit = {
+        scope.launch {
+            appSettingsRepository.update {
+                enableRedGreenStatusAlt()
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionCheckPlatform.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionCheckPlatform.kt
@@ -16,14 +16,15 @@ class DetectionCheckPlatform
     @Inject
     constructor(
         @param:ApplicationContext private val context: Context,
-    ) {
-        val packageName: String
+    ) : DetectionPermissionChecker,
+        DetectionProbeRunner {
+        override val packageName: String
             get() = context.packageName
 
-        fun isPermissionGranted(permission: String): Boolean =
+        override fun isPermissionGranted(permission: String): Boolean =
             ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
 
-        suspend fun runDetectionCheck(
+        override suspend fun runDetectionCheck(
             runner: DetectionCheckRunner,
             config: DetectionRunnerConfig,
             onProgress: (DetectionProgress) -> Unit,

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionCheckPreferences.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionCheckPreferences.kt
@@ -10,19 +10,19 @@ class DetectionCheckPreferences
     @Inject
     constructor(
         @ApplicationContext context: Context,
-    ) {
+    ) : DetectionCheckPreferenceStore {
         private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
-        fun wasOnboardingShown(): Boolean = prefs.getBoolean(PREF_ONBOARDING_SHOWN, false)
+        override fun wasOnboardingShown(): Boolean = prefs.getBoolean(PREF_ONBOARDING_SHOWN, false)
 
-        fun markOnboardingShown() {
+        override fun markOnboardingShown() {
             prefs.edit().putBoolean(PREF_ONBOARDING_SHOWN, true).apply()
         }
 
-        fun wasPermissionRequested(permission: String): Boolean =
+        override fun wasPermissionRequested(permission: String): Boolean =
             prefs.getBoolean(permissionRequestedKey(permission), false)
 
-        fun markPermissionsRequested(permissions: Array<String>) {
+        override fun markPermissionsRequested(permissions: Array<String>) {
             val editor = prefs.edit()
             for (permission in permissions) {
                 editor.putBoolean(permissionRequestedKey(permission), true)

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionCheckStateReducer.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionCheckStateReducer.kt
@@ -1,0 +1,59 @@
+package com.poyka.ripdpi.ui.screens.detection
+
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Shared write seam over the single [MutableStateFlow] that backs the detection screen.
+ *
+ * Every collaborator (run coordinator, auxiliary-state owner, permission owner) mutates the
+ * **same** flow through this reducer so the StateFlow-only effect mechanism is preserved: writes
+ * happen via `state.value = reducer(state.value)` (never `update {}`), on `viewModelScope` only.
+ */
+internal class DetectionCheckStateReducer(
+    private val state: MutableStateFlow<DetectionCheckUiState>,
+) {
+    val value: DetectionCheckUiState
+        get() = state.value
+
+    fun mutate(reducer: (DetectionCheckUiState) -> DetectionCheckUiState) {
+        state.value = reducer(state.value)
+    }
+}
+
+/**
+ * Narrow seam over [DetectionCheckPlatform]'s permission probe so the permission owner is unit
+ * testable without Robolectric. [DetectionCheckPlatform] implements this in addition to its
+ * existing surface — purely additive, no behavior change.
+ */
+internal interface DetectionPermissionChecker {
+    fun isPermissionGranted(permission: String): Boolean
+}
+
+/**
+ * Narrow seam over [DetectionCheckPlatform]'s probe surface so the run coordinator is unit testable
+ * without a real Android [android.content.Context]. [DetectionCheckPlatform] implements this in
+ * addition to its existing surface — purely additive, no behavior change.
+ */
+internal interface DetectionProbeRunner {
+    val packageName: String
+
+    suspend fun runDetectionCheck(
+        runner: com.poyka.ripdpi.core.detection.DetectionCheckRunner,
+        config: com.poyka.ripdpi.core.detection.DetectionRunnerConfig,
+        onProgress: (com.poyka.ripdpi.core.detection.DetectionProgress) -> Unit,
+    ): com.poyka.ripdpi.core.detection.DetectionCheckResult
+}
+
+/**
+ * Narrow seam over [DetectionCheckPreferences] for the same reason. [DetectionCheckPreferences]
+ * implements this in addition to its existing surface — purely additive.
+ */
+internal interface DetectionCheckPreferenceStore {
+    fun wasOnboardingShown(): Boolean
+
+    fun markOnboardingShown()
+
+    fun wasPermissionRequested(permission: String): Boolean
+
+    fun markPermissionsRequested(permissions: Array<String>)
+}

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionCheckViewModel.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionCheckViewModel.kt
@@ -1,44 +1,25 @@
 package com.poyka.ripdpi.ui.screens.detection
 
-import android.Manifest
-import android.os.Build
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.poyka.ripdpi.R
-import com.poyka.ripdpi.core.detection.BypassPortRange
-import com.poyka.ripdpi.core.detection.BypassScanOptions
 import com.poyka.ripdpi.core.detection.DetectionCheckResult
 import com.poyka.ripdpi.core.detection.DetectionCheckRunner
 import com.poyka.ripdpi.core.detection.DetectionHistoryEntry
 import com.poyka.ripdpi.core.detection.DetectionHistoryRepository
 import com.poyka.ripdpi.core.detection.DetectionPermissionPlanner
 import com.poyka.ripdpi.core.detection.DetectionProgress
-import com.poyka.ripdpi.core.detection.DetectionRecommendations
-import com.poyka.ripdpi.core.detection.DetectionReportFormatter
-import com.poyka.ripdpi.core.detection.DetectionRunnerConfig
-import com.poyka.ripdpi.core.detection.MethodologyVersion
 import com.poyka.ripdpi.core.detection.Recommendation
-import com.poyka.ripdpi.core.detection.StealthScore
 import com.poyka.ripdpi.core.detection.VerdictNarrative
 import com.poyka.ripdpi.core.detection.community.CommunityStats
 import com.poyka.ripdpi.core.detection.community.CommunityStatsRepository
-import com.poyka.ripdpi.core.detection.debug.DetectionDebugFormatter
-import com.poyka.ripdpi.core.detection.debug.DetectionDebugSettings
 import com.poyka.ripdpi.core.detection.ui.DetectionColorVisionMode
 import com.poyka.ripdpi.data.AppSettingsRepository
-import com.poyka.ripdpi.detection.RoutingProtectionRecommendationStrings
 import com.poyka.ripdpi.platform.StringResolver
-import com.poyka.ripdpi.proto.AppSettings
 import com.poyka.ripdpi.services.RoutingProtectionCatalogService
-import com.poyka.ripdpi.services.RoutingProtectionCatalogSnapshot
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class DetectionCheckUiState(
@@ -75,436 +56,89 @@ data class DetectionCheckUiState(
 class DetectionCheckViewModel
     @Inject
     constructor(
-        private val appSettingsRepository: AppSettingsRepository,
-        private val networkFingerprintProvider: com.poyka.ripdpi.data.NetworkFingerprintProvider,
-        private val routingProtectionCatalogService: RoutingProtectionCatalogService,
-        private val detectionCheckRunner: DetectionCheckRunner,
-        private val historyStore: DetectionHistoryRepository,
-        private val communityStatsRepository: CommunityStatsRepository,
-        private val detectionCheckPreferences: DetectionCheckPreferences,
-        private val detectionCheckPlatform: DetectionCheckPlatform,
-        private val stringResolver: StringResolver,
+        appSettingsRepository: AppSettingsRepository,
+        networkFingerprintProvider: com.poyka.ripdpi.data.NetworkFingerprintProvider,
+        routingProtectionCatalogService: RoutingProtectionCatalogService,
+        detectionCheckRunner: DetectionCheckRunner,
+        historyStore: DetectionHistoryRepository,
+        communityStatsRepository: CommunityStatsRepository,
+        detectionCheckPreferences: DetectionCheckPreferences,
+        detectionCheckPlatform: DetectionCheckPlatform,
+        stringResolver: StringResolver,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(DetectionCheckUiState())
         val uiState: StateFlow<DetectionCheckUiState> = _uiState.asStateFlow()
 
-        private var runJob: Job? = null
+        private val reducer = DetectionCheckStateReducer(_uiState)
+
+        private val auxStateOwner =
+            DetectionAuxStateOwner(
+                scope = viewModelScope,
+                reducer = reducer,
+                appSettingsRepository = appSettingsRepository,
+                networkFingerprintProvider = networkFingerprintProvider,
+                historyStore = historyStore,
+                communityStatsRepository = communityStatsRepository,
+                detectionCheckPreferences = detectionCheckPreferences,
+            )
+
+        private val permissionStateOwner =
+            DetectionPermissionStateOwner(
+                reducer = reducer,
+                permissionChecker = detectionCheckPlatform,
+                preferences = detectionCheckPreferences,
+            )
+
+        private val runCoordinator =
+            DetectionRunCoordinator(
+                scope = viewModelScope,
+                reducer = reducer,
+                appSettingsRepository = appSettingsRepository,
+                detectionCheckRunner = detectionCheckRunner,
+                probeRunner = detectionCheckPlatform,
+                routingProtectionCatalogService = routingProtectionCatalogService,
+                stringResolver = stringResolver,
+                onSaveHistory = { result, score -> auxStateOwner.saveToHistory(result, score) },
+                onRefreshCommunity = { auxStateOwner.refreshCommunityStats() },
+            )
+
+        private val onboardingShown = detectionCheckPreferences.wasOnboardingShown()
 
         init {
-            checkInitialState()
-        }
-
-        private fun checkInitialState() {
-            if (!detectionCheckPreferences.wasOnboardingShown()) {
-                _uiState.value = _uiState.value.copy(showOnboarding = true)
+            if (!onboardingShown) {
+                reducer.mutate { it.copy(showOnboarding = true) }
             }
-            refreshPermissionState()
-            observeDetectionSettings()
-            loadHistory()
-            loadCommunityState()
+            permissionStateOwner.refreshPermissionState()
+            auxStateOwner.observeDetectionSettings()
+            auxStateOwner.loadHistory()
+            auxStateOwner.loadCommunityState()
         }
 
-        private fun observeDetectionSettings() {
-            viewModelScope.launch {
-                appSettingsRepository.settings.collect { settings ->
-                    val privacyModeEnabled = settings.detectionCheckPrivacyModeEnabled
-                    val debugModeEnabled = settings.detectionCheckDebugModeEnabled
-                    val colorVisionMode =
-                        DetectionColorVisionMode.fromWire(settings.detectionCheckColorVisionMode)
-                    _uiState.value =
-                        _uiState.value.copy(
-                            privacyModeEnabled = privacyModeEnabled,
-                            cdnPullingEnabled = settings.detectionCheckCdnPullingEnabled,
-                            debugModeEnabled = debugModeEnabled,
-                            tlsKeylogPath = settings.detectionDiagnosticTlsKeylogPath,
-                            colorVisionMode = colorVisionMode,
-                            redGreenAltEnabled = settings.redGreenStatusAltEnabled,
-                            reportText =
-                                _uiState.value.result?.let { result ->
-                                    DetectionReportFormatter.format(
-                                        result = result,
-                                        privacyModeEnabled = privacyModeEnabled,
-                                    )
-                                } ?: _uiState.value.reportText,
-                            debugReportText =
-                                _uiState.value.result
-                                    ?.takeIf { debugModeEnabled }
-                                    ?.let { result ->
-                                        DetectionDebugFormatter.format(
-                                            result = result,
-                                            settings = settings.toDetectionDebugSettings(),
-                                            privacyModeEnabled = privacyModeEnabled,
-                                        )
-                                    },
-                        )
-                }
-            }
-        }
+        fun startCheck() = runCoordinator.startCheck()
 
-        private fun loadHistory() {
-            viewModelScope.launch {
-                _uiState.value =
-                    _uiState.value.copy(
-                        history = historyStore.loadLatest(),
-                    )
-            }
-        }
+        fun stopCheck() = runCoordinator.stopCheck()
 
-        private fun loadCommunityState() {
-            viewModelScope.launch {
-                val stats = communityStatsRepository.loadCachedOrLocal()
-                if (stats != null) {
-                    _uiState.value = _uiState.value.copy(communityStats = stats)
-                }
-            }
-        }
+        fun reloadCommunityStats() = auxStateOwner.reloadCommunityStats()
 
-        private fun refreshCommunityStats() {
-            viewModelScope.launch {
-                _uiState.value =
-                    _uiState.value.copy(communityStatsLoading = true, communityStatsError = null)
-                try {
-                    val refreshResult = communityStatsRepository.refresh()
-                    val localStats = refreshResult.localStats
-                    _uiState.value = _uiState.value.copy(communityStats = localStats)
+        fun dismissOnboarding() = auxStateOwner.dismissOnboarding()
 
-                    val remoteStats = refreshResult.remoteStats
-                    if (remoteStats != null) {
-                        _uiState.value = _uiState.value.copy(communityStats = remoteStats)
-                    } else if (_uiState.value.communityStats == null) {
-                        _uiState.value =
-                            _uiState.value.copy(
-                                communityStatsError = refreshResult.remoteError?.message,
-                            )
-                    }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (
-                    @Suppress("TooGenericExceptionCaught") e: Exception,
-                ) {
-                    // Defensive UI fallback: refresh chains may throw IOException (cache I/O,
-                    // settings flow), JSON parsing errors, or runtime exceptions; surface any
-                    // failure as an error state instead of crashing the VM.
-                    if (_uiState.value.communityStats == null) {
-                        _uiState.value =
-                            _uiState.value.copy(communityStatsError = e.message)
-                    }
-                } finally {
-                    _uiState.value = _uiState.value.copy(communityStatsLoading = false)
-                }
-            }
-        }
+        fun applyAllFixes() = auxStateOwner.applyAllFixes()
 
-        fun reloadCommunityStats() {
-            refreshCommunityStats()
-        }
+        fun onPermissionsResult() = permissionStateOwner.onPermissionsResult()
 
-        fun dismissOnboarding() {
-            detectionCheckPreferences.markOnboardingShown()
-            _uiState.value = _uiState.value.copy(showOnboarding = false)
-        }
+        fun refreshPermissionState() = permissionStateOwner.refreshPermissionState()
 
-        fun onPermissionsResult() {
-            markPermissionsRequested()
-            refreshPermissionState()
-        }
+        val setPrivacyModeEnabled: (Boolean) -> Unit = auxStateOwner.setPrivacyModeEnabled
 
-        fun refreshPermissionState() {
-            val states =
-                requiredPermissions().map { permission ->
-                    DetectionPermissionPlanner.PermissionState(
-                        permission = permission,
-                        granted = detectionCheckPlatform.isPermissionGranted(permission),
-                        shouldShowRationale = false,
-                        wasRequestedBefore = detectionCheckPreferences.wasPermissionRequested(permission),
-                    )
-                }
-            val action = DetectionPermissionPlanner.decideAction(states)
-            val missing = DetectionPermissionPlanner.missingPermissions(states)
-            _uiState.value =
-                _uiState.value.copy(
-                    permissionAction = action,
-                    missingPermissions = missing,
-                )
-        }
+        val setCdnPullingEnabled: (Boolean) -> Unit = auxStateOwner.setCdnPullingEnabled
 
-        fun startCheck() {
-            if (_uiState.value.isRunning) return
-            runJob =
-                viewModelScope.launch {
-                    _uiState.value = _uiState.value.resetForCheckRun()
-                    val outcome =
-                        runCatching {
-                            val settings = appSettingsRepository.settings.first()
-                            val config = settings.toDetectionRunnerConfig(detectionCheckPlatform.packageName)
-                            val result =
-                                detectionCheckPlatform.runDetectionCheck(
-                                    runner = detectionCheckRunner,
-                                    config = config,
-                                    onProgress = { progress ->
-                                        _uiState.value = _uiState.value.copy(progress = progress)
-                                    },
-                                )
+        val setDebugModeEnabled: (Boolean) -> Unit = auxStateOwner.setDebugModeEnabled
 
-                            val score = StealthScore.compute(result)
-                            val label = StealthScore.label(score)
-                            val recommendations =
-                                buildAllRecommendations(
-                                    result = result,
-                                    settings = settings,
-                                    snapshot = routingProtectionCatalogService.snapshot(),
-                                    stringResolver = stringResolver,
-                                )
-                            val privacyModeEnabled = settings.detectionCheckPrivacyModeEnabled
-                            val reportText =
-                                DetectionReportFormatter.format(
-                                    result = result,
-                                    privacyModeEnabled = privacyModeEnabled,
-                                )
-                            val debugReportText =
-                                result
-                                    .takeIf { settings.detectionCheckDebugModeEnabled }
-                                    ?.let {
-                                        DetectionDebugFormatter.format(
-                                            result = it,
-                                            settings = settings.toDetectionDebugSettings(),
-                                            privacyModeEnabled = privacyModeEnabled,
-                                        )
-                                    }
-                            val fixes = settings.suggestDetectionFixes(result)
+        val setColorVisionMode: (DetectionColorVisionMode) -> Unit = auxStateOwner.setColorVisionMode
 
-                            saveToHistory(result, score)
-                            refreshCommunityStats()
-
-                            _uiState.value =
-                                _uiState.value.withCheckResult(
-                                    result = result,
-                                    score = score,
-                                    label = label,
-                                    recommendations = recommendations,
-                                    fixes = fixes,
-                                    reportText = reportText,
-                                    debugReportText = debugReportText,
-                                )
-                        }
-
-                    outcome.onFailure { error ->
-                        if (error is CancellationException) {
-                            throw error
-                        }
-                        _uiState.value =
-                            _uiState.value.copy(
-                                isRunning = false,
-                                progress = null,
-                                error = error.message ?: stringResolver.getString(R.string.detection_error_unknown),
-                            )
-                    }
-                }
-        }
-
-        private fun DetectionCheckUiState.resetForCheckRun(): DetectionCheckUiState =
-            copy(
-                isRunning = true,
-                progress = null,
-                result = null,
-                narrative = null,
-                stealthScore = null,
-                stealthLabel = null,
-                recommendations = emptyList(),
-                suggestedFixes = emptyList(),
-                reportText = null,
-                debugReportText = null,
-                error = null,
-            )
-
-        private fun DetectionCheckUiState.withCheckResult(
-            result: DetectionCheckResult,
-            score: Int,
-            label: String,
-            recommendations: List<Recommendation>,
-            fixes: List<DetectionSuggestedFix>,
-            reportText: String,
-            debugReportText: String?,
-        ): DetectionCheckUiState =
-            copy(
-                isRunning = false,
-                progress = null,
-                result = result,
-                narrative = result.verdictNarrative,
-                stealthScore = score,
-                stealthLabel = label,
-                recommendations = recommendations,
-                suggestedFixes = fixes,
-                reportText = reportText,
-                debugReportText = debugReportText,
-            )
-
-        private fun AppSettings.toDetectionRunnerConfig(packageName: String): DetectionRunnerConfig =
-            DetectionRunnerConfig(
-                ownProxyPort = proxyPort.takeIf { it > 0 },
-                ownPackageName = packageName,
-                includeBypassCheck = detectionCheckIncludeBypass,
-                includeLocationCheck = detectionCheckIncludeLocation,
-                includeRttTriangulationCheck =
-                    detectionCheckNetworkRequestsEnabled && detectionCheckRttTriangulationEnabled,
-                includeCdnPullingCheck =
-                    detectionCheckNetworkRequestsEnabled && detectionCheckCdnPullingEnabled,
-                includeCallTransportCheck =
-                    detectionCheckNetworkRequestsEnabled && detectionCheckCallTransportProbeEnabled,
-                bypassScanOptions =
-                    BypassScanOptions(
-                        proxyScanEnabled = detectionCheckIncludeBypass,
-                        xrayApiScanEnabled = detectionCheckXrayApiScanEnabled,
-                        callTransportProbeEnabled = false,
-                        portRange = toBypassPortRange(),
-                    ),
-                resolverConfig = toDetectionResolverConfig(),
-                encryptedDnsEnabled = dnsMode == "encrypted" || detectionCheckDnsResolverMode == "doh",
-                webRtcProtectionEnabled = webrtcProtectionEnabled,
-                tlsFingerprintProfile = tlsFingerprintProfile.ifEmpty { "chrome_stable" },
-            )
-
-        private fun AppSettings.toDetectionDebugSettings(): DetectionDebugSettings =
-            DetectionDebugSettings(
-                cdnPullingEnabled = detectionCheckCdnPullingEnabled,
-                dnsResolverMode = detectionCheckDnsResolverMode.ifEmpty { dnsMode },
-                portRange = detectionCheckPortRangeMode.ifEmpty { "popular" },
-                debugModeEnabled = detectionCheckDebugModeEnabled,
-            )
-
-        private fun AppSettings.toBypassPortRange(): BypassPortRange =
-            when (DetectionPortRangeMode.fromWire(detectionCheckPortRangeMode)) {
-                DetectionPortRangeMode.POPULAR -> {
-                    BypassPortRange.Popular
-                }
-
-                DetectionPortRangeMode.EXTENDED -> {
-                    BypassPortRange.Extended
-                }
-
-                DetectionPortRangeMode.FULL -> {
-                    BypassPortRange.Full
-                }
-
-                DetectionPortRangeMode.CUSTOM -> {
-                    BypassPortRange.Custom(
-                        start = detectionCheckCustomPortStart.takeIf { it > 0 } ?: 1080,
-                        end = detectionCheckCustomPortEnd.takeIf { it > 0 } ?: 1090,
-                    )
-                }
-            }
-
-        fun applyAllFixes() {
-            viewModelScope.launch {
-                appSettingsRepository.update {
-                    applyDetectionFixes(_uiState.value.suggestedFixes)
-                }
-                _uiState.value = _uiState.value.copy(suggestedFixes = emptyList())
-            }
-        }
-
-        val setPrivacyModeEnabled: (Boolean) -> Unit = { enabled ->
-            viewModelScope.launch {
-                appSettingsRepository.update {
-                    detectionCheckPrivacyModeEnabled = enabled
-                }
-            }
-        }
-
-        val setCdnPullingEnabled: (Boolean) -> Unit = { enabled ->
-            viewModelScope.launch {
-                appSettingsRepository.update {
-                    detectionCheckCdnPullingEnabled = enabled
-                }
-            }
-        }
-
-        val setDebugModeEnabled: (Boolean) -> Unit = { enabled ->
-            viewModelScope.launch {
-                appSettingsRepository.update {
-                    detectionCheckDebugModeEnabled = enabled
-                }
-            }
-        }
-
-        val setColorVisionMode: (DetectionColorVisionMode) -> Unit = { mode ->
-            viewModelScope.launch {
-                appSettingsRepository.update {
-                    detectionCheckColorVisionMode = mode.wireValue
-                }
-            }
-        }
-
-        val unlockProtanopiaVariant: () -> Unit = {
-            viewModelScope.launch {
-                appSettingsRepository.update {
-                    enableRedGreenStatusAlt()
-                }
-            }
-        }
-
-        fun stopCheck() {
-            runJob?.cancel()
-            runJob = null
-            _uiState.value = _uiState.value.copy(isRunning = false, progress = null)
-        }
-
-        private suspend fun saveToHistory(
-            result: DetectionCheckResult,
-            score: Int,
-        ) {
-            val entry =
-                DetectionHistoryEntry(
-                    networkFingerprint = networkFingerprintProvider.capture()?.scopeKey() ?: "unknown",
-                    networkSummary =
-                        networkFingerprintProvider.capture()?.summary()?.let {
-                            "${it.transport}/${it.identityKind}"
-                        } ?: result.geoIp.findings
-                            .firstOrNull { it.description.startsWith("ISP:") }
-                            ?.description
-                            ?.removePrefix("ISP: ") ?: "Unknown",
-                    timestamp = System.currentTimeMillis(),
-                    verdict = result.verdict.name,
-                    stealthScore = score,
-                    evidenceCount =
-                        result.geoIp.evidence.size +
-                            result.directSigns.evidence.size +
-                            result.indirectSigns.evidence.size +
-                            result.locationSignals.evidence.size +
-                            result.bypassResult.evidence.size,
-                )
-            historyStore.save(entry)
-            loadHistory()
-        }
-
-        private fun markPermissionsRequested() {
-            detectionCheckPreferences.markPermissionsRequested(requiredPermissions())
-        }
+        val unlockProtanopiaVariant: () -> Unit = auxStateOwner.unlockProtanopiaVariant
 
         companion object {
-            fun requiredPermissions(): Array<String> =
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    arrayOf(
-                        Manifest.permission.READ_PHONE_STATE,
-                        Manifest.permission.ACCESS_FINE_LOCATION,
-                        Manifest.permission.NEARBY_WIFI_DEVICES,
-                    )
-                } else {
-                    arrayOf(Manifest.permission.READ_PHONE_STATE, Manifest.permission.ACCESS_FINE_LOCATION)
-                }
+            fun requiredPermissions(): Array<String> = DetectionPermissionStateOwner.requiredPermissions()
         }
     }
-
-private fun buildAllRecommendations(
-    result: DetectionCheckResult,
-    settings: AppSettings,
-    snapshot: RoutingProtectionCatalogSnapshot,
-    stringResolver: StringResolver,
-): List<Recommendation> =
-    DetectionRecommendations.generate(result) +
-        buildRoutingProtectionRecommendations(
-            result = result,
-            settings = settings,
-            snapshot = snapshot,
-            strings = RoutingProtectionRecommendationStrings.resolve(stringResolver),
-        )

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionPermissionStateOwner.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionPermissionStateOwner.kt
@@ -1,0 +1,60 @@
+package com.poyka.ripdpi.ui.screens.detection
+
+import android.Manifest
+import android.os.Build
+import com.poyka.ripdpi.core.detection.DetectionPermissionPlanner
+
+/**
+ * Owns the permission-state slice of the detection screen: probing the required permissions and
+ * deciding the planner action / missing list, plus recording a permission-request round.
+ *
+ * Mutates the screen state exclusively through the shared [DetectionCheckStateReducer]. Permission
+ * probing is synchronous (no coroutine), matching the original VM.
+ */
+internal class DetectionPermissionStateOwner(
+    private val reducer: DetectionCheckStateReducer,
+    private val permissionChecker: DetectionPermissionChecker,
+    private val preferences: DetectionCheckPreferenceStore,
+) {
+    fun onPermissionsResult() {
+        markPermissionsRequested()
+        refreshPermissionState()
+    }
+
+    fun refreshPermissionState() {
+        val states =
+            requiredPermissions().map { permission ->
+                DetectionPermissionPlanner.PermissionState(
+                    permission = permission,
+                    granted = permissionChecker.isPermissionGranted(permission),
+                    shouldShowRationale = false,
+                    wasRequestedBefore = preferences.wasPermissionRequested(permission),
+                )
+            }
+        val action = DetectionPermissionPlanner.decideAction(states)
+        val missing = DetectionPermissionPlanner.missingPermissions(states)
+        reducer.mutate {
+            it.copy(
+                permissionAction = action,
+                missingPermissions = missing,
+            )
+        }
+    }
+
+    private fun markPermissionsRequested() {
+        preferences.markPermissionsRequested(requiredPermissions())
+    }
+
+    companion object {
+        fun requiredPermissions(): Array<String> =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                arrayOf(
+                    Manifest.permission.READ_PHONE_STATE,
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.NEARBY_WIFI_DEVICES,
+                )
+            } else {
+                arrayOf(Manifest.permission.READ_PHONE_STATE, Manifest.permission.ACCESS_FINE_LOCATION)
+            }
+    }
+}

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionResultPresenter.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionResultPresenter.kt
@@ -1,0 +1,130 @@
+package com.poyka.ripdpi.ui.screens.detection
+
+import com.poyka.ripdpi.core.detection.BypassPortRange
+import com.poyka.ripdpi.core.detection.BypassScanOptions
+import com.poyka.ripdpi.core.detection.DetectionCheckResult
+import com.poyka.ripdpi.core.detection.DetectionRecommendations
+import com.poyka.ripdpi.core.detection.DetectionReportFormatter
+import com.poyka.ripdpi.core.detection.DetectionRunnerConfig
+import com.poyka.ripdpi.core.detection.Recommendation
+import com.poyka.ripdpi.core.detection.debug.DetectionDebugFormatter
+import com.poyka.ripdpi.core.detection.debug.DetectionDebugSettings
+import com.poyka.ripdpi.detection.RoutingProtectionRecommendationStrings
+import com.poyka.ripdpi.platform.StringResolver
+import com.poyka.ripdpi.proto.AppSettings
+import com.poyka.ripdpi.services.RoutingProtectionCatalogSnapshot
+
+/**
+ * Pure, stateless mapping from a [DetectionCheckResult] (+ the [AppSettings] snapshot and the
+ * routing-protection catalog) to the presentation artifacts the UI renders: runner/debug config,
+ * report text, debug report text, recommendations and suggested fixes.
+ *
+ * No dependencies; [StringResolver] is passed per-call. Behavior is byte-identical to the original
+ * inline VM logic.
+ */
+internal object DetectionResultPresenter {
+    fun runnerConfig(
+        settings: AppSettings,
+        packageName: String,
+    ): DetectionRunnerConfig = settings.toDetectionRunnerConfig(packageName)
+
+    fun debugSettings(settings: AppSettings): DetectionDebugSettings = settings.toDetectionDebugSettings()
+
+    fun reportText(
+        result: DetectionCheckResult,
+        privacyModeEnabled: Boolean,
+    ): String =
+        DetectionReportFormatter.format(
+            result = result,
+            privacyModeEnabled = privacyModeEnabled,
+        )
+
+    fun debugReportText(
+        result: DetectionCheckResult,
+        settings: AppSettings,
+        privacyModeEnabled: Boolean,
+    ): String? =
+        result
+            .takeIf { settings.detectionCheckDebugModeEnabled }
+            ?.let {
+                DetectionDebugFormatter.format(
+                    result = it,
+                    settings = settings.toDetectionDebugSettings(),
+                    privacyModeEnabled = privacyModeEnabled,
+                )
+            }
+
+    fun recommendations(
+        result: DetectionCheckResult,
+        settings: AppSettings,
+        snapshot: RoutingProtectionCatalogSnapshot,
+        stringResolver: StringResolver,
+    ): List<Recommendation> =
+        DetectionRecommendations.generate(result) +
+            buildRoutingProtectionRecommendations(
+                result = result,
+                settings = settings,
+                snapshot = snapshot,
+                strings = RoutingProtectionRecommendationStrings.resolve(stringResolver),
+            )
+
+    fun suggestedFixes(
+        settings: AppSettings,
+        result: DetectionCheckResult,
+    ): List<DetectionSuggestedFix> = settings.suggestDetectionFixes(result)
+}
+
+private fun AppSettings.toDetectionRunnerConfig(packageName: String): DetectionRunnerConfig =
+    DetectionRunnerConfig(
+        ownProxyPort = proxyPort.takeIf { it > 0 },
+        ownPackageName = packageName,
+        includeBypassCheck = detectionCheckIncludeBypass,
+        includeLocationCheck = detectionCheckIncludeLocation,
+        includeRttTriangulationCheck =
+            detectionCheckNetworkRequestsEnabled && detectionCheckRttTriangulationEnabled,
+        includeCdnPullingCheck =
+            detectionCheckNetworkRequestsEnabled && detectionCheckCdnPullingEnabled,
+        includeCallTransportCheck =
+            detectionCheckNetworkRequestsEnabled && detectionCheckCallTransportProbeEnabled,
+        bypassScanOptions =
+            BypassScanOptions(
+                proxyScanEnabled = detectionCheckIncludeBypass,
+                xrayApiScanEnabled = detectionCheckXrayApiScanEnabled,
+                callTransportProbeEnabled = false,
+                portRange = toBypassPortRange(),
+            ),
+        resolverConfig = toDetectionResolverConfig(),
+        encryptedDnsEnabled = dnsMode == "encrypted" || detectionCheckDnsResolverMode == "doh",
+        webRtcProtectionEnabled = webrtcProtectionEnabled,
+        tlsFingerprintProfile = tlsFingerprintProfile.ifEmpty { "chrome_stable" },
+    )
+
+private fun AppSettings.toDetectionDebugSettings(): DetectionDebugSettings =
+    DetectionDebugSettings(
+        cdnPullingEnabled = detectionCheckCdnPullingEnabled,
+        dnsResolverMode = detectionCheckDnsResolverMode.ifEmpty { dnsMode },
+        portRange = detectionCheckPortRangeMode.ifEmpty { "popular" },
+        debugModeEnabled = detectionCheckDebugModeEnabled,
+    )
+
+private fun AppSettings.toBypassPortRange(): BypassPortRange =
+    when (DetectionPortRangeMode.fromWire(detectionCheckPortRangeMode)) {
+        DetectionPortRangeMode.POPULAR -> {
+            BypassPortRange.Popular
+        }
+
+        DetectionPortRangeMode.EXTENDED -> {
+            BypassPortRange.Extended
+        }
+
+        DetectionPortRangeMode.FULL -> {
+            BypassPortRange.Full
+        }
+
+        DetectionPortRangeMode.CUSTOM -> {
+            BypassPortRange.Custom(
+                start = detectionCheckCustomPortStart.takeIf { it > 0 } ?: 1080,
+                end = detectionCheckCustomPortEnd.takeIf { it > 0 } ?: 1090,
+            )
+        }
+    }

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionRunCoordinator.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionRunCoordinator.kt
@@ -1,0 +1,146 @@
+package com.poyka.ripdpi.ui.screens.detection
+
+import com.poyka.ripdpi.R
+import com.poyka.ripdpi.core.detection.DetectionCheckResult
+import com.poyka.ripdpi.core.detection.DetectionCheckRunner
+import com.poyka.ripdpi.core.detection.Recommendation
+import com.poyka.ripdpi.core.detection.StealthScore
+import com.poyka.ripdpi.data.AppSettingsRepository
+import com.poyka.ripdpi.platform.StringResolver
+import com.poyka.ripdpi.services.RoutingProtectionCatalogService
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the cancellable probe-run lifecycle for the detection screen: reset -> probe (progress) ->
+ * score/label -> recommendations -> report/debug-report -> suggested fixes -> save history ->
+ * community refresh -> terminal result, plus error/cancellation handling and [stopCheck].
+ *
+ * Mutates the screen state exclusively through the shared [DetectionCheckStateReducer], on [scope]
+ * (the host VM's `viewModelScope`). Side effects that belong to the auxiliary owner (history save,
+ * community refresh) are delegated via [onSaveHistory] / [onRefreshCommunity] so they run inside the
+ * run BEFORE the terminal emission, preserving the original ordering.
+ */
+internal class DetectionRunCoordinator(
+    private val scope: CoroutineScope,
+    private val reducer: DetectionCheckStateReducer,
+    private val appSettingsRepository: AppSettingsRepository,
+    private val detectionCheckRunner: DetectionCheckRunner,
+    private val probeRunner: DetectionProbeRunner,
+    private val routingProtectionCatalogService: RoutingProtectionCatalogService,
+    private val stringResolver: StringResolver,
+    private val onSaveHistory: suspend (DetectionCheckResult, Int) -> Unit,
+    private val onRefreshCommunity: () -> Unit,
+) {
+    private var runJob: Job? = null
+
+    fun startCheck() {
+        if (reducer.value.isRunning) return
+        runJob =
+            scope.launch {
+                reducer.mutate { it.resetForCheckRun() }
+                val outcome = runCatching { runOnce() }
+
+                outcome.onFailure { error ->
+                    if (error is CancellationException) {
+                        throw error
+                    }
+                    reducer.mutate {
+                        it.copy(
+                            isRunning = false,
+                            progress = null,
+                            error = error.message ?: stringResolver.getString(R.string.detection_error_unknown),
+                        )
+                    }
+                }
+            }
+    }
+
+    fun stopCheck() {
+        runJob?.cancel()
+        runJob = null
+        reducer.mutate { it.copy(isRunning = false, progress = null) }
+    }
+
+    private suspend fun runOnce() {
+        val settings = appSettingsRepository.settings.first()
+        val config = DetectionResultPresenter.runnerConfig(settings, probeRunner.packageName)
+        val result =
+            probeRunner.runDetectionCheck(
+                runner = detectionCheckRunner,
+                config = config,
+                onProgress = { progress ->
+                    reducer.mutate { it.copy(progress = progress) }
+                },
+            )
+
+        val score = StealthScore.compute(result)
+        val label = StealthScore.label(score)
+        val recommendations =
+            DetectionResultPresenter.recommendations(
+                result = result,
+                settings = settings,
+                snapshot = routingProtectionCatalogService.snapshot(),
+                stringResolver = stringResolver,
+            )
+        val privacyModeEnabled = settings.detectionCheckPrivacyModeEnabled
+        val reportText = DetectionResultPresenter.reportText(result, privacyModeEnabled)
+        val debugReportText = DetectionResultPresenter.debugReportText(result, settings, privacyModeEnabled)
+        val fixes = DetectionResultPresenter.suggestedFixes(settings, result)
+
+        onSaveHistory(result, score)
+        onRefreshCommunity()
+
+        reducer.mutate {
+            it.withCheckResult(
+                result = result,
+                score = score,
+                label = label,
+                recommendations = recommendations,
+                fixes = fixes,
+                reportText = reportText,
+                debugReportText = debugReportText,
+            )
+        }
+    }
+
+    private fun DetectionCheckUiState.resetForCheckRun(): DetectionCheckUiState =
+        copy(
+            isRunning = true,
+            progress = null,
+            result = null,
+            narrative = null,
+            stealthScore = null,
+            stealthLabel = null,
+            recommendations = emptyList(),
+            suggestedFixes = emptyList(),
+            reportText = null,
+            debugReportText = null,
+            error = null,
+        )
+
+    private fun DetectionCheckUiState.withCheckResult(
+        result: DetectionCheckResult,
+        score: Int,
+        label: String,
+        recommendations: List<Recommendation>,
+        fixes: List<DetectionSuggestedFix>,
+        reportText: String,
+        debugReportText: String?,
+    ): DetectionCheckUiState =
+        copy(
+            isRunning = false,
+            progress = null,
+            result = result,
+            narrative = result.verdictNarrative,
+            stealthScore = score,
+            stealthLabel = label,
+            recommendations = recommendations,
+            suggestedFixes = fixes,
+            reportText = reportText,
+            debugReportText = debugReportText,
+        )
+}

--- a/app/src/test/kotlin/com/poyka/ripdpi/backup/BackupExportCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/backup/BackupExportCoordinatorTest.kt
@@ -1,0 +1,345 @@
+package com.poyka.ripdpi.backup
+
+import com.poyka.ripdpi.data.AppSettingsRepository
+import com.poyka.ripdpi.data.ProxyGroup
+import com.poyka.ripdpi.data.ProxyGroupRepository
+import com.poyka.ripdpi.data.backup.BackupExportUseCase
+import com.poyka.ripdpi.data.backup.BackupProfileProvider
+import com.poyka.ripdpi.data.backup.BackupVariant
+import com.poyka.ripdpi.data.rules.OutboundTag
+import com.poyka.ripdpi.data.rules.RuleDao
+import com.poyka.ripdpi.data.rules.RuleEntity
+import com.poyka.ripdpi.proto.AppSettings
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.OutputStream
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BackupExportCoordinatorTest {
+    // -- export() -------------------------------------------------------------
+
+    @Test
+    fun `export is a no-op when already exporting`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+            h.state.update { it.copy(exporting = true) }
+            var opened = false
+
+            h.coordinator.export(BackupVariant.FULL, openOutput = {
+                opened = true
+                null
+            }, onWriteFailed = {})
+            testScheduler.advanceUntilIdle()
+
+            assertFalse(opened)
+            assertTrue(h.exportEffects.isEmpty())
+        }
+
+    @Test
+    fun `export is a no-op when disabled by policy`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness(policyDisabled = true)
+            var opened = false
+
+            h.coordinator.export(BackupVariant.FULL, openOutput = {
+                opened = true
+                null
+            }, onWriteFailed = {})
+            testScheduler.advanceUntilIdle()
+
+            assertFalse(opened)
+            assertTrue(h.exportEffects.isEmpty())
+        }
+
+    @Test
+    fun `export with null output flips exporting and emits exactly one Cancelled`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+
+            h.coordinator.export(BackupVariant.FULL, openOutput = { null }, onWriteFailed = {})
+            assertTrue(h.state.value.exporting)
+            testScheduler.advanceUntilIdle()
+
+            assertFalse(h.state.value.exporting)
+            assertEquals(listOf(BackupExportEffect.Cancelled), h.exportEffects)
+        }
+
+    @Test
+    fun `export SHARE success emits Success with offerShare true and closes stream`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+            val stream = CloseTrackingStream()
+
+            h.coordinator.export(BackupVariant.SHARE, openOutput = { stream }, onWriteFailed = {})
+            testScheduler.advanceUntilIdle()
+
+            val effect = h.exportEffects.single() as BackupExportEffect.Success
+            assertEquals(BackupVariant.SHARE, effect.variant)
+            assertTrue(effect.offerShare)
+            assertTrue(effect.byteCount > 0)
+            assertTrue(stream.closed)
+            assertFalse(h.state.value.exporting)
+        }
+
+    @Test
+    fun `export FULL success emits Success with offerShare false`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+
+            h.coordinator.export(BackupVariant.FULL, openOutput = { ByteArrayOutputStream() }, onWriteFailed = {})
+            testScheduler.advanceUntilIdle()
+
+            val effect = h.exportEffects.single() as BackupExportEffect.Success
+            assertEquals(BackupVariant.FULL, effect.variant)
+            assertFalse(effect.offerShare)
+        }
+
+    @Test
+    fun `export write failure invokes onWriteFailed once and emits WriteFailed and closes stream`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+            val stream = FailingStream()
+            var writeFailedCalls = 0
+
+            h.coordinator.export(
+                BackupVariant.FULL,
+                openOutput = { stream },
+                onWriteFailed = { writeFailedCalls++ },
+            )
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(1, writeFailedCalls)
+            assertEquals(listOf<BackupExportEffect>(BackupExportEffect.WriteFailed), h.exportEffects)
+            assertTrue(stream.closed)
+            assertFalse(h.state.value.exporting)
+        }
+
+    // -- prepareShareBackup() -------------------------------------------------
+
+    @Test
+    fun `prepareShareBackup is a no-op when already sharing`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+            h.state.update { it.copy(sharing = true) }
+            var opened = false
+
+            h.coordinator.prepareShareBackup {
+                opened = true
+                null
+            }
+            testScheduler.advanceUntilIdle()
+
+            assertFalse(opened)
+            assertTrue(h.shareEffects.isEmpty())
+        }
+
+    @Test
+    fun `prepareShareBackup is a no-op when disabled by policy`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness(policyDisabled = true)
+            var opened = false
+
+            h.coordinator.prepareShareBackup {
+                opened = true
+                null
+            }
+            testScheduler.advanceUntilIdle()
+
+            assertFalse(opened)
+            assertTrue(h.shareEffects.isEmpty())
+        }
+
+    @Test
+    fun `prepareShareBackup with null output flips sharing and emits Failed`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+
+            h.coordinator.prepareShareBackup { null }
+            assertTrue(h.state.value.sharing)
+            testScheduler.advanceUntilIdle()
+
+            assertFalse(h.state.value.sharing)
+            assertEquals(listOf<BackupShareEffect>(BackupShareEffect.Failed), h.shareEffects)
+        }
+
+    @Test
+    fun `prepareShareBackup success always exports SHARE and emits Ready`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+            val stream = CloseTrackingStream()
+
+            h.coordinator.prepareShareBackup { stream }
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(listOf<BackupShareEffect>(BackupShareEffect.Ready), h.shareEffects)
+            // The forced-SHARE variant is observable through the redacted document:
+            // SHARE marks the archive non-credential-bearing (FULL would be `true`).
+            assertTrue(stream.text().contains("\"containsCredentials\": false"))
+            assertFalse(h.state.value.sharing)
+            assertTrue(stream.closed)
+        }
+
+    @Test
+    fun `prepareShareBackup write failure emits Failed and closes stream`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+            val stream = FailingStream()
+
+            h.coordinator.prepareShareBackup { stream }
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(listOf<BackupShareEffect>(BackupShareEffect.Failed), h.shareEffects)
+            assertFalse(h.state.value.sharing)
+            assertTrue(stream.closed)
+        }
+
+    // -- Harness --------------------------------------------------------------
+
+    private class Harness(
+        val coordinator: BackupExportCoordinator,
+        val state: MutableStateFlow<BackupRestoreUiState>,
+        val exportEffects: List<BackupExportEffect>,
+        val shareEffects: List<BackupShareEffect>,
+    )
+
+    private fun TestScope.harness(policyDisabled: Boolean = false): Harness {
+        val state = MutableStateFlow(BackupRestoreUiState(exportDisabledByPolicy = policyDisabled))
+        val exportEffects = mutableListOf<BackupExportEffect>()
+        val shareEffects = mutableListOf<BackupShareEffect>()
+        val useCase =
+            BackupExportUseCase(
+                groupRepository = FakeGroupRepository(),
+                profileProvider = BackupProfileProvider { emptyList() },
+                ruleDao = FakeRuleDao(),
+                settingsRepository = FakeAppSettingsRepository(),
+            )
+        val coordinator =
+            BackupExportCoordinator(
+                // The TestScope created by runTest drives launches via testScheduler.
+                scope = this,
+                exportUseCase = useCase,
+                appVersion = "1.0.0",
+                exportDisabledByPolicy = { state.value.exportDisabledByPolicy },
+                currentState = state::value,
+                updateState = state::update,
+                emitExportEffect = { exportEffects.add(it) },
+                emitShareEffect = { shareEffects.add(it) },
+            )
+        return Harness(coordinator, state, exportEffects, shareEffects)
+    }
+
+    private class CloseTrackingStream : OutputStream() {
+        var closed = false
+            private set
+        private val buffer = ByteArrayOutputStream()
+
+        override fun write(b: Int) = buffer.write(b)
+
+        fun text(): String = buffer.toString("UTF-8")
+
+        override fun close() {
+            closed = true
+            super.close()
+        }
+    }
+
+    private class FailingStream : OutputStream() {
+        var closed = false
+            private set
+
+        override fun write(b: Int): Unit = throw IOException("boom")
+
+        override fun write(
+            b: ByteArray,
+            off: Int,
+            len: Int,
+        ): Unit = throw IOException("boom")
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private class FakeGroupRepository : ProxyGroupRepository {
+        private val state = MutableStateFlow(emptyList<ProxyGroup>())
+
+        override suspend fun add(group: ProxyGroup) = Unit
+
+        override suspend fun update(group: ProxyGroup) = Unit
+
+        override suspend fun delete(id: String) = Unit
+
+        override suspend fun list(): List<ProxyGroup> = emptyList()
+
+        override suspend fun replaceAll(groups: List<ProxyGroup>) = Unit
+
+        override fun groups(): Flow<List<ProxyGroup>> = state.asStateFlow()
+    }
+
+    private class FakeAppSettingsRepository : AppSettingsRepository {
+        private val state = MutableStateFlow(AppSettings.getDefaultInstance())
+
+        override val settings: Flow<AppSettings> = state.asStateFlow()
+
+        override suspend fun snapshot(): AppSettings = state.first()
+
+        override suspend fun update(transform: AppSettings.Builder.() -> Unit) {
+            state.value =
+                state.value
+                    .toBuilder()
+                    .apply(transform)
+                    .build()
+        }
+
+        override suspend fun replace(settings: AppSettings) {
+            state.value = settings
+        }
+    }
+
+    private class FakeRuleDao : RuleDao() {
+        override suspend fun deleteAll() = Unit
+
+        override fun allRules(): Flow<List<RuleEntity>> = flowOf(emptyList())
+
+        override fun enabledRules(): Flow<List<RuleEntity>> = flowOf(emptyList())
+
+        override fun rulesExcludingName(excludedName: String): Flow<List<RuleEntity>> = flowOf(emptyList())
+
+        override fun rulesByName(name: String): Flow<List<RuleEntity>> = flowOf(emptyList())
+
+        override suspend fun findByName(name: String): RuleEntity? = null
+
+        override suspend fun maxUserOrder(excludedName: String): Int? = null
+
+        override suspend fun insert(rule: RuleEntity): Long = error("not used")
+
+        override suspend fun update(rule: RuleEntity) = error("not used")
+
+        override suspend fun delete(rule: RuleEntity) = error("not used")
+
+        override suspend fun resetOutboundTags(
+            ruleIds: List<Long>,
+            targetTag: OutboundTag,
+            replacementTag: OutboundTag,
+        ): Int = error("not used")
+
+        override suspend fun updateOrder(
+            id: Long,
+            order: Int,
+        ) = error("not used")
+    }
+}

--- a/app/src/test/kotlin/com/poyka/ripdpi/backup/BackupImportCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/backup/BackupImportCoordinatorTest.kt
@@ -1,0 +1,451 @@
+package com.poyka.ripdpi.backup
+
+import com.poyka.ripdpi.data.AppSettingsRepository
+import com.poyka.ripdpi.data.ProxyGroup
+import com.poyka.ripdpi.data.ProxyGroupRepository
+import com.poyka.ripdpi.data.ProxyGroupType
+import com.poyka.ripdpi.data.ProxyProfile
+import com.poyka.ripdpi.data.backup.BackupExportUseCase
+import com.poyka.ripdpi.data.backup.BackupProfileProvider
+import com.poyka.ripdpi.data.backup.BackupProfileRestoreSink
+import com.poyka.ripdpi.data.backup.BackupRestoreUseCase
+import com.poyka.ripdpi.data.backup.BackupVariant
+import com.poyka.ripdpi.data.rules.OutboundTag
+import com.poyka.ripdpi.data.rules.RuleDao
+import com.poyka.ripdpi.data.rules.RuleEntity
+import com.poyka.ripdpi.proto.AppSettings
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BackupImportCoordinatorTest {
+    private val sampleGroup =
+        ProxyGroup(id = "g-1", name = "Group", type = ProxyGroupType.BASIC, order = 0, isSelector = false)
+    private val sampleProfile =
+        ProxyProfile.Shadowsocks(
+            id = "ss-1",
+            displayName = "SS",
+            groupId = "g-1",
+            server = "ss.example.com",
+            serverPort = 8388,
+            method = "aes-256-gcm",
+            password = "secret",
+        )
+
+    // -- openImport() ---------------------------------------------------------
+
+    @Test
+    fun `openImport is a no-op while importing`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+            h.state.update { it.copy(importing = true) }
+            var opened = false
+
+            h.coordinator.openImport {
+                opened = true
+                null
+            }
+            testScheduler.advanceUntilIdle()
+
+            assertFalse(opened)
+        }
+
+    @Test
+    fun `openImport is a no-op while restoring`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+            h.state.update { it.copy(restoring = true) }
+            var opened = false
+
+            h.coordinator.openImport {
+                opened = true
+                null
+            }
+            testScheduler.advanceUntilIdle()
+
+            assertFalse(opened)
+        }
+
+    @Test
+    fun `openImport with null input clears importing with no preview and no effect`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+
+            h.coordinator.openImport { null }
+            testScheduler.advanceUntilIdle()
+
+            assertFalse(h.state.value.importing)
+            assertNull(h.state.value.importPreview)
+            assertTrue(h.restoreEffects.isEmpty())
+        }
+
+    @Test
+    fun `openImport with throwing input clears importing with no preview and no effect`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+
+            h.coordinator.openImport { throw IOException("boom") }
+            testScheduler.advanceUntilIdle()
+
+            assertFalse(h.state.value.importing)
+            assertNull(h.state.value.importPreview)
+            assertTrue(h.restoreEffects.isEmpty())
+        }
+
+    @Test
+    fun `openImport Ready populates preview with exact default selection predicates`() =
+        runTest(StandardTestDispatcher()) {
+            // FULL backup with one decodable profile + one group, NO rules. The settings
+            // map always carries the single snapshot key, so settingCount > 0.
+            val json = exportJson(BackupVariant.FULL, profiles = listOf(sampleProfile), groups = listOf(sampleGroup))
+            val h = harness()
+
+            h.coordinator.openImport { json.byteInputStream() }
+            testScheduler.advanceUntilIdle()
+
+            val preview = h.state.value.importPreview!!
+            assertEquals(json, preview.json)
+            // profilesAndGroups = canRestoreProfilesAndGroups (decodable profile + group => true).
+            assertTrue(preview.selection.profilesAndGroups)
+            // routes = ruleCount > 0 (no rules => false).
+            assertFalse(preview.selection.routes)
+            // settings = settingCount > 0 (snapshot key is always present => true).
+            assertTrue(preview.selection.settings)
+            assertFalse(h.state.value.importing)
+            assertTrue(h.restoreEffects.isEmpty())
+        }
+
+    @Test
+    fun `openImport default selection turns profilesAndGroups off when nothing is restorable`() =
+        runTest(StandardTestDispatcher()) {
+            // SHARE backup with a credential-bearing profile: credentials are redacted,
+            // so the profile is undecodable and no group is present => canRestore=false.
+            val json = exportJson(BackupVariant.SHARE, profiles = listOf(sampleProfile), groups = emptyList())
+            val h = harness()
+
+            h.coordinator.openImport { json.byteInputStream() }
+            testScheduler.advanceUntilIdle()
+
+            val preview = h.state.value.importPreview!!
+            assertFalse(preview.selection.profilesAndGroups)
+            assertFalse(preview.selection.routes)
+        }
+
+    @Test
+    fun `openImport UnsupportedVersion emits effect and no preview`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+            val futureJson =
+                """{"schemaVersion":9999,"createdAtEpochMillis":0,"appVersion":"x",""" +
+                    """"profiles":[],"groups":[],"rules":[],"settings":{}}"""
+
+            h.coordinator.openImport { futureJson.byteInputStream() }
+            testScheduler.advanceUntilIdle()
+
+            assertNull(h.state.value.importPreview)
+            assertFalse(h.state.value.importing)
+            assertTrue(h.restoreEffects.single() is BackupRestoreEffect.UnsupportedVersion)
+        }
+
+    @Test
+    fun `openImport Malformed emits effect and no preview`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+
+            h.coordinator.openImport { "not json at all".byteInputStream() }
+            testScheduler.advanceUntilIdle()
+
+            assertNull(h.state.value.importPreview)
+            assertFalse(h.state.value.importing)
+            assertEquals(listOf<BackupRestoreEffect>(BackupRestoreEffect.Malformed), h.restoreEffects)
+        }
+
+    // -- selection edits ------------------------------------------------------
+
+    @Test
+    fun `set selected mutate only the active preview selection`() =
+        runTest(StandardTestDispatcher()) {
+            val json = exportJson(BackupVariant.FULL, profiles = listOf(sampleProfile), groups = listOf(sampleGroup))
+            val h = harness()
+            h.coordinator.openImport { json.byteInputStream() }
+            testScheduler.advanceUntilIdle()
+
+            h.coordinator.setProfilesAndGroupsSelected(false)
+            h.coordinator.setRoutesSelected(true)
+            h.coordinator.setSettingsSelected(true)
+
+            val sel =
+                h.state.value.importPreview!!
+                    .selection
+            assertFalse(sel.profilesAndGroups)
+            assertTrue(sel.routes)
+            assertTrue(sel.settings)
+        }
+
+    @Test
+    fun `set selected are no-ops when there is no active preview`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+
+            h.coordinator.setProfilesAndGroupsSelected(true)
+            h.coordinator.setRoutesSelected(true)
+            h.coordinator.setSettingsSelected(true)
+
+            assertNull(h.state.value.importPreview)
+        }
+
+    @Test
+    fun `cancelImport clears the preview`() =
+        runTest(StandardTestDispatcher()) {
+            val json = exportJson(BackupVariant.FULL, profiles = listOf(sampleProfile), groups = listOf(sampleGroup))
+            val h = harness()
+            h.coordinator.openImport { json.byteInputStream() }
+            testScheduler.advanceUntilIdle()
+            assertTrue(h.state.value.importPreview != null)
+
+            h.coordinator.cancelImport()
+
+            assertNull(h.state.value.importPreview)
+        }
+
+    // -- confirmRestore() -----------------------------------------------------
+
+    @Test
+    fun `confirmRestore is a no-op when there is no preview`() =
+        runTest(StandardTestDispatcher()) {
+            val h = harness()
+
+            h.coordinator.confirmRestore()
+            testScheduler.advanceUntilIdle()
+
+            assertTrue(h.restoreEffects.isEmpty())
+            assertFalse(h.state.value.restoring)
+        }
+
+    @Test
+    fun `confirmRestore is a no-op while restoring`() =
+        runTest(StandardTestDispatcher()) {
+            val json = exportJson(BackupVariant.FULL, profiles = listOf(sampleProfile), groups = listOf(sampleGroup))
+            val h = harness()
+            h.coordinator.openImport { json.byteInputStream() }
+            testScheduler.advanceUntilIdle()
+            h.state.update { it.copy(restoring = true) }
+            h.restoreEffects.clear()
+
+            h.coordinator.confirmRestore()
+            testScheduler.advanceUntilIdle()
+
+            assertTrue(h.restoreEffects.isEmpty())
+        }
+
+    @Test
+    fun `confirmRestore with empty selection emits NothingSelected and does not flip restoring`() =
+        runTest(StandardTestDispatcher()) {
+            val json = exportJson(BackupVariant.FULL, profiles = listOf(sampleProfile), groups = listOf(sampleGroup))
+            val h = harness()
+            h.coordinator.openImport { json.byteInputStream() }
+            testScheduler.advanceUntilIdle()
+            // Clear every category.
+            h.coordinator.setProfilesAndGroupsSelected(false)
+            h.coordinator.setRoutesSelected(false)
+            h.coordinator.setSettingsSelected(false)
+            h.restoreEffects.clear()
+
+            h.coordinator.confirmRestore()
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(listOf<BackupRestoreEffect>(BackupRestoreEffect.NothingSelected), h.restoreEffects)
+            assertFalse(h.state.value.restoring)
+            // Preview survives a NothingSelected (no restore was attempted).
+            assertTrue(h.state.value.importPreview != null)
+        }
+
+    @Test
+    fun `confirmRestore success flips restoring clears preview and emits Restored`() =
+        runTest(StandardTestDispatcher()) {
+            val json = exportJson(BackupVariant.FULL, profiles = listOf(sampleProfile), groups = listOf(sampleGroup))
+            val h = harness()
+            h.coordinator.openImport { json.byteInputStream() }
+            testScheduler.advanceUntilIdle()
+
+            h.coordinator.confirmRestore()
+            // restoring flips true synchronously, before the suspend restore runs.
+            assertTrue(h.state.value.restoring)
+            testScheduler.advanceUntilIdle()
+
+            assertFalse(h.state.value.restoring)
+            assertNull(h.state.value.importPreview)
+            assertEquals(listOf<BackupRestoreEffect>(BackupRestoreEffect.Restored), h.restoreEffects)
+        }
+
+    @Test
+    fun `confirmRestore reuses the exact previewed json bytes`() =
+        runTest(StandardTestDispatcher()) {
+            val json = exportJson(BackupVariant.FULL, profiles = listOf(sampleProfile), groups = listOf(sampleGroup))
+            val h = harness()
+            h.coordinator.openImport { json.byteInputStream() }
+            testScheduler.advanceUntilIdle()
+
+            // The preview retains the exact bytes the file carried; confirmRestore
+            // threads preview.json verbatim into restore (see coordinator), so a
+            // byte-identical preview.json proves the same bytes reach the restore.
+            val previewedJson =
+                h.state.value.importPreview!!
+                    .json
+            assertEquals(json, previewedJson)
+
+            h.coordinator.confirmRestore()
+            testScheduler.advanceUntilIdle()
+
+            // A successful Restored proves the previewed bytes were valid + accepted.
+            assertEquals(listOf<BackupRestoreEffect>(BackupRestoreEffect.Restored), h.restoreEffects)
+        }
+
+    // -- Harness --------------------------------------------------------------
+
+    private class Harness(
+        val coordinator: BackupImportCoordinator,
+        val state: MutableStateFlow<BackupRestoreUiState>,
+        val restoreEffects: MutableList<BackupRestoreEffect>,
+    )
+
+    private fun TestScope.harness(): Harness {
+        val state = MutableStateFlow(BackupRestoreUiState())
+        val effects = mutableListOf<BackupRestoreEffect>()
+        // The real use case (final class) is constructed with hand-rolled fakes; no
+        // Robolectric/Room needed. `android.util.Log` no-ops under the app module's
+        // unitTests.isReturnDefaultValues = true.
+        val restoreUseCase =
+            BackupRestoreUseCase(
+                groupRepository = MutableGroupRepository(),
+                profileSink = CapturingProfileSink(),
+                ruleDao = FakeRuleDao(),
+                settingsRepository = FakeAppSettingsRepository(),
+            )
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val coordinator =
+            BackupImportCoordinator(
+                scope = this,
+                restoreUseCase = restoreUseCase,
+                currentState = state::value,
+                updateState = state::update,
+                emitRestoreEffect = { effects.add(it) },
+                ioDispatcher = dispatcher,
+                defaultDispatcher = dispatcher,
+            )
+        return Harness(coordinator, state, effects)
+    }
+
+    private fun exportJson(
+        variant: BackupVariant,
+        profiles: List<ProxyProfile> = emptyList(),
+        groups: List<ProxyGroup> = emptyList(),
+    ): String {
+        val out = ByteArrayOutputStream()
+        runBlocking {
+            BackupExportUseCase(
+                groupRepository = MutableGroupRepository(groups),
+                profileProvider = BackupProfileProvider { profiles },
+                ruleDao = FakeRuleDao(),
+                settingsRepository = FakeAppSettingsRepository(),
+            ).export(variant = variant, output = out, appVersion = "1.0.0")
+        }
+        return out.toString("UTF-8")
+    }
+
+    private class CapturingProfileSink : BackupProfileRestoreSink {
+        override suspend fun replaceAll(profiles: List<ProxyProfile>) = Unit
+    }
+
+    private class MutableGroupRepository(
+        initial: List<ProxyGroup> = emptyList(),
+    ) : ProxyGroupRepository {
+        private val groups = initial.toMutableList()
+        private val state = MutableStateFlow(groups.toList())
+
+        override suspend fun add(group: ProxyGroup) = Unit
+
+        override suspend fun update(group: ProxyGroup) = Unit
+
+        override suspend fun delete(id: String) = Unit
+
+        override suspend fun list(): List<ProxyGroup> = groups.toList()
+
+        override suspend fun replaceAll(groups: List<ProxyGroup>) {
+            this.groups.clear()
+            this.groups.addAll(groups)
+            state.value = this.groups.toList()
+        }
+
+        override fun groups(): Flow<List<ProxyGroup>> = state.asStateFlow()
+    }
+
+    private class FakeAppSettingsRepository : AppSettingsRepository {
+        private val state = MutableStateFlow(AppSettings.getDefaultInstance())
+
+        override val settings: Flow<AppSettings> = state.asStateFlow()
+
+        override suspend fun snapshot(): AppSettings = state.first()
+
+        override suspend fun update(transform: AppSettings.Builder.() -> Unit) {
+            state.value =
+                state.value
+                    .toBuilder()
+                    .apply(transform)
+                    .build()
+        }
+
+        override suspend fun replace(settings: AppSettings) {
+            state.value = settings
+        }
+    }
+
+    private class FakeRuleDao : RuleDao() {
+        override suspend fun deleteAll() = Unit
+
+        override fun allRules(): Flow<List<RuleEntity>> = flowOf(emptyList())
+
+        override fun enabledRules(): Flow<List<RuleEntity>> = flowOf(emptyList())
+
+        override fun rulesExcludingName(excludedName: String): Flow<List<RuleEntity>> = flowOf(emptyList())
+
+        override fun rulesByName(name: String): Flow<List<RuleEntity>> = flowOf(emptyList())
+
+        override suspend fun findByName(name: String): RuleEntity? = null
+
+        override suspend fun maxUserOrder(excludedName: String): Int? = null
+
+        override suspend fun insert(rule: RuleEntity): Long = error("not used")
+
+        override suspend fun update(rule: RuleEntity) = error("not used")
+
+        override suspend fun delete(rule: RuleEntity) = error("not used")
+
+        override suspend fun resetOutboundTags(
+            ruleIds: List<Long>,
+            targetTag: OutboundTag,
+            replacementTag: OutboundTag,
+        ): Int = error("not used")
+
+        override suspend fun updateOrder(
+            id: Long,
+            order: Int,
+        ) = error("not used")
+    }
+}

--- a/app/src/test/kotlin/com/poyka/ripdpi/backup/BackupResetCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/backup/BackupResetCoordinatorTest.kt
@@ -1,0 +1,294 @@
+package com.poyka.ripdpi.backup
+
+import com.poyka.ripdpi.data.AppSettingsRepository
+import com.poyka.ripdpi.data.ProxyGroup
+import com.poyka.ripdpi.data.ProxyGroupRepository
+import com.poyka.ripdpi.data.ProxyProfile
+import com.poyka.ripdpi.data.backup.BackupProfileRestoreSink
+import com.poyka.ripdpi.data.diagnostics.DiagnosticsHistoryResetStore
+import com.poyka.ripdpi.data.rules.OutboundTag
+import com.poyka.ripdpi.data.rules.RuleDao
+import com.poyka.ripdpi.data.rules.RuleEntity
+import com.poyka.ripdpi.proto.AppSettings
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BackupResetCoordinatorTest {
+    @Test
+    fun `setResetDialogVisible true shows dialog and clears input`() =
+        runTest {
+            val harness = harness()
+            harness.state.update { it.copy(resetConfirmationInput = "RES") }
+
+            harness.coordinator.setResetDialogVisible(true)
+
+            assertTrue(harness.state.value.resetDialogVisible)
+            assertEquals("", harness.state.value.resetConfirmationInput)
+        }
+
+    @Test
+    fun `setResetDialogVisible false hides dialog and clears input`() =
+        runTest {
+            val harness = harness()
+            harness.state.update { it.copy(resetDialogVisible = true, resetConfirmationInput = "RES") }
+
+            harness.coordinator.setResetDialogVisible(false)
+
+            assertFalse(harness.state.value.resetDialogVisible)
+            assertEquals("", harness.state.value.resetConfirmationInput)
+        }
+
+    @Test
+    fun `setResetDialogVisible ignored while resetting`() =
+        runTest {
+            val harness = harness()
+            harness.state.update { it.copy(resetting = true, resetDialogVisible = true) }
+
+            harness.coordinator.setResetDialogVisible(false)
+
+            // No change: still visible, still resetting.
+            assertTrue(harness.state.value.resetDialogVisible)
+        }
+
+    @Test
+    fun `onResetConfirmationInputChange records input verbatim`() =
+        runTest {
+            val harness = harness()
+
+            harness.coordinator.onResetConfirmationInputChange("res")
+
+            assertEquals("res", harness.state.value.resetConfirmationInput)
+        }
+
+    @Test
+    fun `confirmReset is a no-op while already resetting`() =
+        runTest(StandardTestDispatcher()) {
+            val harness = harness(defaultDispatcher = StandardTestDispatcher(testScheduler))
+            harness.state.update { it.copy(resetting = true, resetConfirmationInput = ResetConfirmationToken) }
+
+            harness.coordinator.confirmReset()
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(0, harness.useCaseProbe.resetCalls)
+            assertTrue(harness.resetEffects.isEmpty())
+        }
+
+    @Test
+    fun `confirmReset is a no-op when token does not match`() =
+        runTest(StandardTestDispatcher()) {
+            val harness = harness(defaultDispatcher = StandardTestDispatcher(testScheduler))
+            harness.state.update { it.copy(resetConfirmationInput = "nope") }
+
+            harness.coordinator.confirmReset()
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(0, harness.useCaseProbe.resetCalls)
+            assertTrue(harness.resetEffects.isEmpty())
+            assertFalse(harness.state.value.resetting)
+        }
+
+    @Test
+    fun `confirmReset with exact token wipes once and flips resetting and emits Wiped`() =
+        runTest(StandardTestDispatcher()) {
+            val harness = harness(defaultDispatcher = StandardTestDispatcher(testScheduler))
+            harness.state.update {
+                it.copy(resetDialogVisible = true, resetConfirmationInput = ResetConfirmationToken)
+            }
+
+            harness.coordinator.confirmReset()
+            // Synchronous part: resetting flips true before the wipe runs.
+            assertTrue(harness.state.value.resetting)
+            assertEquals(0, harness.useCaseProbe.resetCalls)
+
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(1, harness.useCaseProbe.resetCalls)
+            assertFalse(harness.state.value.resetting)
+            assertFalse(harness.state.value.resetDialogVisible)
+            assertEquals("", harness.state.value.resetConfirmationInput)
+            assertEquals(listOf(BackupResetEffect.Wiped), harness.resetEffects)
+        }
+
+    @Test
+    fun `Wiped is emitted only after the wipe completes`() =
+        runTest(StandardTestDispatcher()) {
+            val harness = harness(defaultDispatcher = StandardTestDispatcher(testScheduler))
+            harness.state.update { it.copy(resetConfirmationInput = ResetConfirmationToken) }
+
+            harness.coordinator.confirmReset()
+            testScheduler.runCurrent()
+            // The wipe coroutine has not been driven yet: no effect.
+            assertTrue(harness.useCaseProbe.resetCalls <= 1)
+
+            testScheduler.advanceUntilIdle()
+
+            // resetting is cleared (state-then-effect) and exactly one Wiped emitted.
+            assertEquals(1, harness.useCaseProbe.resetCalls)
+            assertEquals(listOf(BackupResetEffect.Wiped), harness.resetEffects)
+        }
+
+    // -- Harness --------------------------------------------------------------
+
+    /**
+     * Counts how many times the real [ResetAllSettingsUseCase] ran to completion by
+     * observing its LAST wipe step (the cache cleaner). [resetCalls] is therefore a
+     * faithful "the wipe committed" counter without faking the use case itself.
+     */
+    private class UseCaseProbe {
+        var resetCalls = 0
+            private set
+
+        fun onWipeCompleted() {
+            resetCalls++
+        }
+    }
+
+    private class Harness(
+        val coordinator: BackupResetCoordinator,
+        val state: MutableStateFlow<BackupRestoreUiState>,
+        val resetEffects: List<BackupResetEffect>,
+        val useCaseProbe: UseCaseProbe,
+    )
+
+    private fun TestScope.harness(
+        defaultDispatcher: CoroutineDispatcher = StandardTestDispatcher(testScheduler),
+    ): Harness {
+        val state = MutableStateFlow(BackupRestoreUiState())
+        val effects = mutableListOf<BackupResetEffect>()
+        val probe = UseCaseProbe()
+        val useCase =
+            ResetAllSettingsUseCase(
+                resetEventRecorder = FakeResetEventRecorder(),
+                profileSink = FakeProfileSink(),
+                groupRepository = FakeGroupRepository(),
+                ruleDao = FakeRuleDao(),
+                settingsRepository = FakeAppSettingsRepository(),
+                diagnosticsHistoryResetStore = FakeDiagnosticsHistoryResetStore(),
+                cacheDirectoryCleaner = FakeCacheDirectoryCleaner(probe),
+            )
+        val coordinator =
+            BackupResetCoordinator(
+                scope = this,
+                resetAllSettingsUseCase = useCase,
+                currentState = state::value,
+                updateState = state::update,
+                emitResetEffect = { effects.add(it) },
+                defaultDispatcher = defaultDispatcher,
+            )
+        return Harness(coordinator, state, effects, probe)
+    }
+
+    private class FakeResetEventRecorder : ResetEventRecorder {
+        private var pending = false
+
+        override fun recordResetInitiated() {
+            pending = true
+        }
+
+        override fun hasPendingResetEvent(): Boolean = pending
+
+        override fun consumeResetEvent(): Boolean {
+            if (!pending) return false
+            pending = false
+            return true
+        }
+    }
+
+    private class FakeProfileSink : BackupProfileRestoreSink {
+        override suspend fun replaceAll(profiles: List<ProxyProfile>) = Unit
+    }
+
+    private class FakeGroupRepository : ProxyGroupRepository {
+        private val state = MutableStateFlow(emptyList<ProxyGroup>())
+
+        override suspend fun add(group: ProxyGroup) = Unit
+
+        override suspend fun update(group: ProxyGroup) = Unit
+
+        override suspend fun delete(id: String) = Unit
+
+        override suspend fun list(): List<ProxyGroup> = emptyList()
+
+        override suspend fun replaceAll(groups: List<ProxyGroup>) = Unit
+
+        override fun groups(): Flow<List<ProxyGroup>> = state.asStateFlow()
+    }
+
+    private class FakeAppSettingsRepository : AppSettingsRepository {
+        private val state = MutableStateFlow(AppSettings.getDefaultInstance())
+
+        override val settings: Flow<AppSettings> = state.asStateFlow()
+
+        override suspend fun snapshot(): AppSettings = state.first()
+
+        override suspend fun update(transform: AppSettings.Builder.() -> Unit) {
+            state.value =
+                state.value
+                    .toBuilder()
+                    .apply(transform)
+                    .build()
+        }
+
+        override suspend fun replace(settings: AppSettings) {
+            state.value = settings
+        }
+    }
+
+    private class FakeDiagnosticsHistoryResetStore : DiagnosticsHistoryResetStore {
+        override suspend fun clearRuntimeHistory() = Unit
+    }
+
+    private class FakeCacheDirectoryCleaner(
+        private val probe: UseCaseProbe,
+    ) : CacheDirectoryCleaner {
+        // Cache clearing is the LAST step of the use case; reaching it == wipe done.
+        override fun clearCaches() = probe.onWipeCompleted()
+    }
+
+    private class FakeRuleDao : RuleDao() {
+        override suspend fun deleteAll() = Unit
+
+        override fun allRules(): Flow<List<RuleEntity>> = flowOf(emptyList())
+
+        override fun enabledRules(): Flow<List<RuleEntity>> = flowOf(emptyList())
+
+        override fun rulesExcludingName(excludedName: String): Flow<List<RuleEntity>> = flowOf(emptyList())
+
+        override fun rulesByName(name: String): Flow<List<RuleEntity>> = flowOf(emptyList())
+
+        override suspend fun findByName(name: String): RuleEntity? = null
+
+        override suspend fun maxUserOrder(excludedName: String): Int? = null
+
+        override suspend fun insert(rule: RuleEntity): Long = error("not used")
+
+        override suspend fun update(rule: RuleEntity) = error("not used")
+
+        override suspend fun delete(rule: RuleEntity) = error("not used")
+
+        override suspend fun resetOutboundTags(
+            ruleIds: List<Long>,
+            targetTag: OutboundTag,
+            replacementTag: OutboundTag,
+        ): Int = error("not used")
+
+        override suspend fun updateOrder(
+            id: Long,
+            order: Int,
+        ) = error("not used")
+    }
+}

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckProbeOrchestratorTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckProbeOrchestratorTest.kt
@@ -1,0 +1,262 @@
+package com.poyka.ripdpi.ui.screens.blockcheck
+
+import com.poyka.ripdpi.core.detection.BlockLayer
+import com.poyka.ripdpi.core.detection.BlockLayerDiagnosis
+import com.poyka.ripdpi.core.detection.BypassStrategyClass
+import com.poyka.ripdpi.core.detection.EvidenceConfidence
+import com.poyka.ripdpi.diagnostics.StrategyProbeCandidate
+import com.poyka.ripdpi.diagnostics.StrategyProbeCandidateProvider
+import com.poyka.ripdpi.diagnostics.StrategyProbeConfig
+import com.poyka.ripdpi.diagnostics.StrategyProbeFailureKind
+import com.poyka.ripdpi.diagnostics.StrategyProbeResult
+import com.poyka.ripdpi.diagnostics.StrategyProbeService
+import com.poyka.ripdpi.diagnostics.summarizeStrategyProbeResults
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BlockcheckProbeOrchestratorTest {
+    @Test
+    fun `run emits running snapshot first then complete`() =
+        runTest {
+            val orchestrator =
+                orchestrator(
+                    results = listOf(orchestratorProbeResult("fake", success = true, latencyMs = 90)),
+                )
+
+            val snapshots =
+                orchestrator
+                    .run(domains = listOf("youtube.com"), candidates = orchestratorCandidates())
+                    .toList()
+
+            assertEquals(BlockcheckRunState.Running, snapshots.first().runState)
+            assertTrue(snapshots.first().results.isEmpty())
+            assertEquals(BlockcheckRunState.Complete, snapshots.last().runState)
+        }
+
+    @Test
+    fun `run accumulates ranking incrementally and matches summarize`() =
+        runTest {
+            val emitted =
+                listOf(
+                    orchestratorProbeResult("split", success = false, latencyMs = 300),
+                    orchestratorProbeResult("fake", success = false, latencyMs = 100),
+                    orchestratorProbeResult("split", success = true, latencyMs = 50),
+                )
+            val orchestrator = orchestrator(results = emitted)
+
+            val snapshots =
+                orchestrator
+                    .run(domains = listOf("youtube.com"), candidates = orchestratorCandidates())
+                    .toList()
+
+            // snapshots[0] is the clean Running snapshot, then one per emitted result, then Complete.
+            val perResult = snapshots.drop(1).dropLast(1)
+            assertEquals(emitted.size, perResult.size)
+            perResult.forEachIndexed { index, snapshot ->
+                val cumulative = emitted.take(index + 1)
+                assertEquals(
+                    summarizeStrategyProbeResults(cumulative).rankedStrategies,
+                    snapshot.rankedStrategies,
+                )
+                assertEquals(index + 1, snapshot.results.size)
+            }
+            assertEquals(
+                summarizeStrategyProbeResults(emitted).rankedStrategies,
+                snapshots.last().rankedStrategies,
+            )
+        }
+
+    @Test
+    fun `run maps diagnosis bypass class to matching recommended candidate`() =
+        runTest {
+            val orchestrator =
+                orchestrator(
+                    results =
+                        listOf(
+                            orchestratorProbeResult("split", success = false, latencyMs = 300),
+                            orchestratorProbeResult("tlsrec_split", success = true, latencyMs = 90),
+                        ),
+                    diagnosisRunner =
+                        FakeBlockcheckDiagnosisRunner(
+                            listOf(
+                                orchestratorSiteDiagnosis(
+                                    domain = "youtube.com",
+                                    layer = BlockLayer.SNI_BASED_RESET,
+                                    bypassClass = BypassStrategyClass.TLS_RECORD_SPLIT,
+                                ),
+                            ),
+                        ),
+                    candidates =
+                        listOf(
+                            StrategyProbeCandidate("fake", "Fake packet", "[tcp]\nfake auto(host)"),
+                            StrategyProbeCandidate("tlsrec_split", "TLS record split", "[tcp]\ntlsrec split"),
+                        ),
+                )
+
+            val complete =
+                orchestrator
+                    .run(
+                        domains = listOf("youtube.com"),
+                        candidates =
+                            listOf(
+                                StrategyProbeCandidate("fake", "Fake packet", "[tcp]\nfake auto(host)"),
+                                StrategyProbeCandidate("tlsrec_split", "TLS record split", "[tcp]\ntlsrec split"),
+                            ),
+                    ).toList()
+                    .last()
+
+            assertEquals("tlsrec_split", complete.recommendedStrategyId)
+            assertEquals("TLS record split", complete.recommendedStrategyLabel)
+        }
+
+    @Test
+    fun `run falls back to diagnoseFromStrategyResults when diagnoses empty`() =
+        runTest {
+            val orchestrator =
+                orchestrator(
+                    results =
+                        listOf(
+                            orchestratorProbeResult(
+                                "split",
+                                success = false,
+                                latencyMs = 300,
+                                dnsTampered = true,
+                            ),
+                        ),
+                    diagnosisRunner = FakeBlockcheckDiagnosisRunner(emptyList()),
+                )
+
+            val complete =
+                orchestrator
+                    .run(domains = listOf("youtube.com"), candidates = orchestratorCandidates())
+                    .toList()
+                    .last()
+
+            assertEquals(BlockLayer.DNS_POISONING, complete.primaryDiagnosis?.diagnosis?.layer)
+            assertEquals(
+                BypassStrategyClass.ENCRYPTED_DNS,
+                complete.primaryDiagnosis?.diagnosis?.bypassClass,
+            )
+        }
+
+    @Test
+    fun `run rethrows cancellation from probe stream`() =
+        runTest {
+            val orchestrator =
+                orchestrator(
+                    probeService = CancellingStrategyProbeService(),
+                    results = emptyList(),
+                )
+
+            try {
+                orchestrator
+                    .run(domains = listOf("youtube.com"), candidates = orchestratorCandidates())
+                    .toList()
+                fail("expected CancellationException")
+            } catch (expected: CancellationException) {
+                assertEquals("cancelled mid-stream", expected.message)
+            }
+        }
+
+    @Test
+    fun `diagnose returns empty on non-cancellation error`() =
+        runTest {
+            val orchestrator =
+                orchestrator(
+                    diagnosisRunner = ThrowingBlockcheckDiagnosisRunner(IllegalStateException("boom")),
+                    results = emptyList(),
+                )
+
+            assertTrue(orchestrator.diagnose(listOf("youtube.com")).isEmpty())
+        }
+
+    @Test
+    fun `diagnose rethrows cancellation`() =
+        runTest {
+            val orchestrator =
+                orchestrator(
+                    diagnosisRunner = ThrowingBlockcheckDiagnosisRunner(CancellationException("cancel")),
+                    results = emptyList(),
+                )
+
+            try {
+                orchestrator.diagnose(listOf("youtube.com"))
+                fail("expected CancellationException")
+            } catch (expected: CancellationException) {
+                assertEquals("cancel", expected.message)
+            }
+        }
+
+    private fun orchestrator(
+        probeService: StrategyProbeService? = null,
+        candidateProvider: StrategyProbeCandidateProvider? = null,
+        candidates: List<StrategyProbeCandidate> = orchestratorCandidates(),
+        diagnosisRunner: BlockcheckDiagnosisRunner = FakeBlockcheckDiagnosisRunner(),
+        results: List<StrategyProbeResult>,
+    ): BlockcheckProbeOrchestrator =
+        BlockcheckProbeOrchestrator(
+            probeService = probeService ?: FakeStrategyProbeService(results),
+            candidateProvider = candidateProvider ?: FakeStrategyProbeCandidateProvider(candidates),
+            diagnosisRunner = diagnosisRunner,
+        )
+}
+
+private fun orchestratorCandidates(): List<StrategyProbeCandidate> =
+    listOf(
+        StrategyProbeCandidate("split", "Split", "[tcp]\nsplit auto(balanced)"),
+        StrategyProbeCandidate("fake", "Fake packet", "[tcp]\nfake auto(host)"),
+    )
+
+private fun orchestratorSiteDiagnosis(
+    domain: String,
+    layer: BlockLayer,
+    bypassClass: BypassStrategyClass,
+): BlockcheckSiteDiagnosis =
+    BlockcheckSiteDiagnosis(
+        domain = domain,
+        diagnosis =
+            BlockLayerDiagnosis(
+                layer = layer,
+                bypassClass = bypassClass,
+                confidence = EvidenceConfidence.HIGH,
+                reasonCode = "test",
+            ),
+    )
+
+private fun orchestratorProbeResult(
+    strategyId: String,
+    success: Boolean,
+    latencyMs: Long,
+    dnsTampered: Boolean = false,
+): StrategyProbeResult =
+    StrategyProbeResult(
+        strategyId = strategyId,
+        strategyLabel = if (strategyId == "fake") "Fake packet" else strategyId,
+        domain = "youtube.com",
+        success = success,
+        latencyMs = latencyMs,
+        failureKind = if (!success && !dnsTampered) StrategyProbeFailureKind.ConnectionFailed else null,
+        dnsTampered = dnsTampered,
+    )
+
+private class ThrowingBlockcheckDiagnosisRunner(
+    private val error: Throwable,
+) : BlockcheckDiagnosisRunner {
+    override suspend fun diagnose(domains: List<String>): List<BlockcheckSiteDiagnosis> = throw error
+}
+
+private class CancellingStrategyProbeService : StrategyProbeService {
+    override fun run(config: StrategyProbeConfig): Flow<StrategyProbeResult> =
+        flow {
+            throw CancellationException("cancelled mid-stream")
+        }
+}

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckRecommendationRepositoryTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckRecommendationRepositoryTest.kt
@@ -1,0 +1,121 @@
+package com.poyka.ripdpi.ui.screens.blockcheck
+
+import com.poyka.ripdpi.data.TcpChainStepKind
+import com.poyka.ripdpi.data.effectiveTcpChainSteps
+import com.poyka.ripdpi.diagnostics.StrategyProbeCandidate
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BlockcheckRecommendationRepositoryTest {
+    @Test
+    fun `applyStrategy writes winner config and reloads`() =
+        runTest {
+            val settings = FakeAppSettingsRepository()
+            val reloader = FakeBlockcheckStrategyReloader()
+            val repository = DefaultBlockcheckRecommendationRepository(settings, reloader)
+
+            val outcome =
+                repository.applyStrategy(
+                    strategyId = "fake",
+                    candidates = candidates(),
+                )
+
+            assertEquals(BlockcheckApplyOutcome.Applied, outcome)
+            assertEquals(1, reloader.reloadCount)
+            val appliedStep =
+                settings
+                    .snapshot()
+                    .effectiveTcpChainSteps()
+                    .single()
+            assertEquals(TcpChainStepKind.Fake, appliedStep.kind)
+        }
+
+    @Test
+    fun `applyStrategy sets chain steps from configDsl when present`() =
+        runTest {
+            val settings = FakeAppSettingsRepository()
+            val reloader = FakeBlockcheckStrategyReloader()
+            val repository = DefaultBlockcheckRecommendationRepository(settings, reloader)
+
+            repository.applyStrategy(
+                strategyId = "fake",
+                candidates = listOf(StrategyProbeCandidate("fake", "Fake packet", "[tcp]\nfake auto(host)")),
+            )
+
+            // configDsl is parsed into the persisted TCP chain (setRawStrategyChainDsl).
+            val steps = settings.snapshot().effectiveTcpChainSteps()
+            assertTrue(steps.any { it.kind == TcpChainStepKind.Fake })
+        }
+
+    @Test
+    fun `applyStrategy returns Unregistered without touching settings or reloader`() =
+        runTest {
+            val settings = FakeAppSettingsRepository()
+            val reloader = FakeBlockcheckStrategyReloader()
+            val repository = DefaultBlockcheckRecommendationRepository(settings, reloader)
+            val before = settings.snapshot()
+
+            val outcome =
+                repository.applyStrategy(
+                    strategyId = "missing",
+                    candidates = candidates(),
+                )
+
+            assertEquals(BlockcheckApplyOutcome.Unregistered, outcome)
+            assertEquals(0, reloader.reloadCount)
+            assertEquals(before, settings.snapshot())
+        }
+
+    @Test
+    fun `applyStrategy returns ReloadFailed when reload reports an error`() =
+        runTest {
+            val settings = FakeAppSettingsRepository()
+            val reloader = FakeBlockcheckStrategyReloader(reloadError = "native reload failed")
+            val repository = DefaultBlockcheckRecommendationRepository(settings, reloader)
+
+            val outcome =
+                repository.applyStrategy(
+                    strategyId = "fake",
+                    candidates = candidates(),
+                )
+
+            assertEquals(BlockcheckApplyOutcome.ReloadFailed("native reload failed"), outcome)
+            assertEquals(1, reloader.reloadCount)
+        }
+
+    @Test
+    fun `applyStrategy writes class-matched recommended candidate`() =
+        runTest {
+            val settings = FakeAppSettingsRepository()
+            val reloader = FakeBlockcheckStrategyReloader()
+            val repository = DefaultBlockcheckRecommendationRepository(settings, reloader)
+
+            val outcome =
+                repository.applyStrategy(
+                    strategyId = "tlsrec_split",
+                    candidates =
+                        listOf(
+                            StrategyProbeCandidate("fake", "Fake packet", "[tcp]\nfake auto(host)"),
+                            StrategyProbeCandidate(
+                                "tlsrec_split",
+                                "TLS record split",
+                                "[tcp]\ntlsrec sniext+1\nsplit host",
+                            ),
+                        ),
+                )
+
+            assertEquals(BlockcheckApplyOutcome.Applied, outcome)
+            val steps = settings.snapshot().effectiveTcpChainSteps()
+            assertTrue(steps.any { it.kind == TcpChainStepKind.TlsRec })
+        }
+}
+
+private fun candidates(): List<StrategyProbeCandidate> =
+    listOf(
+        StrategyProbeCandidate("split", "Split", "[tcp]\nsplit auto(balanced)"),
+        StrategyProbeCandidate("fake", "Fake packet", "[tcp]\nfake auto(host)"),
+    )

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckTestFakes.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckTestFakes.kt
@@ -1,0 +1,113 @@
+package com.poyka.ripdpi.ui.screens.blockcheck
+
+import com.poyka.ripdpi.core.detection.BlockLayer
+import com.poyka.ripdpi.core.detection.BlockLayerDiagnosis
+import com.poyka.ripdpi.core.detection.BypassStrategyClass
+import com.poyka.ripdpi.core.detection.EvidenceConfidence
+import com.poyka.ripdpi.data.AppSettingsRepository
+import com.poyka.ripdpi.diagnostics.StrategyProbeCandidate
+import com.poyka.ripdpi.diagnostics.StrategyProbeCandidateProvider
+import com.poyka.ripdpi.diagnostics.StrategyProbeConfig
+import com.poyka.ripdpi.diagnostics.StrategyProbeResult
+import com.poyka.ripdpi.diagnostics.StrategyProbeService
+import com.poyka.ripdpi.proto.AppSettings
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+
+internal class FakeBlockcheckDiagnosisRunner(
+    private val diagnoses: List<BlockcheckSiteDiagnosis> = emptyList(),
+) : BlockcheckDiagnosisRunner {
+    override suspend fun diagnose(domains: List<String>): List<BlockcheckSiteDiagnosis> = diagnoses
+}
+
+internal class FakeStrategyProbeService(
+    private val results: List<StrategyProbeResult>,
+) : StrategyProbeService {
+    override fun run(config: StrategyProbeConfig): Flow<StrategyProbeResult> =
+        flow {
+            results.forEach { emit(it) }
+        }
+}
+
+internal class StreamingStrategyProbeService : StrategyProbeService {
+    private val results = MutableSharedFlow<StrategyProbeResult>(extraBufferCapacity = 8)
+
+    override fun run(config: StrategyProbeConfig): Flow<StrategyProbeResult> = results
+
+    fun emit(result: StrategyProbeResult): Boolean = results.tryEmit(result)
+}
+
+internal class FakeStrategyProbeCandidateProvider(
+    private val candidates: List<StrategyProbeCandidate> = defaultBlockcheckCandidates(),
+) : StrategyProbeCandidateProvider {
+    override suspend fun listCandidates(): List<StrategyProbeCandidate> = candidates
+}
+
+internal class FakeAppSettingsRepository : AppSettingsRepository {
+    private val state = MutableStateFlow(AppSettings.getDefaultInstance())
+
+    override val settings: Flow<AppSettings> = state
+
+    override suspend fun snapshot(): AppSettings = state.value
+
+    override suspend fun update(transform: AppSettings.Builder.() -> Unit) {
+        state.value =
+            state
+                .value
+                .toBuilder()
+                .apply(transform)
+                .build()
+    }
+
+    override suspend fun replace(settings: AppSettings) {
+        state.value = settings
+    }
+}
+
+internal class FakeBlockcheckStrategyReloader(
+    private val reloadError: String? = null,
+) : BlockcheckStrategyReloader {
+    var reloadCount = 0
+
+    override fun reloadConfig(): String? {
+        reloadCount += 1
+        return reloadError
+    }
+}
+
+internal fun defaultBlockcheckCandidates(): List<StrategyProbeCandidate> =
+    listOf(
+        StrategyProbeCandidate("split", "Split", "[tcp]\nsplit auto(balanced)"),
+        StrategyProbeCandidate("fake", "Fake packet", "[tcp]\nfake auto(host)"),
+    )
+
+internal fun blockcheckDiagnosis(
+    domain: String,
+    layer: BlockLayer,
+    bypassClass: BypassStrategyClass,
+): BlockcheckSiteDiagnosis =
+    BlockcheckSiteDiagnosis(
+        domain = domain,
+        diagnosis =
+            BlockLayerDiagnosis(
+                layer = layer,
+                bypassClass = bypassClass,
+                confidence = EvidenceConfidence.HIGH,
+                reasonCode = "test",
+            ),
+    )
+
+internal fun blockcheckProbeResult(
+    strategyId: String,
+    success: Boolean,
+    latencyMs: Long,
+): StrategyProbeResult =
+    StrategyProbeResult(
+        strategyId = strategyId,
+        strategyLabel = if (strategyId == "fake") "Fake packet" else "Split",
+        domain = "youtube.com",
+        success = success,
+        latencyMs = latencyMs,
+    )

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckViewModelTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/blockcheck/BlockcheckViewModelTest.kt
@@ -2,25 +2,16 @@ package com.poyka.ripdpi.ui.screens.blockcheck
 
 import com.poyka.ripdpi.R
 import com.poyka.ripdpi.core.detection.BlockLayer
-import com.poyka.ripdpi.core.detection.BlockLayerDiagnosis
 import com.poyka.ripdpi.core.detection.BypassStrategyClass
-import com.poyka.ripdpi.core.detection.EvidenceConfidence
-import com.poyka.ripdpi.data.AppSettingsRepository
 import com.poyka.ripdpi.data.TcpChainStepKind
 import com.poyka.ripdpi.data.effectiveTcpChainSteps
 import com.poyka.ripdpi.diagnostics.StrategyProbeCandidate
 import com.poyka.ripdpi.diagnostics.StrategyProbeCandidateProvider
-import com.poyka.ripdpi.diagnostics.StrategyProbeConfig
 import com.poyka.ripdpi.diagnostics.StrategyProbeResult
 import com.poyka.ripdpi.diagnostics.StrategyProbeService
 import com.poyka.ripdpi.diagnostics.summarizeStrategyProbeResults
-import com.poyka.ripdpi.proto.AppSettings
 import com.poyka.ripdpi.util.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -289,109 +280,30 @@ class BlockcheckViewModelTest {
         candidateProvider: StrategyProbeCandidateProvider = FakeStrategyProbeCandidateProvider(),
         diagnosisRunner: BlockcheckDiagnosisRunner = FakeBlockcheckDiagnosisRunner(),
         results: List<StrategyProbeResult>,
-    ): BlockcheckViewModel {
-        val viewModel =
-            BlockcheckViewModel(
-                probeService = probeService ?: FakeStrategyProbeService(results),
-                candidateProvider = candidateProvider,
-                appSettingsRepository = repository,
-                diagnosisRunner = diagnosisRunner,
-            )
-        viewModel.strategyReloader = reloader
-        return viewModel
-    }
+    ): BlockcheckViewModel =
+        BlockcheckViewModel(
+            orchestrator =
+                BlockcheckProbeOrchestrator(
+                    probeService = probeService ?: FakeStrategyProbeService(results),
+                    candidateProvider = candidateProvider,
+                    diagnosisRunner = diagnosisRunner,
+                ),
+            recommendationRepository =
+                DefaultBlockcheckRecommendationRepository(
+                    appSettingsRepository = repository,
+                    reloader = reloader,
+                ),
+        )
 }
-
-private class FakeBlockcheckDiagnosisRunner(
-    private val diagnoses: List<BlockcheckSiteDiagnosis> = emptyList(),
-) : BlockcheckDiagnosisRunner {
-    override suspend fun diagnose(domains: List<String>): List<BlockcheckSiteDiagnosis> = diagnoses
-}
-
-private class FakeStrategyProbeService(
-    private val results: List<StrategyProbeResult>,
-) : StrategyProbeService {
-    override fun run(config: StrategyProbeConfig): Flow<StrategyProbeResult> =
-        flow {
-            results.forEach { emit(it) }
-        }
-}
-
-private class StreamingStrategyProbeService : StrategyProbeService {
-    private val results = MutableSharedFlow<StrategyProbeResult>(extraBufferCapacity = 8)
-
-    override fun run(config: StrategyProbeConfig): Flow<StrategyProbeResult> = results
-
-    fun emit(result: StrategyProbeResult): Boolean = results.tryEmit(result)
-}
-
-private class FakeStrategyProbeCandidateProvider(
-    private val candidates: List<StrategyProbeCandidate> = defaultCandidates(),
-) : StrategyProbeCandidateProvider {
-    override suspend fun listCandidates(): List<StrategyProbeCandidate> = candidates
-}
-
-private fun defaultCandidates(): List<StrategyProbeCandidate> =
-    listOf(
-        StrategyProbeCandidate("split", "Split", "[tcp]\nsplit auto(balanced)"),
-        StrategyProbeCandidate("fake", "Fake packet", "[tcp]\nfake auto(host)"),
-    )
 
 private fun diagnosis(
     domain: String,
     layer: BlockLayer,
     bypassClass: BypassStrategyClass,
-): BlockcheckSiteDiagnosis =
-    BlockcheckSiteDiagnosis(
-        domain = domain,
-        diagnosis =
-            BlockLayerDiagnosis(
-                layer = layer,
-                bypassClass = bypassClass,
-                confidence = EvidenceConfidence.HIGH,
-                reasonCode = "test",
-            ),
-    )
-
-private class FakeAppSettingsRepository : AppSettingsRepository {
-    private val state = MutableStateFlow(AppSettings.getDefaultInstance())
-
-    override val settings: Flow<AppSettings> = state
-
-    override suspend fun snapshot(): AppSettings = state.value
-
-    override suspend fun update(transform: AppSettings.Builder.() -> Unit) {
-        state.value =
-            state
-                .value
-                .toBuilder()
-                .apply(transform)
-                .build()
-    }
-
-    override suspend fun replace(settings: AppSettings) {
-        state.value = settings
-    }
-}
-
-private class FakeBlockcheckStrategyReloader : BlockcheckStrategyReloader {
-    var reloadCount = 0
-
-    override fun reloadConfig(): String? {
-        reloadCount += 1
-        return null
-    }
-}
+): BlockcheckSiteDiagnosis = blockcheckDiagnosis(domain = domain, layer = layer, bypassClass = bypassClass)
 
 private fun result(
     strategyId: String,
     success: Boolean,
     latencyMs: Long,
-): StrategyProbeResult =
-    StrategyProbeResult(
-        strategyId = strategyId,
-        strategyLabel = if (strategyId == "fake") "Fake packet" else "Split",
-        domain = "youtube.com",
-        success = success,
-        latencyMs = latencyMs,
-    )
+): StrategyProbeResult = blockcheckProbeResult(strategyId = strategyId, success = success, latencyMs = latencyMs)

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionAuxStateOwnerTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionAuxStateOwnerTest.kt
@@ -1,0 +1,361 @@
+package com.poyka.ripdpi.ui.screens.detection
+
+import com.poyka.ripdpi.core.detection.Verdict
+import com.poyka.ripdpi.core.detection.community.CommunityStats
+import com.poyka.ripdpi.core.detection.community.CommunityStatsRefreshResult
+import com.poyka.ripdpi.util.MainDispatcherRule
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DetectionAuxStateOwnerTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val testScope = CoroutineScope(UnconfinedTestDispatcher())
+
+    @After
+    fun tearDown() {
+        testScope.cancel()
+    }
+
+    private fun reducer(
+        initial: DetectionCheckUiState = DetectionCheckUiState(),
+    ): Pair<MutableStateFlow<DetectionCheckUiState>, DetectionCheckStateReducer> {
+        val flow = MutableStateFlow(initial)
+        return flow to DetectionCheckStateReducer(flow)
+    }
+
+    @Test
+    fun `observeDetectionSettings folds flags and reformats existing result`() =
+        runTest {
+            val result = detectionResult(Verdict.NOT_DETECTED)
+            val (flow, red) = reducer(DetectionCheckUiState(result = result))
+            val owner =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red,
+                    appSettingsRepository =
+                        FakeDetectionAppSettingsRepository(
+                            com.poyka.ripdpi.proto.AppSettings
+                                .getDefaultInstance()
+                                .toBuilder()
+                                .apply {
+                                    detectionCheckPrivacyModeEnabled = true
+                                    detectionCheckDebugModeEnabled = true
+                                    detectionCheckCdnPullingEnabled = true
+                                }.build(),
+                        ),
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(),
+                    historyStore = FakeDetectionHistoryRepository(),
+                    communityStatsRepository = FakeCommunityStatsRepository(),
+                    detectionCheckPreferences = FakeDetectionCheckPreferenceStore(),
+                )
+
+            owner.observeDetectionSettings()
+            advanceUntilIdle()
+
+            assertTrue(flow.value.privacyModeEnabled)
+            assertTrue(flow.value.debugModeEnabled)
+            assertTrue(flow.value.cdnPullingEnabled)
+            assertTrue(flow.value.reportText != null)
+            assertTrue(flow.value.debugReportText != null)
+        }
+
+    @Test
+    fun `observeDetectionSettings leaves debugReport null when no result`() =
+        runTest {
+            val (flow, red) = reducer()
+            val owner =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red,
+                    appSettingsRepository = FakeDetectionAppSettingsRepository(),
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(),
+                    historyStore = FakeDetectionHistoryRepository(),
+                    communityStatsRepository = FakeCommunityStatsRepository(),
+                    detectionCheckPreferences = FakeDetectionCheckPreferenceStore(),
+                )
+
+            owner.observeDetectionSettings()
+            advanceUntilIdle()
+
+            assertNull(flow.value.reportText)
+            assertNull(flow.value.debugReportText)
+        }
+
+    @Test
+    fun `loadCommunityState only writes when stats non-null`() =
+        runTest {
+            val (flow, red) = reducer()
+            val withNull =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red,
+                    appSettingsRepository = FakeDetectionAppSettingsRepository(),
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(),
+                    historyStore = FakeDetectionHistoryRepository(),
+                    communityStatsRepository = FakeCommunityStatsRepository(cachedOrLocal = null),
+                    detectionCheckPreferences = FakeDetectionCheckPreferenceStore(),
+                )
+            withNull.loadCommunityState()
+            advanceUntilIdle()
+            assertNull(flow.value.communityStats)
+
+            val (flow2, red2) = reducer()
+            val withStats =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red2,
+                    appSettingsRepository = FakeDetectionAppSettingsRepository(),
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(),
+                    historyStore = FakeDetectionHistoryRepository(),
+                    communityStatsRepository =
+                        FakeCommunityStatsRepository(cachedOrLocal = CommunityStats(totalReports = 3)),
+                    detectionCheckPreferences = FakeDetectionCheckPreferenceStore(),
+                )
+            withStats.loadCommunityState()
+            advanceUntilIdle()
+            assertEquals(3, flow2.value.communityStats?.totalReports)
+        }
+
+    @Test
+    fun `refreshCommunityStats applies local then remote override and clears loading`() =
+        runTest {
+            val (flow, red) = reducer()
+            val owner =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red,
+                    appSettingsRepository = FakeDetectionAppSettingsRepository(),
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(),
+                    historyStore = FakeDetectionHistoryRepository(),
+                    communityStatsRepository =
+                        FakeCommunityStatsRepository(
+                            refreshResult =
+                                CommunityStatsRefreshResult(
+                                    localStats = CommunityStats(totalReports = 1),
+                                    remoteStats = CommunityStats(totalReports = 9),
+                                    remoteError = null,
+                                ),
+                        ),
+                    detectionCheckPreferences = FakeDetectionCheckPreferenceStore(),
+                )
+
+            owner.refreshCommunityStats()
+            advanceUntilIdle()
+
+            assertEquals(9, flow.value.communityStats?.totalReports)
+            assertFalse(flow.value.communityStatsLoading)
+            assertNull(flow.value.communityStatsError)
+        }
+
+    @Test
+    fun `refreshCommunityStats sets error only when no existing stats on null remote`() =
+        runTest {
+            val (flow, red) =
+                reducer(DetectionCheckUiState(communityStats = CommunityStats(totalReports = 4)))
+            val owner =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red,
+                    appSettingsRepository = FakeDetectionAppSettingsRepository(),
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(),
+                    historyStore = FakeDetectionHistoryRepository(),
+                    communityStatsRepository =
+                        FakeCommunityStatsRepository(
+                            refreshResult =
+                                CommunityStatsRefreshResult(
+                                    localStats = CommunityStats(totalReports = 4),
+                                    remoteStats = null,
+                                    remoteError = IllegalStateException("boom"),
+                                ),
+                        ),
+                    detectionCheckPreferences = FakeDetectionCheckPreferenceStore(),
+                )
+
+            owner.refreshCommunityStats()
+            advanceUntilIdle()
+
+            assertNull(flow.value.communityStatsError)
+            assertFalse(flow.value.communityStatsLoading)
+        }
+
+    @Test
+    fun `refreshCommunityStats exception path sets error only when no existing stats`() =
+        runTest {
+            val (flow, red) = reducer()
+            val owner =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red,
+                    appSettingsRepository = FakeDetectionAppSettingsRepository(),
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(),
+                    historyStore = FakeDetectionHistoryRepository(),
+                    communityStatsRepository =
+                        FakeCommunityStatsRepository(refreshThrows = IllegalStateException("io")),
+                    detectionCheckPreferences = FakeDetectionCheckPreferenceStore(),
+                )
+
+            owner.refreshCommunityStats()
+            advanceUntilIdle()
+
+            assertEquals("io", flow.value.communityStatsError)
+            assertFalse(flow.value.communityStatsLoading)
+        }
+
+    @Test
+    fun `refreshCommunityStats rethrows cancellation`() =
+        runTest {
+            val (flow, red) = reducer()
+            val owner =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red,
+                    appSettingsRepository = FakeDetectionAppSettingsRepository(),
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(),
+                    historyStore = FakeDetectionHistoryRepository(),
+                    communityStatsRepository =
+                        FakeCommunityStatsRepository(refreshThrows = CancellationException("cancel")),
+                    detectionCheckPreferences = FakeDetectionCheckPreferenceStore(),
+                )
+
+            owner.refreshCommunityStats()
+            advanceUntilIdle()
+
+            // Cancellation must not be converted into an error state.
+            assertNull(flow.value.communityStatsError)
+        }
+
+    @Test
+    fun `dismissOnboarding marks shown and clears flag`() =
+        runTest {
+            val (flow, red) = reducer(DetectionCheckUiState(showOnboarding = true))
+            val prefs = FakeDetectionCheckPreferenceStore()
+            val owner =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red,
+                    appSettingsRepository = FakeDetectionAppSettingsRepository(),
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(),
+                    historyStore = FakeDetectionHistoryRepository(),
+                    communityStatsRepository = FakeCommunityStatsRepository(),
+                    detectionCheckPreferences = prefs,
+                )
+
+            owner.dismissOnboarding()
+
+            assertEquals(1, prefs.markOnboardingShownCount)
+            assertFalse(flow.value.showOnboarding)
+        }
+
+    @Test
+    fun `saveToHistory uses fingerprint scope key and reloads history`() =
+        runTest {
+            val (_, red) = reducer()
+            val history = FakeDetectionHistoryRepository()
+            val owner =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red,
+                    appSettingsRepository = FakeDetectionAppSettingsRepository(),
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(wifiFingerprint()),
+                    historyStore = history,
+                    communityStatsRepository = FakeCommunityStatsRepository(),
+                    detectionCheckPreferences = FakeDetectionCheckPreferenceStore(),
+                )
+
+            owner.saveToHistory(detectionResult(Verdict.NOT_DETECTED), score = 80)
+            advanceUntilIdle()
+
+            assertEquals(1, history.saved.size)
+            assertEquals("wifi/wifi", history.saved.first().networkSummary)
+            assertEquals(80, history.saved.first().stealthScore)
+            assertTrue(history.loadLatestCount >= 1)
+        }
+
+    @Test
+    fun `saveToHistory falls back to Unknown summary when no fingerprint`() =
+        runTest {
+            val (_, red) = reducer()
+            val history = FakeDetectionHistoryRepository()
+            val owner =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red,
+                    appSettingsRepository = FakeDetectionAppSettingsRepository(),
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(null),
+                    historyStore = history,
+                    communityStatsRepository = FakeCommunityStatsRepository(),
+                    detectionCheckPreferences = FakeDetectionCheckPreferenceStore(),
+                )
+
+            owner.saveToHistory(detectionResult(Verdict.NOT_DETECTED), score = 10)
+            advanceUntilIdle()
+
+            assertEquals("unknown", history.saved.first().networkFingerprint)
+            assertEquals("Unknown", history.saved.first().networkSummary)
+        }
+
+    @Test
+    fun `applyAllFixes clears suggested fixes`() =
+        runTest {
+            val (flow, red) =
+                reducer(DetectionCheckUiState(suggestedFixes = emptyList()))
+            val owner =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red,
+                    appSettingsRepository = FakeDetectionAppSettingsRepository(),
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(),
+                    historyStore = FakeDetectionHistoryRepository(),
+                    communityStatsRepository = FakeCommunityStatsRepository(),
+                    detectionCheckPreferences = FakeDetectionCheckPreferenceStore(),
+                )
+
+            owner.applyAllFixes()
+            advanceUntilIdle()
+
+            assertTrue(flow.value.suggestedFixes.isEmpty())
+        }
+
+    @Test
+    fun `set lambdas write the matching settings field`() =
+        runTest {
+            val (_, red) = reducer()
+            val settingsRepo = FakeDetectionAppSettingsRepository()
+            val owner =
+                DetectionAuxStateOwner(
+                    scope = testScope,
+                    reducer = red,
+                    appSettingsRepository = settingsRepo,
+                    networkFingerprintProvider = FakeNetworkFingerprintProvider(),
+                    historyStore = FakeDetectionHistoryRepository(),
+                    communityStatsRepository = FakeCommunityStatsRepository(),
+                    detectionCheckPreferences = FakeDetectionCheckPreferenceStore(),
+                )
+
+            owner.setPrivacyModeEnabled(true)
+            owner.setCdnPullingEnabled(true)
+            owner.setDebugModeEnabled(true)
+            advanceUntilIdle()
+
+            val snapshot = settingsRepo.snapshot()
+            assertTrue(snapshot.detectionCheckPrivacyModeEnabled)
+            assertTrue(snapshot.detectionCheckCdnPullingEnabled)
+            assertTrue(snapshot.detectionCheckDebugModeEnabled)
+        }
+}

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionCheckTestFakes.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionCheckTestFakes.kt
@@ -1,0 +1,165 @@
+package com.poyka.ripdpi.ui.screens.detection
+
+import com.poyka.ripdpi.core.detection.BypassResult
+import com.poyka.ripdpi.core.detection.CategoryResult
+import com.poyka.ripdpi.core.detection.DetectionCheckResult
+import com.poyka.ripdpi.core.detection.DetectionHistoryEntry
+import com.poyka.ripdpi.core.detection.DetectionHistoryRepository
+import com.poyka.ripdpi.core.detection.Verdict
+import com.poyka.ripdpi.core.detection.community.CommunityStats
+import com.poyka.ripdpi.core.detection.community.CommunityStatsRefreshResult
+import com.poyka.ripdpi.core.detection.community.CommunityStatsRepository
+import com.poyka.ripdpi.data.AppSettingsRepository
+import com.poyka.ripdpi.data.NetworkFingerprint
+import com.poyka.ripdpi.data.NetworkFingerprintProvider
+import com.poyka.ripdpi.platform.StringResolver
+import com.poyka.ripdpi.proto.AppSettings
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+internal class FakeDetectionAppSettingsRepository(
+    initial: AppSettings = AppSettings.getDefaultInstance(),
+) : AppSettingsRepository {
+    private val state = MutableStateFlow(initial)
+
+    override val settings: Flow<AppSettings> = state
+
+    override suspend fun snapshot(): AppSettings = state.value
+
+    override suspend fun update(transform: AppSettings.Builder.() -> Unit) {
+        state.value =
+            state.value
+                .toBuilder()
+                .apply(transform)
+                .build()
+    }
+
+    override suspend fun replace(settings: AppSettings) {
+        state.value = settings
+    }
+}
+
+internal class FakeDetectionHistoryRepository(
+    private val latest: List<DetectionHistoryEntry> = emptyList(),
+) : DetectionHistoryRepository {
+    val saved = mutableListOf<DetectionHistoryEntry>()
+    var loadLatestCount = 0
+
+    override suspend fun save(entry: DetectionHistoryEntry) {
+        saved += entry
+    }
+
+    override suspend fun loadLatest(count: Int): List<DetectionHistoryEntry> {
+        loadLatestCount += 1
+        return latest
+    }
+
+    override suspend fun findByFingerprint(fingerprint: String): DetectionHistoryEntry? = null
+
+    override suspend fun clear() = Unit
+}
+
+internal class FakeCommunityStatsRepository(
+    private val cachedOrLocal: CommunityStats? = null,
+    private val refreshResult: CommunityStatsRefreshResult? = null,
+    private val refreshThrows: Throwable? = null,
+) : CommunityStatsRepository {
+    var refreshCount = 0
+
+    override suspend fun loadCachedOrLocal(): CommunityStats? = cachedOrLocal
+
+    override suspend fun refresh(): CommunityStatsRefreshResult {
+        refreshCount += 1
+        refreshThrows?.let { throw it }
+        return refreshResult ?: CommunityStatsRefreshResult(
+            localStats = CommunityStats(totalReports = 0),
+            remoteStats = null,
+            remoteError = null,
+        )
+    }
+}
+
+internal class FakeNetworkFingerprintProvider(
+    private val fingerprint: NetworkFingerprint? = null,
+) : NetworkFingerprintProvider {
+    var captureCount = 0
+
+    override fun capture(): NetworkFingerprint? {
+        captureCount += 1
+        return fingerprint
+    }
+}
+
+internal class FakeDetectionPermissionChecker(
+    private val granted: Set<String> = emptySet(),
+) : DetectionPermissionChecker {
+    override fun isPermissionGranted(permission: String): Boolean = permission in granted
+}
+
+internal class FakeDetectionCheckPreferenceStore(
+    private var onboardingShown: Boolean = false,
+    requestedPermissions: Set<String> = emptySet(),
+) : DetectionCheckPreferenceStore {
+    val requested = requestedPermissions.toMutableSet()
+    var markOnboardingShownCount = 0
+
+    override fun wasOnboardingShown(): Boolean = onboardingShown
+
+    override fun markOnboardingShown() {
+        markOnboardingShownCount += 1
+        onboardingShown = true
+    }
+
+    override fun wasPermissionRequested(permission: String): Boolean = permission in requested
+
+    override fun markPermissionsRequested(permissions: Array<String>) {
+        requested += permissions
+    }
+}
+
+internal class RecordingStringResolver : StringResolver {
+    override fun getString(
+        resId: Int,
+        vararg formatArgs: Any,
+    ): String = "string:$resId"
+}
+
+internal fun detectionResult(verdict: Verdict = Verdict.NOT_DETECTED): DetectionCheckResult =
+    DetectionCheckResult(
+        geoIp = emptyCategory("GeoIP"),
+        directSigns = emptyCategory("Direct"),
+        indirectSigns = emptyCategory("Indirect"),
+        locationSignals = emptyCategory("Location"),
+        bypassResult =
+            BypassResult(
+                proxyEndpoint = null,
+                directIp = null,
+                proxyIp = null,
+                xrayApiScanResult = null,
+                findings = emptyList(),
+                detected = false,
+            ),
+        verdict = verdict,
+    )
+
+private fun emptyCategory(name: String): CategoryResult =
+    CategoryResult(
+        name = name,
+        detected = false,
+        findings = emptyList(),
+    )
+
+internal fun wifiFingerprint(): NetworkFingerprint =
+    NetworkFingerprint(
+        transport = "wifi",
+        networkValidated = true,
+        captivePortalDetected = false,
+        privateDnsMode = "system",
+        dnsServers = listOf("1.1.1.1"),
+        wifi =
+            com.poyka.ripdpi.data.WifiNetworkIdentityTuple(
+                ssid = "ssid",
+                bssid = "aa:bb:cc:dd:ee:ff",
+                gateway = "192.168.0.1",
+            ),
+    )

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionPermissionStateOwnerTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionPermissionStateOwnerTest.kt
@@ -1,0 +1,93 @@
+package com.poyka.ripdpi.ui.screens.detection
+
+import android.Manifest
+import com.poyka.ripdpi.core.detection.DetectionPermissionPlanner
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class DetectionPermissionStateOwnerTest {
+    private class Harness(
+        val flow: MutableStateFlow<DetectionCheckUiState>,
+        val prefs: FakeDetectionCheckPreferenceStore,
+        val owner: DetectionPermissionStateOwner,
+    )
+
+    private fun harness(
+        granted: Set<String> = emptySet(),
+        requested: Set<String> = emptySet(),
+    ): Harness {
+        val flow = MutableStateFlow(DetectionCheckUiState())
+        val prefs = FakeDetectionCheckPreferenceStore(requestedPermissions = requested)
+        val stateOwner =
+            DetectionPermissionStateOwner(
+                reducer = DetectionCheckStateReducer(flow),
+                permissionChecker = FakeDetectionPermissionChecker(granted = granted),
+                preferences = prefs,
+            )
+        return Harness(flow, prefs, stateOwner)
+    }
+
+    @Test
+    @Config(sdk = [33])
+    fun `requiredPermissions includes nearby wifi on tiramisu and above`() {
+        val perms = DetectionPermissionStateOwner.requiredPermissions().toList()
+        assertTrue(Manifest.permission.NEARBY_WIFI_DEVICES in perms)
+        assertEquals(3, perms.size)
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `requiredPermissions omits nearby wifi below tiramisu`() {
+        val perms = DetectionPermissionStateOwner.requiredPermissions().toList()
+        assertFalse(Manifest.permission.NEARBY_WIFI_DEVICES in perms)
+        assertEquals(2, perms.size)
+    }
+
+    @Test
+    @Config(sdk = [33])
+    fun `refreshPermissionState reports missing for ungranted permissions`() {
+        val h = harness(granted = emptySet())
+        h.owner.refreshPermissionState()
+        assertEquals(
+            DetectionPermissionStateOwner.requiredPermissions().toSet(),
+            h.flow.value.missingPermissions
+                .toSet(),
+        )
+        assertTrue(h.flow.value.permissionAction != DetectionPermissionPlanner.Action.NONE)
+    }
+
+    @Test
+    @Config(sdk = [33])
+    fun `refreshPermissionState reports none missing when all granted`() {
+        val granted = DetectionPermissionStateOwner.requiredPermissions().toSet()
+        val h = harness(granted = granted)
+        h.owner.refreshPermissionState()
+        assertTrue(
+            h.flow.value.missingPermissions
+                .isEmpty(),
+        )
+        assertEquals(DetectionPermissionPlanner.Action.NONE, h.flow.value.permissionAction)
+    }
+
+    @Test
+    @Config(sdk = [33])
+    fun `onPermissionsResult marks all requested then refreshes`() {
+        val granted = DetectionPermissionStateOwner.requiredPermissions().toSet()
+        val h = harness(granted = granted)
+        h.owner.onPermissionsResult()
+        assertEquals(granted, h.prefs.requested)
+        assertTrue(
+            h.flow.value.missingPermissions
+                .isEmpty(),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionResultPresenterTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionResultPresenterTest.kt
@@ -1,0 +1,175 @@
+package com.poyka.ripdpi.ui.screens.detection
+
+import com.poyka.ripdpi.core.detection.BypassPortRange
+import com.poyka.ripdpi.core.detection.Verdict
+import com.poyka.ripdpi.proto.AppSettings
+import com.poyka.ripdpi.services.RoutingProtectionCatalogSnapshot
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DetectionResultPresenterTest {
+    private fun settings(block: AppSettings.Builder.() -> Unit = {}): AppSettings =
+        AppSettings
+            .getDefaultInstance()
+            .toBuilder()
+            .apply(block)
+            .build()
+
+    @Test
+    fun `runnerConfig sets ownProxyPort only when proxyPort positive`() {
+        assertNull(DetectionResultPresenter.runnerConfig(settings { proxyPort = 0 }, "pkg").ownProxyPort)
+        assertEquals(
+            8080,
+            DetectionResultPresenter.runnerConfig(settings { proxyPort = 8080 }, "pkg").ownProxyPort,
+        )
+    }
+
+    @Test
+    fun `runnerConfig network feature flags require network requests and per-feature flag`() {
+        val withoutNetwork =
+            settings {
+                detectionCheckNetworkRequestsEnabled = false
+                detectionCheckRttTriangulationEnabled = true
+                detectionCheckCdnPullingEnabled = true
+                detectionCheckCallTransportProbeEnabled = true
+            }
+        DetectionResultPresenter.runnerConfig(withoutNetwork, "pkg").let {
+            assertTrue(!it.includeRttTriangulationCheck)
+            assertTrue(!it.includeCdnPullingCheck)
+            assertTrue(!it.includeCallTransportCheck)
+        }
+
+        val withNetwork =
+            settings {
+                detectionCheckNetworkRequestsEnabled = true
+                detectionCheckRttTriangulationEnabled = true
+                detectionCheckCdnPullingEnabled = true
+                detectionCheckCallTransportProbeEnabled = true
+            }
+        DetectionResultPresenter.runnerConfig(withNetwork, "pkg").let {
+            assertTrue(it.includeRttTriangulationCheck)
+            assertTrue(it.includeCdnPullingCheck)
+            assertTrue(it.includeCallTransportCheck)
+        }
+
+        val networkOnly =
+            settings {
+                detectionCheckNetworkRequestsEnabled = true
+                detectionCheckRttTriangulationEnabled = false
+                detectionCheckCdnPullingEnabled = false
+                detectionCheckCallTransportProbeEnabled = false
+            }
+        DetectionResultPresenter.runnerConfig(networkOnly, "pkg").let {
+            assertTrue(!it.includeRttTriangulationCheck)
+            assertTrue(!it.includeCdnPullingCheck)
+            assertTrue(!it.includeCallTransportCheck)
+        }
+    }
+
+    @Test
+    fun `runnerConfig encryptedDnsEnabled when dnsMode encrypted or resolver doh`() {
+        assertTrue(DetectionResultPresenter.runnerConfig(settings { dnsMode = "encrypted" }, "pkg").encryptedDnsEnabled)
+        assertTrue(
+            DetectionResultPresenter
+                .runnerConfig(settings { detectionCheckDnsResolverMode = "doh" }, "pkg")
+                .encryptedDnsEnabled,
+        )
+        assertTrue(!DetectionResultPresenter.runnerConfig(settings { dnsMode = "plain" }, "pkg").encryptedDnsEnabled)
+    }
+
+    @Test
+    fun `runnerConfig tlsFingerprintProfile defaults to chrome_stable when empty`() {
+        assertEquals(
+            "chrome_stable",
+            DetectionResultPresenter.runnerConfig(settings { tlsFingerprintProfile = "" }, "pkg").tlsFingerprintProfile,
+        )
+        assertEquals(
+            "firefox",
+            DetectionResultPresenter
+                .runnerConfig(settings { tlsFingerprintProfile = "firefox" }, "pkg")
+                .tlsFingerprintProfile,
+        )
+    }
+
+    @Test
+    fun `runnerConfig bypass port range maps each mode`() {
+        fun range(mode: String): BypassPortRange =
+            DetectionResultPresenter
+                .runnerConfig(settings { detectionCheckPortRangeMode = mode }, "pkg")
+                .bypassScanOptions
+                .portRange
+
+        assertEquals(BypassPortRange.Popular, range("popular"))
+        assertEquals(BypassPortRange.Extended, range("extended"))
+        assertEquals(BypassPortRange.Full, range("full"))
+    }
+
+    @Test
+    fun `runnerConfig custom port range uses configured then fallback values`() {
+        val configured =
+            DetectionResultPresenter
+                .runnerConfig(
+                    settings {
+                        detectionCheckPortRangeMode = "custom"
+                        detectionCheckCustomPortStart = 2000
+                        detectionCheckCustomPortEnd = 3000
+                    },
+                    "pkg",
+                ).bypassScanOptions
+                .portRange
+        assertEquals(BypassPortRange.Custom(start = 2000, end = 3000), configured)
+
+        val fallback =
+            DetectionResultPresenter
+                .runnerConfig(settings { detectionCheckPortRangeMode = "custom" }, "pkg")
+                .bypassScanOptions
+                .portRange
+        assertEquals(BypassPortRange.Custom(start = 1080, end = 1090), fallback)
+    }
+
+    @Test
+    fun `debugReportText is null when debug mode off`() {
+        val result = detectionResult()
+        assertNull(
+            DetectionResultPresenter.debugReportText(
+                result = result,
+                settings = settings { detectionCheckDebugModeEnabled = false },
+                privacyModeEnabled = false,
+            ),
+        )
+        assertNotNull(
+            DetectionResultPresenter.debugReportText(
+                result = result,
+                settings = settings { detectionCheckDebugModeEnabled = true },
+                privacyModeEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `recommendations preserve generate-then-routing order`() {
+        val result = detectionResult(Verdict.NOT_DETECTED)
+        val recommendations =
+            DetectionResultPresenter.recommendations(
+                result = result,
+                settings = settings(),
+                snapshot = RoutingProtectionCatalogSnapshot(),
+                stringResolver = RecordingStringResolver(),
+            )
+        // Empty snapshot contributes no routing recommendations; the list equals the generated set.
+        val generated =
+            com.poyka.ripdpi.core.detection.DetectionRecommendations
+                .generate(result)
+        assertEquals(generated, recommendations)
+    }
+
+    @Test
+    fun `suggestedFixes delegates to AppSettings extension`() {
+        val result = detectionResult()
+        val expected = settings().suggestDetectionFixes(result)
+        assertEquals(expected, DetectionResultPresenter.suggestedFixes(settings(), result))
+    }
+}

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionRunCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/detection/DetectionRunCoordinatorTest.kt
@@ -1,0 +1,212 @@
+package com.poyka.ripdpi.ui.screens.detection
+
+import com.poyka.ripdpi.core.detection.DetectionCheckResult
+import com.poyka.ripdpi.core.detection.DetectionCheckRunner
+import com.poyka.ripdpi.core.detection.DetectionProgress
+import com.poyka.ripdpi.core.detection.DetectionRunnerConfig
+import com.poyka.ripdpi.core.detection.DetectionStage
+import com.poyka.ripdpi.core.detection.Verdict
+import com.poyka.ripdpi.services.RoutingProtectionCatalogService
+import com.poyka.ripdpi.services.RoutingProtectionCatalogSnapshot
+import com.poyka.ripdpi.util.MainDispatcherRule
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+private class FakeProbeRunner(
+    private val result: DetectionCheckResult? = null,
+    private val error: Throwable? = null,
+    private val progress: List<DetectionProgress> = emptyList(),
+    private val gate: CompletableDeferred<Unit>? = null,
+) : DetectionProbeRunner {
+    override val packageName: String = "com.example"
+    var runCount = 0
+
+    override suspend fun runDetectionCheck(
+        runner: DetectionCheckRunner,
+        config: DetectionRunnerConfig,
+        onProgress: (DetectionProgress) -> Unit,
+    ): DetectionCheckResult {
+        runCount += 1
+        progress.forEach(onProgress)
+        gate?.await()
+        error?.let { throw it }
+        return result ?: detectionResult(Verdict.NOT_DETECTED)
+    }
+}
+
+private class NoopDetectionCheckRunner : DetectionCheckRunner {
+    override suspend fun run(
+        context: android.content.Context,
+        config: DetectionRunnerConfig,
+        onProgress: (suspend (DetectionProgress) -> Unit)?,
+    ): DetectionCheckResult = detectionResult(Verdict.NOT_DETECTED)
+}
+
+private class NoopRoutingCatalog : RoutingProtectionCatalogService {
+    override fun snapshot(): RoutingProtectionCatalogSnapshot = RoutingProtectionCatalogSnapshot()
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DetectionRunCoordinatorTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    // Initialized in @Before (after MainDispatcherRule swaps Main): Dispatchers.Main is then the
+    // rule's UnconfinedTestDispatcher, so launches run eagerly to first suspension on a single
+    // shared scheduler, mirroring viewModelScope under test.
+    private lateinit var testScope: CoroutineScope
+
+    @Before
+    fun setUp() {
+        testScope = CoroutineScope(Dispatchers.Main)
+    }
+
+    @After
+    fun tearDown() {
+        testScope.cancel()
+    }
+
+    private fun coordinator(
+        flow: MutableStateFlow<DetectionCheckUiState>,
+        probe: DetectionProbeRunner,
+        scope: CoroutineScope = testScope,
+        onSaveHistory: suspend (DetectionCheckResult, Int) -> Unit = { _, _ -> },
+        onRefreshCommunity: () -> Unit = {},
+    ): DetectionRunCoordinator =
+        DetectionRunCoordinator(
+            scope = scope,
+            reducer = DetectionCheckStateReducer(flow),
+            appSettingsRepository = FakeDetectionAppSettingsRepository(),
+            detectionCheckRunner = NoopDetectionCheckRunner(),
+            probeRunner = probe,
+            routingProtectionCatalogService = NoopRoutingCatalog(),
+            stringResolver = RecordingStringResolver(),
+            onSaveHistory = onSaveHistory,
+            onRefreshCommunity = onRefreshCommunity,
+        )
+
+    @Test
+    fun `startCheck is no-op while already running`() {
+        val flow = MutableStateFlow(DetectionCheckUiState(isRunning = true))
+        val probe = FakeProbeRunner()
+        coordinator(flow, probe).startCheck()
+        assertEquals(0, probe.runCount)
+    }
+
+    @Test
+    fun `startCheck resets state before probing and forwards progress to terminal`() {
+        val flow =
+            MutableStateFlow(
+                DetectionCheckUiState(
+                    result = detectionResult(),
+                    error = "stale",
+                    stealthScore = 50,
+                ),
+            )
+        val probe =
+            FakeProbeRunner(
+                result = detectionResult(Verdict.NOT_DETECTED),
+                progress =
+                    listOf(
+                        DetectionProgress(stage = DetectionStage.GEO_IP, label = "Geo", detail = "checking"),
+                    ),
+            )
+        coordinator(flow, probe).startCheck()
+
+        assertFalse(flow.value.isRunning)
+        assertNull(flow.value.error)
+        assertNull(flow.value.progress)
+        assertTrue(flow.value.result != null)
+    }
+
+    @Test
+    fun `successful run invokes side effects once before the terminal emission`() {
+        val flow = MutableStateFlow(DetectionCheckUiState())
+        var saveCount = 0
+        var refreshCount = 0
+        var savedBeforeTerminal = false
+        coordinator(
+            flow,
+            FakeProbeRunner(result = detectionResult(Verdict.NOT_DETECTED)),
+            onSaveHistory = { _, _ ->
+                saveCount += 1
+                savedBeforeTerminal = flow.value.result == null
+            },
+            onRefreshCommunity = { refreshCount += 1 },
+        ).startCheck()
+
+        assertEquals(1, saveCount)
+        assertEquals(1, refreshCount)
+        assertTrue(savedBeforeTerminal)
+        assertTrue(flow.value.result != null)
+        assertTrue(flow.value.stealthScore != null)
+    }
+
+    @Test
+    fun `non-cancellation failure with null message uses unknown fallback`() {
+        val flow = MutableStateFlow(DetectionCheckUiState())
+        coordinator(flow, FakeProbeRunner(error = RuntimeException())).startCheck()
+
+        assertFalse(flow.value.isRunning)
+        assertNull(flow.value.progress)
+        assertTrue(flow.value.error?.startsWith("string:") == true)
+    }
+
+    @Test
+    fun `non-cancellation failure surfaces error message`() {
+        val flow = MutableStateFlow(DetectionCheckUiState())
+        coordinator(flow, FakeProbeRunner(error = RuntimeException("explicit"))).startCheck()
+
+        assertEquals("explicit", flow.value.error)
+    }
+
+    @Test
+    fun `cancellation is not converted to an error state`() {
+        val flow = MutableStateFlow(DetectionCheckUiState())
+        coordinator(flow, FakeProbeRunner(error = CancellationException("cancel"))).startCheck()
+
+        assertNull(flow.value.error)
+    }
+
+    @Test
+    fun `stopCheck cancels an in-flight run and clears running and progress`() {
+        val flow = MutableStateFlow(DetectionCheckUiState())
+        val gate = CompletableDeferred<Unit>()
+        val coordinator = coordinator(flow, FakeProbeRunner(gate = gate))
+
+        coordinator.startCheck()
+        assertTrue(flow.value.isRunning)
+
+        coordinator.stopCheck()
+
+        assertFalse(flow.value.isRunning)
+        assertNull(flow.value.progress)
+    }
+
+    @Test
+    fun `stopCheck leaves an existing result untouched`() {
+        // stopCheck must not mutate result; with no active run the prior result survives.
+        val existing = detectionResult(Verdict.NOT_DETECTED)
+        val flow = MutableStateFlow(DetectionCheckUiState(result = existing))
+        val coordinator = coordinator(flow, FakeProbeRunner())
+
+        coordinator.stopCheck()
+
+        assertEquals(existing, flow.value.result)
+        assertFalse(flow.value.isRunning)
+        assertNull(flow.value.progress)
+    }
+}

--- a/docs/tasks/issues/decompose-god-viewmodels-blockcheck-detection-backup.md
+++ b/docs/tasks/issues/decompose-god-viewmodels-blockcheck-detection-backup.md
@@ -1,7 +1,7 @@
 ---
 title: "Decompose BlockcheckViewModel, DetectionCheckViewModel, BackupRestoreViewModel"
 type: task
-status: backlog
+status: done
 area: ui
 priority: medium
 owner: unassigned
@@ -9,7 +9,7 @@ parent: epic-june-2026-audit-remediation
 blocks: []
 blocked_by: []
 created: 2026-06-10
-updated: 2026-06-10
+updated: 2026-06-14
 source_wiki_pages: []
 linked_task: null
 ---
@@ -33,10 +33,34 @@ These are high-churn, hard-to-test classes. The fix pattern is already proven in
 
 ## Acceptance criteria
 
-- [ ] Each of the three VMs drops below a reasonable size threshold (target < ~250 lines) with single-responsibility collaborators extracted.
-- [ ] Extracted use-cases/repositories are unit-tested in isolation (the point of the split).
-- [ ] No behavior change in the three screens — existing Roborazzi goldens unchanged (no bless).
-- [ ] `./gradlew :app:testDebugUnitTest --locked` and `staticAnalysis` green; detekt baseline NOT extended.
+- [x] Each of the three VMs drops below a reasonable size threshold (target < ~250 lines) with single-responsibility collaborators extracted.
+- [x] Extracted use-cases/repositories are unit-tested in isolation (the point of the split).
+- [x] No behavior change in the three screens — existing Roborazzi goldens unchanged (no bless).
+- [x] `:app:testGithubDebugUnitTest` and `staticAnalysis` green; detekt baseline NOT extended.
+
+## Resolution (2026-06-14)
+
+Done on `worktree-decompose-godvms`, one atomic commit per VM, each gated by a
+`kotlin-design-auditor` adversarial-review pass (all PASS, no required fixes).
+
+| ViewModel | Before | After (file / class body) | Collaborators extracted |
+| --- | --- | --- | --- |
+| `BlockcheckViewModel` | 526 | 231 / ~116 | `BlockcheckProbeOrchestrator` (use-case), `BlockcheckRecommendationRepository` (repo), `BlockcheckReport` |
+| `DetectionCheckViewModel` | 510 | 144 / ~88 | `DetectionRunCoordinator`, `DetectionResultPresenter` (pure), `DetectionAuxStateOwner`, `DetectionPermissionStateOwner`, `DetectionCheckStateReducer` |
+| `BackupRestoreViewModel` | 447 | 180 / ~158 | `BackupExportCoordinator`, `BackupImportCoordinator`, `BackupResetCoordinator`, `BackupRestoreUiModels` |
+
+Notes:
+- Pure refactor — public ViewModel surfaces, effect mechanisms (Blockcheck/Detection
+  StateFlow-only; Backup four `MutableSharedFlow` channels with `tryEmit` + buffer-1/
+  DROP_OLDEST), and Hilt graphs preserved. Compose layers untouched; screenshot goldens
+  unchanged (no bless). No baseline extended.
+- New isolated collaborator unit tests: Blockcheck 20, Detection ~30, Backup 38.
+- Build task is flavored: `:app:testGithubDebugUnitTest` (the original `:app:testDebugUnitTest`
+  does not exist; `--locked` is a cargo flag, not gradle).
+- Minor honest caveat (Blockcheck): a transient `Idle`+diagnoses snapshot is now folded into
+  the clean `Running` snapshot — a conflated-StateFlow transient no UI observes.
+- `introduce-vpn-session-hilt-scope`: not needed — every collaborator is ViewModel-lived,
+  none belong to a VPN-session lifetime.
 
 ## Risks / open questions
 


### PR DESCRIPTION
## Summary

Pure refactor (zero behavior change) decomposing the three god ViewModels that emerged after the `MainViewModel` owner/action extraction, using the same proven idiom. One atomic commit per ViewModel, each gated by an adversarial `kotlin-design-auditor` review (all PASS, no required fixes).

| ViewModel | Before | After (file / class body) | Collaborators extracted |
| --- | --- | --- | --- |
| `BlockcheckViewModel` | 526 | **231 / ~116** | `BlockcheckProbeOrchestrator` (use-case), `BlockcheckRecommendationRepository` (repo), `BlockcheckReport` |
| `DetectionCheckViewModel` | 510 | **144 / ~88** | `DetectionRunCoordinator`, `DetectionResultPresenter` (pure), `DetectionAuxStateOwner`, `DetectionPermissionStateOwner`, `DetectionCheckStateReducer` |
| `BackupRestoreViewModel` | 447 | **180 / ~158** | `BackupExportCoordinator`, `BackupImportCoordinator`, `BackupResetCoordinator`, `BackupRestoreUiModels` |

Each ViewModel is now a thin UI-state holder/delegator; logic was genuinely **moved** into single-responsibility collaborators (verified by the reviewer against the originals), not shuffled.

## Behavior preservation (pure refactor)

- **Public ViewModel surfaces unchanged** — same member names/signatures, including Detection's val-lambda vs method distinction and Backup's full 19-member surface.
- **Effect mechanisms preserved exactly** — Blockcheck & Detection are StateFlow-only (message-in-state); Backup keeps its four `MutableSharedFlow` channels (`extraBufferCapacity=1` + `DROP_OLDEST` + `tryEmit`), state-update-before-emit ordering, the atomic `confirmRestore` clear, exact default `RestoreSelection` predicates, and dispatcher-per-step.
- **Hilt graphs intact** — Backup's `@Inject` ctor (6 params) and `BackupModule` untouched; Detection injects the same concrete singletons; Blockcheck's `BlockcheckStrategyReloader` becomes a bound dependency replacing a mutable test seam. No new Hilt scope (no collaborator is session-lived; `introduce-vpn-session-hilt-scope` not needed).
- **Compose layers untouched; screenshot goldens unchanged (no bless).**
- **No baseline extended** (detekt / arch-health / file-LoC); `checkFileLocLimits` passes clean.

## Tests

New isolated collaborator unit tests — Blockcheck **20**, Detection **~30**, Backup **38** (the Detection & Backup VMs were previously untested). Existing `BlockcheckViewModelTest` re-pointed through the real collaborators with no coverage loss.

## Verification

- `./gradlew :app:testGithubDebugUnitTest` → **BUILD SUCCESSFUL**, 0 failures (Hilt compiles clean — no broken consumers of the changed Blockcheck ctor).
- `./gradlew staticAnalysis` → **BUILD SUCCESSFUL** (detekt + ktlint + lint + custom LoC/boundary gates).
- Backup Roborazzi screenshot suite verified unchanged during implementation.

## Notes

- Honest caveat (Blockcheck): a transient `Idle`+diagnoses snapshot is now folded into the clean `Running` snapshot — a conflated-`StateFlow` transient no UI observes, and it matches the intended contract more faithfully.
- **RDS:** no UI surface, token, motion, or copy changed — all edits are non-Compose logic/test files, so no RDS spec card applies.
- Build task is flavored: `:app:testGithubDebugUnitTest` (the `:app:testDebugUnitTest` named in the task does not exist; `--locked` is a cargo flag, not gradle).

Closes the `decompose-god-viewmodels-blockcheck-detection-backup` task (status → done in this PR).