### PR TITLE
chore(deps): nightly audit 2026-06-21

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -241,9 +241,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "arti-client"
@@ -3599,9 +3599,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loom"


### PR DESCRIPTION
Automated nightly dependency audit — 2026-06-21.

Scope: Rust workspace (115 crates, `native/rust/`), Kotlin/Gradle frontend (13 modules, `gradle/libs.versions.toml`).

Tools available: `cargo check`, `cargo info`, `cargo update --dry-run`, web fetches against crates.io / Maven Central / rustsec.org. (`cargo audit` and `cargo deny` are not installed in the CI agent; deny.toml dispositions were reviewed manually.)

---

## Applied

### Rust

| Crate | Old | New | Rationale |
|---|---|---|---|
| `arrayvec` | 0.7.6 | 0.7.7 | Patch; generic fixed-capacity array, no crypto/net/async surface |
| `log` | 0.4.32 | 0.4.33 | Patch; logging facade, no API changes |

Both applied via targeted `cargo update -p <crate>` and verified with `cargo check --locked --workspace` across the full 115-crate workspace. Diff is 8 lines in `Cargo.lock`, two checksum swaps.

---

## Security

### New advisories (2026, not yet in deny.toml)

| Advisory | Severity | Crate | CVE | Status |
|---|---|---|---|---|
| RUSTSEC-2026-0154 | HIGH (CVSS 7.5) | `russh` | CVE-2026-46673 | **NOT AFFECTED** — workspace pins `russh = "=0.61.2"`, patched at ≥ 0.60.3 |
| RUSTSEC-2026-0153 | HIGH (CVSS 7.5) | `russh-cryptovec` | CVE-2026-46673 | **NOT AFFECTED** — same fix boundary; 0.61.2 is clean |

**RUSTSEC-2026-0154 detail**: Both client and server sides of the russh SSH agent failed to validate maximum frame sizes, allowing a peer to advertise an oversized frame and cause the process to attempt a multi-GB allocation (DoS). Fixed by capping frame acceptance at 256 KiB before allocation. Our pin at 0.61.2 already incorporates this fix.

**RUSTSEC-2026-0153 detail**: `russh-cryptovec` had unchecked capacity growth and unsafe allocation paths; a local SSH agent peer could trigger unbounded buffer growth (DoS). Same fix release (0.60.3). Our pin is unaffected.

### Previously documented advisories (deny.toml — status unchanged)

All five existing advisories retain their documented dispositions. No new upgrade paths have opened:

| Advisory | Crate | Disposition |
|---|---|---|
| RUSTSEC-2024-0436 | `paste` 1.0.15 | Unmaintained proc-macro; compile-time only, no upgrade path |
| RUSTSEC-2025-0069 | `daemonize` 0.5.0 | Unmaintained; opt-in root mode only, no replacement |
| RUSTSEC-2023-0071 | `rsa` (0.9.10 via Arti, 0.10.0-rc.18 via russh) | Marvin timing sidechannel; not practically exploitable in RIPDPI's usage patterns |
| RUSTSEC-2025-0141 | `bincode` 2.0.1 | Unmaintained; internal to Arti's directory cache, no RIPDPI direct usage |
| RUSTSEC-2026-0173 | `proc-macro-error2` 2.0.1 | Unmaintained compile-time-only proc-macro; via defmt→smoltcp, no upgrade path |

---

## Needs review

### Rust — patch-level but security/networking/async surface

| Crate | Locked | Available | Why withheld |
|---|---|---|---|
| `webpki-roots` | 1.0.7 | 1.0.8 | Patch, but TLS trust-root set — require changelog review before accepting root additions/removals |
| `webpki-root-certs` | 1.0.7 | 1.0.8 | Same root-set update (companion crate) |
| `h2` | 0.4.14 | 0.4.15 | Patch; HTTP/2 framing library, networking-sensitive |
| `getrandom` | 0.4.2 | 0.4.3 | Patch; OS entropy interface, security-critical |
| `block-buffer` | 0.12.0 | 0.12.1 | Patch; crypto-adjacent buffer used in digest impls |
| `crypto-bigint` | 0.7.3 | 0.7.4 | Patch; integer arithmetic for crypto (RSA/ECDSA primitives) |

### Rust — minor version bumps (semver-breaking by policy)

