### PR TITLE
ci(bench): exclude ws_tunnel_1MiB from enforced regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1044,6 +1044,11 @@ jobs:
       # 20% threshold tolerates shared-runner noise while catching the 25% DoD target.
       # Until a reference-runner baseline lands the 7 protocol-throughput/* keys, this
       # is a safe no-op (missing keys -> "new benchmark" warning -> exit 0).
+      # ws_tunnel_1MiB is excluded from the HARD gate: its 1 MiB full-duplex TLS echo
+      # on a multi-thread tokio runtime is bound by the shared runner's vCPU count, not
+      # the code -- identical code measures 1.75ms (fast box) to 11.5ms (shared CI), with
+      # a ~+-35% 95% CI within a single run. It stays measured and visible in the advisory
+      # lane below; only the pass/fail gate skips it. See the ws-tunnel variance analysis.
       - name: Check for regressions (enforced, nightly)
         if: github.event_name == 'schedule'
         run: |
@@ -1051,6 +1056,7 @@ jobs:
             --criterion-dir native/rust/target/criterion \
             --baseline scripts/ci/rust-bench-baseline.json \
             --only-prefix 'protocol-throughput/' \
+            --exclude 'protocol-throughput/ws_tunnel_1MiB' \
             --max-regression-percent 20 \
             --markdown-output "$RUNNER_TEMP/criterion-summary.md"
           cat "$RUNNER_TEMP/criterion-summary.md" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/ci/check-criterion-regressions.py
+++ b/scripts/ci/check-criterion-regressions.py
@@ -53,6 +53,25 @@ def filter_by_prefix(
     return {name: values for name, values in benchmarks.items() if any(name.startswith(p) for p in prefixes)}
 
 
+def filter_excluding(
+    benchmarks: dict[str, dict[str, float]],
+    excludes: list[str],
+) -> dict[str, dict[str, float]]:
+    """Drop benchmarks whose name exactly matches one of ``excludes``.
+
+    Used by the enforcing nightly lane to skip a specific benchmark whose
+    measurement variance on shared CI runners exceeds the gate threshold (e.g.
+    ``protocol-throughput/ws_tunnel_1MiB``, whose 1 MiB full-duplex TLS echo on a
+    multi-thread runtime is bound by the runner's vCPU count, not the code). The
+    excluded bench is still measured and still reported by the advisory lane; it
+    is only removed from the hard gate. An empty ``excludes`` list is a no-op.
+    """
+    if not excludes:
+        return benchmarks
+    skip = set(excludes)
+    return {name: values for name, values in benchmarks.items() if name not in skip}
+
+
 def build_baseline_payload(
     current: dict[str, dict[str, float]],
     max_regression_percent: float,
@@ -216,6 +235,18 @@ def main() -> int:
             "the full result set."
         ),
     )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="BENCH",
+        help=(
+            "Exclude an exact benchmark name from the comparison (repeatable). Use "
+            "for benches whose CI-runner variance exceeds the gate threshold. The "
+            "bench is still measured and reported by the advisory lane; only the "
+            "hard gate skips it. Does not affect --dump-current."
+        ),
+    )
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parents[2]
@@ -244,6 +275,9 @@ def main() -> int:
     if args.only_prefix:
         current = filter_by_prefix(current, args.only_prefix)
         baseline["benchmarks"] = filter_by_prefix(baseline.get("benchmarks", {}), args.only_prefix)
+    if args.exclude:
+        current = filter_excluding(current, args.exclude)
+        baseline["benchmarks"] = filter_excluding(baseline.get("benchmarks", {}), args.exclude)
     threshold = args.max_regression_percent if args.max_regression_percent is not None else baseline["maxRegressionPercent"]
     regressions, improvements, warnings = compare(current, baseline, args.max_regression_percent)
 


### PR DESCRIPTION
Follow-up to PR #184. The nightly `rust-criterion-bench` enforced gate still failed on `protocol-throughput/ws_tunnel_1MiB` (+217% median) even after switching mean→median.

## Investigation: not a regression
- `git log <baseline-capture>..HEAD -- native/rust/crates/ripdpi-ws-tunnel/src/` is **empty** — the data plane is byte-identical to when the baseline was recorded.
- Same code, three environments: **1.75ms** (fast local box, ±11%) → baseline **3.23ms** median (its own mean was 7.78ms) → **8–15ms** on shared CI runners, with a **±35% 95% CI within a single run**.
- The bench is a 1 MiB full-duplex TLS echo on a `new_multi_thread` tokio runtime, so throughput is bound by the runner's available vCPU count, not the code. It cannot be measured to the 20% gate threshold on shared CI.

## Fix
Add a repeatable `--exclude` flag to `check-criterion-regressions.py` and drop only `protocol-throughput/ws_tunnel_1MiB` from the **enforced** lane. It stays measured, in the baseline, and visible in the **advisory** (warn-only) summary; the other 7 protocol-throughput transports remain gated at 20%.

## Verification
Against the real measured medians from the dispatch run:
- without `--exclude` → `ws_tunnel` regresses (reproduces the failure);
- with `--exclude` → enforced gate passes;
- a doubled `hysteria2` median still fails → genuine regressions on non-excluded benches are still caught.