### PR TITLE
chore(deps): nightly audit 2026-06-28

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -208,9 +208,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"


### PR DESCRIPTION
## Task

Nightly dependency and security audit — Rust Cargo workspace + Kotlin/Gradle frontend.

## Summary

Automated audit of all external dependencies across the Rust workspace (~116 crates) and Kotlin/Gradle modules (~16 modules). One SAFE patch bump applied. All other findings are documented below for human review.

**Audit tooling used:**
- `cargo-deny 0.16.3` — licenses, bans, sources (advisories check blocked: GitHub git-clone is proxy-denied; OSV API used as substitute for advisory lookups)
- `cargo update -p anyhow --precise 1.0.103` — targeted patch bump
- `cargo fetch --locked` — dependency-resolution verification
- OSV API (`api.osv.dev`) — advisory DB queries for ~65 crates
- crates.io API — version comparison for all locked external deps
- Google Maven / Maven Central — Gradle library version comparison

## Applied

### Rust

| Crate | Old | New | Notes |
|-------|-----|-----|-------|
| `anyhow` | 1.0.102 | 1.0.103 | Pure error-handling utility; no crypto/net/async/JNI |

### Gradle

_No SAFE Gradle changes (gRPC 1.82.0 → 1.82.1 is a patch bump but networking → see Needs Review)._

## Security

### Known advisories (all pre-acknowledged in `native/rust/deny.toml`)

| ID | Severity | Crate | Status | Note |
|----|----------|-------|--------|------|
| RUSTSEC-2024-0436 | Informational | `paste` 1.0.15 | **Unresolved** — no upstream fix | Unmaintained proc-macro; no runtime risk; pulled transitively via `netlink-packet-core` |
| RUSTSEC-2025-0069 | Informational | `daemonize` 0.5.0 | **Unresolved** — no replacement | Unmaintained; used only in `ripdpi-root-helper` binary (opt-in, root mode only) |
| RUSTSEC-2023-0071 | Medium | `rsa` (0.9.10 + 0.10.0-rc.18) | **Unresolved** — no safe upgrade path | Marvin timing side-channel; enters via Arti 0.43.0→`ssh-key-fork-arti` and via `russh 0.61.2`; neither path is practically exploitable (RIPDPI is a Tor *client*, not server; russh SSH publickey auth signs a transcript hash, not attacker-chosen plaintext). Tracked in deny.toml; re-scanned daily by CI. |

**Applied update resolves:** none of the above (all require upstream action).

**OSV full-database scan:** 0 new advisories found across 65 checked crates including all crypto/TLS/networking crates (`rustls 0.23.41`, `ring 0.17.14`, `boring 5.1.0`, `quinn 0.11.11`, `reqwest 0.13.4`, `tokio 1.52.3`, `hyper 1.10.1`, `tungstenite 0.29.0`, `boringtun 0.7.1`, `hickory-proto/resolver 0.26.1`, `arti-client/tor-rtcompat 0.43.0`, and others).

### cargo-deny result

```
bans ok, licenses ok, sources ok
```

Duplicate-version warnings only (all from the `russh 0.61.2` RC-crypto transitive path — already documented in deny.toml).

## Needs Review

### Gradle — patch bumps on networking libraries

| Artifact | Current | Available | Semver | Reason held |
|----------|---------|-----------|--------|-------------|
| `io.grpc:grpc-okhttp` | 1.82.0 | 1.82.1 | PATCH | gRPC is a networking layer; patch changes can alter on-wire behaviour in an anti-DPI context |
| `io.grpc:grpc-protobuf-lite` | 1.82.0 | 1.82.1 | PATCH | Same gRPC release train |
| `io.grpc:grpc-stub` | 1.82.0 | 1.82.1 | PATCH | Same gRPC release train |

### Gradle — minor bump

| Artifact | Current | Available | Semver | Reason held |
|----------|---------|-----------|--------|-------------|
| `com.google.dagger:hilt-android` | 2.59.2 | 2.60 | MINOR | Hilt minor bumps sometimes change generated code / component interfaces |
| `com.google.dagger:hilt-compiler` | 2.59.2 | 2.60 | MINOR | Must match `hilt-android` |

### Rust — KSP version note

`libs.versions.toml` declares `ksp = "2.3.9"` while Kotlin is `kotlin-compose = "2.4.0"`. KSP versions normally must mirror the Kotlin version (e.g. `2.4.0-1.0.x`). Google Maven returned no match for this version, suggesting either the KSP artifact key differs from what was checked or the version string is a project-local alias. Recommend human verification that `ksp = "2.3.9"` resolves correctly against Kotlin 2.4.0.

## Conflicts

No cross-module Gradle version conflicts detected. All 16 modules consume dependency versions exclusively through the version catalog (`gradle/libs.versions.toml`). No hardcoded library version strings found in any `build.gradle.kts` file (only `ripdpiVersionName = "0.1.3"` which is the app version, not a dep).

## Test plan

- `cargo fetch --locked` passed after applying the `anyhow` bump (dependencies resolved cleanly)
- `cargo-deny check licenses bans sources` passed (no errors, duplicate-version warnings only)
- OSV advisory API scanned 65 external crates — no new findings
- crates.io version API compared all locked external deps — only `anyhow` had a patch update available
- Google Maven / Maven Central checked 30+ Gradle dependencies — all at latest stable except gRPC (+0.0.1 patch) and Hilt (+0.1 minor), both withheld per audit policy

## Checklist

- [x] No baseline files extended (detekt, lint, LoC)
- [x] `timeout-minutes` added to any new CI job — N/A (no new jobs)
- [x] Native ABI matrix not broken (if touching native builds) — Cargo.lock only, no source change
- [x] Non-rooted device path still works (if touching VPN/root features) — N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfogXYW5yqGPQ4L8udsGq8)_