### PR TITLE
chore(deps): nightly audit 2026-06-19

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -10018,9 +10018,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
## Nightly dependency audit — 2026-06-19

Tools used: `cargo audit 0.22.2`, `cargo deny 0.19.9`, `cargo update --dry-run`, manual Gradle version-catalog inspection.

---

## Applied

### Rust

| Crate | Old | New | Notes |
|-------|-----|-----|-------|
| `which` | 8.0.2 | 8.0.4 | Patch bump. Build-time only — used by `luajit-src` to locate executables during compilation; zero runtime footprint in the APK. `cargo check --workspace --lib` and `cargo deny check` both pass. |

---

## Security

All advisories found by `cargo audit` are already tracked in `deny.toml`. No new advisories since the 2026-06-18 audit.

| ID | Severity | Crate (version) | Status |
|----|----------|-----------------|--------|
| RUSTSEC-2023-0071 | Medium (5.9) | `rsa 0.9.10` (via Arti → ssh-key-fork-arti) | No fix available. RIPDPI uses Arti only as Tor client backend; RSA private-key ops are not exposed. Triaged. |
| RUSTSEC-2023-0071 | Medium (5.9) | `rsa 0.10.0-rc.18` (via russh → ripdpi-ssh) | No fix available. SSH publickey auth signs session identifier (not attacker-chosen plaintext). Triaged. |
| RUSTSEC-2024-0436 | — | `paste 1.0.15` (unmaintained) | Transitive via netlink-packet-core. Proc-macro, no runtime risk. Triaged. |
| RUSTSEC-2025-0069 | — | `daemonize 0.5.0` (unmaintained) | Used only in the root-helper binary (opt-in, `root_mode_enabled`). Triaged. |
| RUSTSEC-2025-0141 | — | `bincode 2.0.1` (unmaintained) | Transitive via Arti `tor-netdir`. No RIPDPI code touches bincode directly. Triaged. |
| RUSTSEC-2026-0173 | — | `proc-macro-error2 2.0.1` (unmaintained) | Compile-time only. Transitive via defmt-macros → smoltcp. Triaged. |

**Note on deny.toml/cargo-audit discrepancy:** `cargo deny check` reports `RUSTSEC-2025-0141` and `RUSTSEC-2026-0173` as "advisory-not-detected" (the advisory criteria don't match any package in its view of the lockfile), while `cargo audit` still flags both. The `deny.toml` ignore entries are still needed to suppress `cargo audit` warnings. No action required; the discrepancy is a tool-DB sync artifact.

---

## Needs Review

### Rust — TLS/crypto patch bumps (patch-level but crypto/TLS-adjacent per policy)

| Crate | Old | New | Reason withheld |
|-------|-----|-----|-----------------|
| `webpki-roots` | 1.0.7 | 1.0.8 | TLS root certificate bundle update — affects TLS trust anchors for all outbound connections |
| `webpki-root-certs` | 1.0.7 | 1.0.8 | Same root bundle, companion crate |
| `rustls-native-certs` | 0.8.3 | 0.8.4 | TLS cert loading from OS store, crypto-adjacent |
| `h2` | 0.4.14 | 0.4.15 | HTTP/2 protocol implementation, networking |
| `getrandom` | 0.4.2 | 0.4.3 | Cryptographic RNG source, crypto-adjacent |
| `crypto-bigint` | 0.7.3 | 0.7.4 | Constant-time big-integer arithmetic, crypto |
| `crypto-primes` | 0.7.0 | 0.7.2 | Primality testing, crypto |
| `block-buffer` | 0.12.0 | 0.12.1 | Hash/cipher block buffering, crypto |
| `aead` | 0.6.0-rc.10 | 0.6.1 | Authenticated encryption trait (RC → stable), crypto |
| `zeroize` | 1.8.2 | 1.9.0 | Secure memory zeroization, minor bump, crypto |

### Rust — minor bumps

| Crate | Old | New | Reason withheld |
|-------|-----|-----|-----------------|
| `bitflags` | 2.11.1 | 2.13.0 | Minor bump (11→13), used across net/crypto paths |
| `bitvec` | 1.0.1 | 1.1.1 | Minor bump, used in packet parsing (ripdpi-packets) |
| `bytes` | 1.11.1 | 1.12.0 | Minor bump, core networking byte-buffer abstraction |
| `serde_with` | 3.20.0 | 3.21.0 | Minor bump, serialization helper |

### Rust — blocked by `c2rust-bitfields-derive 0.22.1` exact pins

`c2rust-bitfields-derive 0.22.1` (pulled in by `tun-rs 2.8.5` → `c2rust-bitfields 0.22.1`) uses exact-version pins: `proc-macro2 = "=1.0.103"`, `quote = "=1.0.40"`, `syn = "=2.0.106"`, `unicode-ident = "=1.0.22"`. These pins block a large swath of build-tool proc-macro updates. Updating any of them independently would downgrade `c2rust-bitfields` (and therefore the TUN driver), which is unsafe. Resolution requires upgrading `tun-rs` past the version that depends on `c2rust-bitfields 0.22.1`, which is a NEEDS REVIEW change in its own right.

| Crate | Locked | Available | Blocker |
|-------|--------|-----------|---------|
| `proc-macro2` | 1.0.103 | 1.0.106 | `c2rust-bitfields-derive =1.0.103` |
| `quote` | 1.0.40 | 1.0.45 | `c2rust-bitfields-derive =1.0.40` |
| `syn` | 2.0.106 | 2.0.118 | `c2rust-bitfields-derive =2.0.106` |
| `unicode-ident` | 1.0.22 | 1.0.24 | `c2rust-bitfields-derive =1.0.22` |

---

## Major

| Package | Current | Available | Notes |
|---------|---------|-----------|-------|
| ICU4X ecosystem | 1.5.x | 2.2.x | Massive reorganization: `icu_locid` → `icu_locale_core`, `icu_locid_transform` removed, `zerotrie` added, `zerovec` removed, and more. Used transitively via `idna`/`url`. Upgrading requires Arti or Quinn to adopt ICU 2.x first. |

---

## Conflicts

### Gradle — notes (no blocking conflicts found)

The version catalog is well-structured and all 13 Kotlin/Gradle modules resolve through `gradle/libs.versions.toml` with no cross-module version divergences detected.

Items to verify manually:

| Item | Observation |
|------|-------------|
| `javax.annotation:javax.annotation-api = "1.3.2"` | Hardcoded version in `libs.versions.toml` (not using a `version.ref`). Latest is still 1.3.2; no action required, but consider adding a version alias for consistency. |
| `foojay-resolver-convention "1.0.0"` in `settings.gradle.kts` | Hardcoded; not in the version catalog. Check for updates. |
| `ksp = "2.3.9"` vs `kotlin-compose = "2.4.0"` | KSP plugin version should track the Kotlin version it was compiled against. Verify that KSP 2.3.9 is compatible with Kotlin 2.4.0 (the new standalone KSP versioning may decouple them — confirm this is intentional). |

---

*Generated by nightly audit routine — 2026-06-19*

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2emxVyNWL7XQrnd8N931F)_