### PR TITLE
chore(deps): nightly audit 2026-06-18

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1608,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "derive-deftly"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c002a60a3baf5d3fa28db4e1c98733aa2bc784aa63b83c011a72ae9335fb2"
+checksum = "0bc153c91ebf221a2e7feb166aee259acf8a00ecf35c83df8b79fe8f5c3861d7"
 dependencies = [
  "derive-deftly-macros",
  "heck",
@@ -1618,17 +1618,17 @@ dependencies = [
 
 [[package]]
 name = "derive-deftly-macros"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5850ec9ad2d9ba0aa33fb22c0b0ef4d91e524566be497ac2a6e40b847e67bb"
+checksum = "1747ed5fb4ab3a9f8253da3401efe7ca8f8e5ec373b2e700ff55c3304d84e31f"
 dependencies = [
  "heck",
- "indexmap 2.14.0",
- "itertools 0.14.0",
+ "indexmap 1.9.3",
+ "itertools 0.13.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "sha3 0.12.0",
+ "sha3 0.10.9",
  "strum",
  "syn 2.0.106",
  "unicode-ident",
@@ -2390,17 +2390,17 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -2667,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2997,7 +2997,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3195,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
  "bitflags 2.11.1",
  "inotify-sys",
@@ -3686,9 +3686,9 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
@@ -5182,9 +5182,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5205,9 +5205,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -7609,17 +7609,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
-dependencies = [
- "digest 0.11.3",
- "keccak 0.2.0",
- "sponge-cursor",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7749,9 +7738,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smoltcp"
@@ -7805,12 +7794,6 @@ dependencies = [
  "base64ct",
  "der 0.8.0",
 ]
-
-[[package]]
-name = "sponge-cursor"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sqlite-wasm-rs"
@@ -9684,9 +9667,9 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -9868,9 +9851,9 @@ dependencies = [
 
 [[package]]
 name = "wasix"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1757e0d1f8456693c7e5c6c629bdb54884e032aa0bb53c155f6a39f94440d332"
+checksum = "ae86f02046da16a333a9129d31451423e1657737ecdafed4193838a5f54c5cfe"
 dependencies = [
  "wasi",
 ]
@@ -10636,18 +10619,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Applied

Patch-level bumps for non-crypto / non-networking / non-async / non-JNI crates. All verified clean via OSV.dev batch query; `cargo check` on ripdpi-config, ripdpi-desync, ripdpi-tunnel-core passes. Only `native/rust/Cargo.lock` changes — no `Cargo.toml` edits needed.

### Rust

| Crate | Old | New | Notes |
|---|---|---|---|
| cc | 1.2.63 | 1.2.64 | build tool |
| chrono | 0.4.44 | 0.4.45 | date/time |
| derive-deftly | 1.11.2 | 1.11.3 | proc-macro |
| derive-deftly-macros | 1.11.2 | 1.11.3 | drops sha3 0.12.0 transitive dep |
| generator | 0.8.8 | 0.8.9 | coroutine utility |
| hashlink | 0.11.0 | 0.11.1 | ordered hash map |
| inotify | 0.11.1 | 0.11.2 | fs-watch |
| memchr | 2.8.1 | 2.8.2 | byte search |
| regex | 1.12.3 | 1.12.4 | regex engine |
| regex-syntax | 0.8.10 | 0.8.11 | regex parser |
| smallvec | 1.15.1 | 1.15.2 | inline vec |
| unicode-segmentation | 1.13.2 | 1.13.3 | unicode |
| wasix | 0.13.1 | 0.13.2 | WASI bindings |
| zerocopy | 0.8.50 | 0.8.52 | zero-copy types |
| zerocopy-derive | 0.8.50 | 0.8.52 | derive macro |

Side-effect: sha3 0.12.0 and sponge-cursor 0.1.0 removed from lockfile (were only needed by derive-deftly-macros 1.11.2).

### Gradle

No safe Gradle updates identified. All pinned versions are at latest stable.

---

## Security

All five advisories present in `native/rust/deny.toml` remain the full set — no new advisories were found for any package in the workspace (verified via OSV.dev batch queries across 40+ crates including all crypto/TLS/network/JNI packages).

| Advisory | Crate | Severity | Status |
|---|---|---|---|
| RUSTSEC-2023-0071 | rsa (0.9.10 via Arti, 0.10.0-rc.18 via russh) | Medium | Suppressed in deny.toml — no safe upgrade path; not practically exploitable in RIPDPI's usage (Tor client + SSH transcript signing, not attacker-chosen-plaintext) |
| RUSTSEC-2024-0436 | paste 1.0.15 | Info | Suppressed — unmaintained proc-macro, no runtime risk, no upstream replacement |
| RUSTSEC-2025-0069 | daemonize 0.5.0 | Info | Suppressed — root-helper binary only, no replacement |
| RUSTSEC-2025-0141 | bincode 2.0.1 | Info | Suppressed — transitive via Arti; no RIPDPI code touches bincode directly |
| RUSTSEC-2026-0173 | proc-macro-error2 2.0.1 | Info | Suppressed — compile-time only proc-macro via defmt→smoltcp, zero runtime footprint |

---

## Needs Review

Patch-level bumps on security-sensitive surfaces (crypto / networking / async / TLS). These are excluded from SAFE per audit policy — "NEEDS REVIEW: any change touching crypto, networking, async runtime, or JNI/FFI-adjacent crates, regardless of semver level."

| Crate | Current | Available | Reason withheld |
|---|---|---|---|
| h2 | 0.4.14 | 0.4.15 | HTTP/2 networking |
| getrandom | 0.4.2 | 0.4.3 | entropy source — security-critical |
| rand (0.9.x tree) | 0.9.3 | 0.9.4 | RNG — security-sensitive |
| rustls-native-certs | 0.8.3 | 0.8.4 | TLS cert loading |
| webpki-root-certs | 1.0.7 | 1.0.8 | TLS root store |
| webpki-roots | 1.0.7 | 1.0.8 | TLS root store |
| block-buffer | 0.12.0 | 0.12.1 | crypto digest internals |
| crypto-bigint | 0.7.3 | 0.7.4 | big-integer crypto primitives |

Minor-version bumps (require explicit changelog review before application):

| Crate | Current | Available |
|---|---|---|
| bitflags | 2.11.1 | 2.13.0 |
| crypto-primes | 0.7.0 | 0.7.2 |
| idna_adapter | 1.2.0 | 1.2.2 |
| proc-macro2 | 1.0.103 | 1.0.106 |
| quote | 1.0.40 | 1.0.45 |
| serde_with | 3.20.0 | 3.21.0 |
| serde_with_macros | 3.20.0 | 3.21.0 |
| syn | 2.0.106 | 2.0.118 |
| unicode-ident | 1.0.22 | 1.0.24 |
| which | 8.0.2 | 8.0.4 |
| zeroize | 1.8.2 | 1.9.0 |
| zeroize_derive | 1.4.3 | 1.5.0 |
| androidx.lifecycle | 2.10.0 | 2.11.0 | Gradle — minor bump |

Crypto RC-progression (currently pre-release; await stable release):

| Crate | Current | Available |
|---|---|---|
| aead | 0.6.0-rc.10 | 0.6.1 (stable) |
| ecdsa | 0.17.0-rc.18 | 0.17.0-rc.20 |
| elliptic-curve | 0.14.0-rc.33 | 0.14.0-rc.35 |
| p256 | 0.14.0-rc.10 | 0.14.0-rc.12 |
| p384 | 0.14.0-rc.10 | 0.14.0-rc.12 |
| p521 | 0.14.0-rc.10 | 0.14.0-rc.12 |
| primefield | 0.14.0-rc.11 | 0.14.0-rc.12 |
| primeorder | 0.14.0-rc.10 | 0.14.0-rc.12 |
| ssh-cipher | 0.3.0-rc.9 | 0.3.0-rc.10 |
| ssh-encoding | 0.3.0-rc.9 | 0.3.0 (stable) |

WASM crates (not used in Android builds but present in lockfile via smoltcp/wasm-bindgen dep tree):

| Crate | Current | Available |
|---|---|---|
| js-sys | 0.3.99 | 0.3.102 |
| wasm-bindgen | 0.2.122 | 0.2.125 |
| wasm-bindgen-futures | 0.4.72 | 0.4.75 |
| wasm-bindgen-macro | 0.2.122 | 0.2.125 |
| wasm-bindgen-macro-support | 0.2.122 | 0.2.125 |
| wasm-bindgen-shared | 0.2.122 | 0.2.125 |
| wasip2 | 1.0.3 | 1.0.4 |
| web-sys | 0.3.99 | 0.3.102 |

Lua / LuaJIT source bundles:

| Crate | Current | Available |
|---|---|---|
| lua-src | 550.0.0 | 550.1.1 |
| luajit-src | 210.6.6+707c12b | 210.7.2+b925b3e |

---

## Conflicts

**Cargo.lock — multiple versions coexisting (normal for this workspace depth; flagged for awareness):**

| Crate | Versions in lockfile |
|---|---|
| rand | 0.8.6, 0.9.3, 0.10.1 |
| rand_core | 0.6.4, 0.9.5, 0.10.1 |
| sha2 | 0.10.9, 0.11.0 |
| sha3 | 0.10.9, 0.11.0 *(0.12.0 removed by this PR)* |
| nix | 0.30.1, 0.31.3 |
| rsa | 0.9.10 (via Arti), 0.10.0-rc.18 (via russh) |
| p256 | 0.13.2, 0.14.0-rc.10 |
| p384 | 0.13.1, 0.14.0-rc.10 |

These are expected: different dep chains (Arti 0.43.0, russh 0.61.1, smoltcp 0.13.1) pin to different major versions. No divergence within the same major semver family. The rand triplication (0.8/0.9/0.10) reflects the workspace transition; 0.8.6 is only reachable through older transitive paths.

**Gradle — KSP/Kotlin version alignment note:**
KSP is pinned to `2.3.9` while Kotlin is `2.4.0`. In KSP 2.x the version scheme decoupled from Kotlin — `2.3.9` is the latest stable KSP release and is confirmed to be the latest on Maven Central. No KSP 2.4.x release exists yet. If compilation or annotation processing breaks after any Kotlin upgrade, bump KSP first.

---

*Audit methodology: `cargo update --workspace --dry-run --verbose` (57 packages behind latest, 0 within current semver constraints); targeted `cargo update -p <pkg>` dry-runs; OSV.dev batch vulnerability queries for ~40 key packages; Google Maven and Maven Central XML metadata for Gradle deps. `cargo-audit` and `cargo-deny` binaries not installed in this environment — deny.toml reviewed directly.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_013DpovRMi3jUHr5HubDFbDU

---
_Generated by [Claude Code](https://claude.ai/code/session_013DpovRMi3jUHr5HubDFbDU)_