| Crate | Locked | Available | Why withheld |
|---|---|---|---|
| `bytes` | 1.11.1 | 1.12.0 | Minor; foundational async buffer type pervasive through tokio, h2, quinn, hyper stacks |
| `zeroize` | 1.8.2 | 1.9.0 | Minor; memory-clearing for secret values, security-adjacent |
| `crypto-primes` | 0.7.0 | 0.7.2 | Minor; prime generation for crypto |
| `aead` | 0.6.0-rc.10 | 0.6.1 (stable) | Pre-release → stable promotion; AEAD encryption trait |
| `bitflags` | 2.11.1 | 2.13.0 | Minor bump, check changelog for breaking changes |
| `bitvec` | 1.0.1 | 1.1.1 | Minor bump, bitvec has history of breaking minor releases |

### Kotlin/Gradle — minor version bumps

| Library | Current | Available | Why withheld |
|---|---|---|---|
| `lifecycle` | 2.10.0 | 2.11.0 | Minor; new APIs (scoped ViewModels in Compose, KMP support) — requires regression testing of ViewModel lifecycle behavior across all screens |
| `compose-bom` | 2026.05.01 | 2026.06.00 | Both BOMs map to identical library versions (Compose 1.11.3 / Material3 1.4.0); metadata-only update, but still Compose ecosystem requiring UI smoke test |

### Kotlin/Gradle — compatibility gap (monitor)

- **KSP 2.3.9 with Kotlin 2.4.0**: KSP 2.3.9 was released May 26; Kotlin 2.4.0 dropped June 3. No KSP 2.4.x release exists yet. The build currently passes because KSP 2.3.x maintains forward compatibility with the same Kotlin major series, but this should be resolved as soon as Google ships KSP 2.4.0.

---

## Major

### Rust

| Crate family | Locked | Available | Note |
|---|---|---|---|
| `icu_collections` / `icu_normalizer` / `icu_properties` / `icu_provider` | 1.5.x | 2.2.0 | Major; ICU4X Unicode data crates. Transitive via IDNA/URL processing. A full `cargo update` causes `c2rust-bitfields` to **downgrade** from 0.22.1 → 0.21.0 and `winreg` to downgrade 0.56.0 → 0.55.0, indicating deep transitive incompatibilities. Needs a dedicated untangling PR. |

### Kotlin/Gradle — no major bumps found

All audited Gradle dependencies (AGP 9.2.1, Kotlin 2.4.0, gRPC 1.82.0, Room 2.8.4, Navigation 2.9.8, WorkManager 2.11.2, Hilt 2.59.2, Coroutines 1.11.0) are at current stable releases.

---

## Conflicts

### Rust — multiple-version duplicates (warn in cargo deny, not errors)

These are expected in a 115-crate workspace with deep transitive graphs. Noted for visibility:

| Crate | Versions in lock |
|---|---|
| `rand` | 0.8.6 + 0.9.3 + 0.10.1 |
| `sha2` | 0.10.9 + 0.11.0 |
| `aes` | 0.8.4 + 0.9.1 |
| `thiserror` | 1.0.69 + 2.0.18 |
| `base64` | 0.21.7 + 0.22.1 |
| `nix` | 0.30.1 + 0.31.3 |
| `toml` | 0.8.23 + 1.1.2 |
| `block-buffer` | 0.10.4 + 0.12.0 |
| `bitflags` | 1.3.2 + 2.11.1 |
| `getrandom` | 0.2.17 + 0.3.4 + 0.4.2 |

All covered by `[bans] multiple-versions = "warn"` in `deny.toml`. No cross-module Gradle version divergence found (all deps centralized in `gradle/libs.versions.toml`).

### Carry-over: c2rust-bitfields constraint (from 2026-06-20 audit)

`tun-rs 2.8.5` transitively pins `c2rust-bitfields` and its proc-macro family (`proc-macro2`, `quote`, `syn`, `unicode-ident`) to exact versions. This prevents those common build-tool crates from receiving patch updates. Running `cargo update` without targeted `-p` selectors causes `c2rust-bitfields` to downgrade. A dedicated NEEDS REVIEW PR to evaluate `tun-rs` compatibility is the resolution path.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01TAvHBqdbujukvdzMLUa3Df

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAvHBqdbujukvdzMLUa3Df)_