### PR TITLE
chore(deps): nightly audit 2026-06-20

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -10018,9 +10018,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
Automated nightly dependency + security audit — 2026-06-20.

Tooling available: `cargo metadata`, `cargo update --dry-run`, `cargo info`.
`cargo audit` and `cargo deny` were **not installed** in this environment; no live RUSTSEC advisory fetch was performed. See **Security** section for documented dispositions.

---

## Applied

### Rust (Cargo.lock)

| Crate | Old | New | Reason |
|---|---|---|---|
| `cc` | 1.2.64 | **1.2.65** | patch, build-time C compiler detection only |
| `which` | 8.0.2 | **8.0.4** | patch, build-time executable lookup only |

Both are compile-time-only crates with zero runtime footprint in the Android app.

### Gradle / Kotlin

No safe changes applied. All library versions are managed through a single `gradle/libs.versions.toml` version catalog with no cross-module divergences found in build files. No Gradle-side patch is applicable without running `./gradlew dependencies` (not available in this environment).

---

## Security

`cargo-audit` and `cargo-deny` were not installed; the advisory database was not fetched live. The five advisories documented in `native/rust/deny.toml` retain their existing dispositions:

| RUSTSEC ID | Severity | Crate | Disposition |
|---|---|---|---|
| RUSTSEC-2024-0436 | informational | `paste 1.0.15` | Ignored — unmaintained, proc-macro only, no runtime risk, no replacement available (via `netlink-packet-core`) |
| RUSTSEC-2025-0069 | informational | `daemonize` | Ignored — unmaintained, used only in opt-in root-helper binary |
| RUSTSEC-2023-0071 | medium | `rsa 0.9.10` / `0.10.0-rc.18` | Ignored — Marvin timing sidechannel not exploitable: enters via Arti Tor client + russh SSH (session-identifier signing, not attacker-chosen plaintext) |
| RUSTSEC-2025-0141 | informational | `bincode 2.0.1` | Ignored — unmaintained transitive dep via Arti internal directory-cache, no RIPDPI code touches bincode directly |
| RUSTSEC-2026-0173 | informational | `proc-macro-error2 2.0.1` | Ignored — compile-time-only proc macro, no runtime footprint (via `defmt-macros → defmt → smoltcp`) |

**Action required:** Install `cargo-audit` and `cargo-deny` in CI so future audit runs fetch live advisory data. Until then, advisories published after the last manual `deny.toml` update will be invisible to automated runs.

---

## Needs Review

### 🔴 Yanked / downgrade situations (resolve before next release)

`cargo update --dry-run` shows three crates where the current lockfile holds a version that cargo would **downgrade** if the lockfile were regenerated — strong signal these versions were yanked from crates.io:

| Crate | Locked | Would resolve to | Impact |
|---|---|---|---|
| `c2rust-bitfields` | **0.22.1** | 0.21.0 | Blocks all proc-macro ecosystem updates (see Conflicts) |
| `c2rust-bitfields-derive` | **0.22.1** | 0.21.0 | Same |
| `tun-rs` | **2.8.5** | 2.8.1 | TUN networking driver — requires full network-path review |
| `winreg` | **0.56.0** | 0.55.0 | Windows-only registry crate |

Recommended action: open a separate PR to update the `tun-rs` workspace pin from `"2.8"` to `">=2.8, <2.8.5"` or `"=2.8.1"` so it no longer resolves to the problematic 0.22.1 c2rust chain. After that PR merges, the proc-macro ecosystem patches below become unblocked.

### 🟡 Proc-macro ecosystem patches (blocked by Conflicts — see below)

These are patch-level updates for compile-time-only crates but cannot be applied while `c2rust-bitfields 0.22.1` is in the dependency graph:

| Crate | Locked | Available |
|---|---|---|
| `proc-macro2` | 1.0.103 | 1.0.106 |
| `quote` | 1.0.40 | 1.0.45 |
| `syn` v2 | 2.0.106 | 2.0.118 |
| `unicode-ident` | 1.0.22 | 1.0.24 |

### 🟡 Security / crypto / networking patch updates

Policy: patch-level bumps touching crypto, networking, or async require human review regardless of semver safety.

| Crate | Old | New | Notes |
|---|---|---|---|
| `h2` | 0.4.14 | 0.4.15 | HTTP/2 implementation |
| `getrandom` | 0.4.2 | 0.4.3 | RNG — security-sensitive |
| `rustls-native-certs` | 0.8.3 | 0.8.4 | TLS cert loading |
| `webpki-root-certs` | 1.0.7 | 1.0.8 | TLS root CA bundle update |
| `webpki-roots` | 1.0.7 | 1.0.8 | TLS root CA bundle update |
| `block-buffer` | 0.12.0 | 0.12.1 | Crypto primitive |
| `crypto-bigint` | 0.7.3 | 0.7.4 | Crypto primitive |
| `aead` | 0.6.0-rc.10 | 0.6.1 | Crypto — RC to stable release |
| `idna_adapter` | 1.2.0 | 1.2.2 | IDNA / URL parsing (network-adjacent) |

### 🟡 Minor-version bumps

| Crate | Old | New | Notes |
|---|---|---|---|
| `zeroize` | 1.8.2 | 1.9.0 | Crypto secret-wiping |
| `zeroize_derive` | 1.4.3 | 1.5.0 | Crypto secret-wiping |
| `bytes` | 1.11.1 | 1.12.0 | Core networking I/O buffer |
| `bitflags` | 2.11.1 | 2.13.0 | Utility (minor) |
| `bitvec` | 1.0.1 | 1.1.1 | Bit-manipulation (minor) |
| `serde_with` | 3.20.0 | 3.21.0 | Serialization helpers |
| `crypto-primes` | 0.7.0 | 0.7.2 | Crypto |
| `primefield` | 0.14.0-rc.11 | 0.14.0-rc.12 | Crypto |
| `wasm-bindgen` family | 0.2.122 | 0.2.125 | Wasm-only targets |
| `js-sys` / `web-sys` | 0.3.99 | 0.3.102 | Wasm-only targets |
| `litemap` | 0.7.5 | 0.8.2 | ICU infrastructure |
| `yoke` / `yoke-derive` | 0.7.5 | 0.8.3/0.8.2 | ICU infrastructure |
| `writeable` | 0.5.5 | 0.6.3 | ICU infrastructure |
| `zerovec-derive` | 0.10.3 | 0.11.3 | ICU infrastructure |

---

## Major

### ICU4X 1.5 → 2.2 (breaking)

`cargo update --dry-run` shows the full ICU4X library family crossing a major version boundary. This is a significant structural change:

**Updated (major):** `icu_collections`, `icu_normalizer`, `icu_normalizer_data`, `icu_properties`, `icu_properties_data`, `icu_provider`

**Removed crates:** `icu_locid`, `icu_locid_transform`, `icu_locid_transform_data`, `icu_provider_macros`, `leb128fmt`, `id-arena`, `tinystr`, `utf16_iter`, `zerovec`, `prettyplease`, `wasm-encoder`, `wasm-metadata`, `wasmparser`, `wit-bindgen` family (10+ crates)

**Added crates:** `icu_locale_core`, `itertools`, `potential_utf`, `sha3`, `sponge-cursor`, `zerotrie`

ICU4X 2.x has breaking API changes documented at https://github.com/unicode-org/icu4x/releases. Review carefully before landing — this affects Unicode/IDNA normalization which touches URL parsing in the DNS and TLS layers.

---

## Conflicts

### Rust — `c2rust-bitfields 0.22.1` exact-version lockout (blocker)

`tun-rs ^2.8` resolves to `2.8.5` in the current lockfile, which pulls in `c2rust-bitfields 0.22.1`. That version publishes unusually strict exact-version requirements on four proc-macro ecosystem crates:

```
proc-macro2 = "=1.0.103"
quote        = "=1.0.40"
syn          = "=2.0.106"
unicode-ident = "=1.0.22"
```

These exact pins prevent cargo from updating any of those four crates, blocking approximately half of the available patch updates. `cargo update --dry-run` resolves this by downgrading `tun-rs 2.8.5 → 2.8.1` and `c2rust-bitfields 0.22.1 → 0.21.0`.

**Recommended resolution sequence:**
1. Open a NEEDS REVIEW PR: restrict `tun-rs` to `"=2.8.1"` in `native/rust/Cargo.toml` and update the lockfile.
2. Verify the TUN driver still functions correctly on Android (networking path).
3. After that PR merges, the proc-macro ecosystem patches become a routine follow-up.

### Gradle — `foojay-resolver-convention` hardcoded in `settings.gradle.kts`

`settings.gradle.kts` pins `id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"` directly (not through the version catalog). This is outside the catalog's purview and cannot be detected by version-conflict scanning. Recommend moving to the catalog or adding a comment noting the last-verified date.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TK5WqquUxMtjYXjGYuu5XD

---
_Generated by [Claude Code](https://claude.ai/code/session_01TK5WqquUxMtjYXjGYuu5XD)_