### PR TITLE
fix(uri)+feat(awg): reject unsupported VLESS-Reality transports; expose AWG WG-over-WS carrier

### DIFF
--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/awg/AmneziaWgEditorState.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/awg/AmneziaWgEditorState.kt
@@ -43,6 +43,13 @@ enum class AwgEditorField(
     PRESHARED_KEY(isObfuscation = false),
     PERSISTENT_KEEPALIVE(isObfuscation = false),
 
+    // WG-over-WebSocket carrier URL -- a first-class AwgProfileForm column,
+    // only consulted (and required by [AmneziaWgEditorState.isActivatable])
+    // when [AwgProfileForm.carrier] is [AwgActivationRequest.CARRIER_WS].
+    // Carrier selection itself is a picker, not a text field -- see
+    // [AmneziaWgEditorState.selectCarrier].
+    CARRIER_WS_URL(isObfuscation = false),
+
     // Obfuscation fields — locked when a cohort preset is selected.
     JC(isObfuscation = true),
     JMIN(isObfuscation = true),
@@ -139,6 +146,15 @@ data class AmneziaWgEditorState(
         )
 
     /**
+     * Selects the transport [carrier] ([AwgActivationRequest.CARRIER_UDP] or
+     * [AwgActivationRequest.CARRIER_WS]). A picker choice, not a text-field edit --
+     * mirrors [selectCohort] / [selectCustom] rather than going through [updateField].
+     * [AwgProfileForm.carrierWsUrl] is left untouched so switching back and forth
+     * does not discard an already-typed URL.
+     */
+    fun selectCarrier(carrier: String): AmneziaWgEditorState = copy(form = form.copy(carrier = carrier))
+
+    /**
      * Projects the editor into an [AwgActivationRequest] for the standalone
      * AmneziaWG runtime. Identity, PSK and obfuscation come from [form]; the
      * transport fields the form does not carry as columns ([AwgEditorField.ADDRESS],
@@ -164,7 +180,9 @@ data class AmneziaWgEditorState(
      * `true` when the identity fields required to open a tunnel are all present:
      * server host + port, interface private key, peer public key, and an
      * interface address. Obfuscation fields are optional (an empty set is a
-     * vanilla WireGuard peer).
+     * vanilla WireGuard peer). When [AwgProfileForm.carrier] is
+     * [AwgActivationRequest.CARRIER_WS], [AwgProfileForm.carrierWsUrl] must also
+     * be present -- the WS carrier cannot connect without a request URL.
      */
     fun isActivatable(): Boolean =
         form.server.isNotBlank() &&
@@ -172,7 +190,8 @@ data class AmneziaWgEditorState(
             form.interfacePrivateKey.isNotBlank() &&
             form.peerPublicKey.isNotBlank() &&
             rawText(AwgEditorField.ADDRESS).isNotBlank() &&
-            obfuscationConsistent()
+            obfuscationConsistent() &&
+            (form.carrier != AwgActivationRequest.CARRIER_WS || form.carrierWsUrl.isNotBlank())
 
     /**
      * `true` when the obfuscation knobs are mutually consistent and fit the
@@ -314,6 +333,8 @@ private fun AwgProfileForm.applyField(
 
         AwgEditorField.PRESHARED_KEY -> copy(presharedKey = parsed as String)
 
+        AwgEditorField.CARRIER_WS_URL -> copy(carrierWsUrl = parsed as String)
+
         AwgEditorField.JC -> copy(jc = parsed as Int)
 
         AwgEditorField.JMIN -> copy(jmin = parsed as Int)
@@ -358,6 +379,7 @@ private fun AwgProfileForm.identityRawText(): Map<AwgEditorField, String> =
         AwgEditorField.INTERFACE_PRIVATE_KEY to interfacePrivateKey,
         AwgEditorField.PEER_PUBLIC_KEY to peerPublicKey,
         AwgEditorField.PRESHARED_KEY to presharedKey,
+        AwgEditorField.CARRIER_WS_URL to carrierWsUrl,
     )
 
 private fun AwgProfileForm.obfuscationRawText(): Map<AwgEditorField, String> =

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/awg/AmneziaWgProfileScreen.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/awg/AmneziaWgProfileScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.poyka.ripdpi.R
+import com.poyka.ripdpi.data.awg.AwgActivationRequest
 import com.poyka.ripdpi.data.awg.AwgProfileForm
 import com.poyka.ripdpi.ui.components.buttons.RipDpiButton
 import com.poyka.ripdpi.ui.components.buttons.RipDpiButtonVariant
@@ -33,6 +34,7 @@ import com.poyka.ripdpi.ui.testing.RipDpiTestTags
 import com.poyka.ripdpi.ui.testing.ripDpiTestTag
 import com.poyka.ripdpi.ui.theme.RipDpiIcons
 import com.poyka.ripdpi.ui.theme.RipDpiThemeTokens
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
 /**
@@ -60,6 +62,7 @@ fun AmneziaWgProfileRoute(
         onBack = onBack,
         onFieldChanged = viewModel::onFieldChanged,
         onCohortSelected = viewModel::onCohortSelected,
+        onCarrierSelected = viewModel::onCarrierSelected,
         onPasteConf = { /* clipboard read is wired by the host; no-op in the pure screen */ },
         onRevealPrivateKey = onRequestPrivateKeyReveal ?: viewModel::onPrivateKeyRevealAuthorized,
         onRevealPresharedKey = onRequestPresharedKeyReveal ?: viewModel::onPresharedKeyRevealAuthorized,
@@ -74,6 +77,7 @@ internal fun AmneziaWgProfileScreen(
     onBack: () -> Unit,
     onFieldChanged: (AwgEditorField, String) -> Unit,
     onCohortSelected: (String) -> Unit,
+    onCarrierSelected: (String) -> Unit,
     onPasteConf: () -> Unit,
     onRevealPrivateKey: () -> Unit,
     onRevealPresharedKey: () -> Unit,
@@ -89,12 +93,56 @@ internal fun AmneziaWgProfileScreen(
     ) {
         InterfaceSection(uiState, onFieldChanged, onRevealPrivateKey)
         PeerSection(uiState, onFieldChanged, onRevealPresharedKey)
+        CarrierSection(uiState, onFieldChanged, onCarrierSelected)
         ObfuscationSection(uiState, onFieldChanged, onCohortSelected, onPasteConf)
         ConnectSection(
             canActivate = uiState.canActivate,
             activationStatus = uiState.activationStatus,
             onConnect = onConnect,
         )
+    }
+}
+
+/**
+ * Transport carrier section: a UDP/WebSocket picker plus a WS request-URL field
+ * that only appears (and is only required by [AmneziaWgEditorState.isActivatable])
+ * when the WebSocket carrier is selected. See `vpnservice-protect-invariant.md` --
+ * the WS carrier still egresses through a protected socket in the native runtime;
+ * this section only chooses which carrier that socket uses.
+ */
+@Composable
+private fun CarrierSection(
+    uiState: AmneziaWgProfileUiState,
+    onFieldChanged: (AwgEditorField, String) -> Unit,
+    onCarrierSelected: (String) -> Unit,
+) {
+    val editor = uiState.editor
+    val udpLabel = stringResource(R.string.awg_carrier_udp)
+    val wsLabel = stringResource(R.string.awg_carrier_ws)
+    RipDpiCard {
+        RipDpiPanelHeader(
+            title = stringResource(R.string.awg_section_carrier),
+            supporting = stringResource(R.string.awg_section_carrier_body),
+        )
+        RipDpiDropdown(
+            options =
+                persistentListOf(
+                    RipDpiDropdownOption(value = AwgActivationRequest.CARRIER_UDP, label = udpLabel),
+                    RipDpiDropdownOption(value = AwgActivationRequest.CARRIER_WS, label = wsLabel),
+                ),
+            selectedValue = editor.form.carrier,
+            onValueSelected = onCarrierSelected,
+            label = stringResource(R.string.awg_carrier_picker_label),
+            testTag = RipDpiTestTags.AwgCarrierPicker,
+        )
+        if (editor.form.carrier == AwgActivationRequest.CARRIER_WS) {
+            PlainField(
+                AwgEditorField.CARRIER_WS_URL,
+                R.string.awg_field_carrier_ws_url,
+                editor,
+                onFieldChanged,
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/awg/AmneziaWgProfileViewModel.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/screens/awg/AmneziaWgProfileViewModel.kt
@@ -159,6 +159,14 @@ class AmneziaWgProfileViewModel
         }
 
         /**
+         * Selects the transport carrier ([AwgProfileForm.carrier]) by [carrier] token
+         * ([AwgActivationRequest.CARRIER_UDP] or [AwgActivationRequest.CARRIER_WS]).
+         */
+        fun onCarrierSelected(carrier: String) {
+            mutateEditor { it.selectCarrier(carrier) }
+        }
+
+        /**
          * Replaces the editor state from a pasted AmneziaWG `.conf`. Malformed input or a
          * vanilla WireGuard config leaves the editor unchanged.
          */

--- a/app/src/main/kotlin/com/poyka/ripdpi/ui/testing/RipDpiTestTags.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/ui/testing/RipDpiTestTags.kt
@@ -97,6 +97,7 @@ internal object RipDpiTestTags {
     const val ConfigOverflowMenuButton = "config-overflow-menu-button"
     const val ConfigImportClipboardMenuItem = "config-import-clipboard-menu-item"
     const val AwgCohortPicker = "awg-cohort-picker"
+    const val AwgCarrierPicker = "awg-carrier-picker"
     const val AwgConnectAction = "awg-connect-action"
     const val ModeEditorCancel = "mode-editor-cancel"
     const val ModeEditorSave = "mode-editor-save"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -2758,6 +2758,12 @@ fakeddisorder endhost</string>
     <string name="awg_editor_title">ملف شخصي AmneziaWG</string>
     <string name="awg_section_interface">الواجهة</string>
     <string name="awg_section_peer">الند</string>
+    <string name="awg_section_carrier">النقل</string>
+    <string name="awg_section_carrier_body">كيفية مغادرة رزم WireGuard للجهاز. تُغلّفها WebSocket من أجل الشبكات التي تحظر UDP العادي.</string>
+    <string name="awg_carrier_picker_label">الناقل</string>
+    <string name="awg_carrier_udp">UDP (الافتراضي)</string>
+    <string name="awg_carrier_ws">WebSocket</string>
+    <string name="awg_field_carrier_ws_url">رابط WebSocket</string>
     <string name="awg_section_obfuscation">التعمية</string>
     <string name="awg_section_obfuscation_body">قيم منسَّقة مع الخادم. الصقها كما هي من مزودك، أو اختر إعداداً مسبقاً لمجموعة.</string>
     <string name="awg_field_server">الخادم</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2812,6 +2812,12 @@ Quelle: %2$s</string>
     <string name="awg_editor_title">AmneziaWG-Profil</string>
     <string name="awg_section_interface">Schnittstelle</string>
     <string name="awg_section_peer">Peer</string>
+    <string name="awg_section_carrier">Transport</string>
+    <string name="awg_section_carrier_body">Wie die WireGuard-Datagramme das Gerät verlassen. WebSocket verpackt sie für Netzwerke, die einfaches UDP blockieren.</string>
+    <string name="awg_carrier_picker_label">Träger</string>
+    <string name="awg_carrier_udp">UDP (Standard)</string>
+    <string name="awg_carrier_ws">WebSocket</string>
+    <string name="awg_field_carrier_ws_url">WebSocket-URL</string>
     <string name="awg_section_obfuscation">Verschleierung</string>
     <string name="awg_section_obfuscation_body">Mit dem Server abgestimmte Werte. Füge sie unverändert von deinem Anbieter ein oder wähle eine Kohorten-Vorlage.</string>
     <string name="awg_field_server">Server</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2812,6 +2812,12 @@ Origen: %2$s</string>
     <string name="awg_editor_title">Perfil de AmneziaWG</string>
     <string name="awg_section_interface">Interfaz</string>
     <string name="awg_section_peer">Par</string>
+    <string name="awg_section_carrier">Transporte</string>
+    <string name="awg_section_carrier_body">Cómo salen los datagramas de WireGuard del dispositivo. WebSocket los envuelve para redes que bloquean el UDP normal.</string>
+    <string name="awg_carrier_picker_label">Portador</string>
+    <string name="awg_carrier_udp">UDP (predeterminado)</string>
+    <string name="awg_carrier_ws">WebSocket</string>
+    <string name="awg_field_carrier_ws_url">URL de WebSocket</string>
     <string name="awg_section_obfuscation">Ofuscación</string>
     <string name="awg_section_obfuscation_body">Valores coordinados con el servidor. Pégalos literalmente de tu proveedor o elige un preajuste de cohorte.</string>
     <string name="awg_field_server">Servidor</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -2817,6 +2817,12 @@ fakeddisorder endhost</string>
     <string name="awg_editor_title">نمایهٔ AmneziaWG</string>
     <string name="awg_section_interface">رابط</string>
     <string name="awg_section_peer">همتا</string>
+    <string name="awg_section_carrier">حامل انتقال</string>
+    <string name="awg_section_carrier_body">چگونگی خروج بسته‌های WireGuard از دستگاه. WebSocket آن‌ها را برای شبکه‌هایی که UDP ساده را مسدود می‌کنند بسته‌بندی می‌کند.</string>
+    <string name="awg_carrier_picker_label">حامل</string>
+    <string name="awg_carrier_udp">UDP (پیش‌فرض)</string>
+    <string name="awg_carrier_ws">WebSocket</string>
+    <string name="awg_field_carrier_ws_url">نشانی WebSocket</string>
     <string name="awg_section_obfuscation">مبهم‌سازی</string>
     <string name="awg_section_obfuscation_body">مقادیر هماهنگ‌شده با کارساز. آن‌ها را عیناً از ارائه‌دهندهٔ خود بچسبانید یا یک پیش‌تنظیم گروه را برگزینید.</string>
     <string name="awg_field_server">کارساز</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2812,6 +2812,12 @@ Source : %2$s</string>
     <string name="awg_editor_title">Profil AmneziaWG</string>
     <string name="awg_section_interface">Interface</string>
     <string name="awg_section_peer">Pair</string>
+    <string name="awg_section_carrier">Transport</string>
+    <string name="awg_section_carrier_body">Comment les datagrammes WireGuard quittent l\'appareil. WebSocket les encapsule pour les réseaux qui bloquent l\'UDP simple.</string>
+    <string name="awg_carrier_picker_label">Porteur</string>
+    <string name="awg_carrier_udp">UDP (par défaut)</string>
+    <string name="awg_carrier_ws">WebSocket</string>
+    <string name="awg_field_carrier_ws_url">URL WebSocket</string>
     <string name="awg_section_obfuscation">Obfuscation</string>
     <string name="awg_section_obfuscation_body">Valeurs coordonnées avec le serveur. Collez-les telles quelles depuis votre fournisseur, ou choisissez un préréglage de cohorte.</string>
     <string name="awg_field_server">Serveur</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2941,6 +2941,12 @@ fakeddisorder endhost</string>
     <string name="awg_editor_title">Профиль AmneziaWG</string>
     <string name="awg_section_interface">Интерфейс</string>
     <string name="awg_section_peer">Пир</string>
+    <string name="awg_section_carrier">Транспорт</string>
+    <string name="awg_section_carrier_body">Как датаграммы WireGuard покидают устройство. WebSocket оборачивает их для сетей, блокирующих обычный UDP.</string>
+    <string name="awg_carrier_picker_label">Носитель</string>
+    <string name="awg_carrier_udp">UDP (по умолчанию)</string>
+    <string name="awg_carrier_ws">WebSocket</string>
+    <string name="awg_field_carrier_ws_url">URL WebSocket</string>
     <string name="awg_section_obfuscation">Обфускация</string>
     <string name="awg_section_obfuscation_body">Значения, согласованные с сервером. Вставьте их дословно от провайдера или выберите пресет когорты.</string>
     <string name="awg_field_server">Сервер</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2808,6 +2808,12 @@ fake_burst 3</string>
     <string name="awg_editor_title">AmneziaWG 配置</string>
     <string name="awg_section_interface">接口</string>
     <string name="awg_section_peer">对端</string>
+    <string name="awg_section_carrier">传输方式</string>
+    <string name="awg_section_carrier_body">WireGuard 数据报离开设备的方式。WebSocket 会将其封装，以应对屏蔽普通 UDP 的网络。</string>
+    <string name="awg_carrier_picker_label">承载方式</string>
+    <string name="awg_carrier_udp">UDP（默认）</string>
+    <string name="awg_carrier_ws">WebSocket</string>
+    <string name="awg_field_carrier_ws_url">WebSocket 地址</string>
     <string name="awg_section_obfuscation">混淆</string>
     <string name="awg_section_obfuscation_body">由服务器协调的值。请从提供商处原样粘贴，或选择一个群组预设。</string>
     <string name="awg_field_server">服务器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2968,6 +2968,12 @@ Source: %2$s</string>
     <string name="awg_editor_title">AmneziaWG profile</string>
     <string name="awg_section_interface">Interface</string>
     <string name="awg_section_peer">Peer</string>
+    <string name="awg_section_carrier">Transport</string>
+    <string name="awg_section_carrier_body">How the WireGuard datagrams leave the device. WebSocket wraps them for networks that block plain UDP.</string>
+    <string name="awg_carrier_picker_label">Carrier</string>
+    <string name="awg_carrier_udp">UDP (default)</string>
+    <string name="awg_carrier_ws">WebSocket</string>
+    <string name="awg_field_carrier_ws_url">WebSocket URL</string>
     <string name="awg_section_obfuscation">Obfuscation</string>
     <string name="awg_section_obfuscation_body">Server-coordinated values. Paste them verbatim from your provider, or pick a cohort preset.</string>
     <string name="awg_field_server">Server</string>

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/awg/AmneziaWgProfileScreenTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screens/awg/AmneziaWgProfileScreenTest.kt
@@ -228,6 +228,7 @@ private fun ScreenUnderTest(viewModel: AmneziaWgProfileViewModel) {
         onBack = {},
         onFieldChanged = viewModel::onFieldChanged,
         onCohortSelected = viewModel::onCohortSelected,
+        onCarrierSelected = viewModel::onCarrierSelected,
         onPasteConf = {},
         onRevealPrivateKey = viewModel::onPrivateKeyRevealAuthorized,
         onRevealPresharedKey = viewModel::onPresharedKeyRevealAuthorized,

--- a/app/src/test/kotlin/com/poyka/ripdpi/ui/screenshot/AmneziaWgProfileScreenshotTest.kt
+++ b/app/src/test/kotlin/com/poyka/ripdpi/ui/screenshot/AmneziaWgProfileScreenshotTest.kt
@@ -135,6 +135,7 @@ class AmneziaWgProfileScreenshotTest {
                 onBack = {},
                 onFieldChanged = { _, _ -> },
                 onCohortSelected = {},
+                onCarrierSelected = {},
                 onPasteConf = {},
                 onRevealPrivateKey = {},
                 onRevealPresharedKey = {},

--- a/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/awg/AwgActivationRequest.kt
+++ b/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/awg/AwgActivationRequest.kt
@@ -96,10 +96,11 @@ data class AwgActivationObfuscation(
  * ([interfaceAddressV4], [mtu], [persistentKeepalive]).
  *
  * The obfuscation group (including the AWG-2.0 `i1`..`i5` payloads and the full
- * `s1`..`s4` junk-size knobs) and the identity + PSK fields come straight from
- * [form]; `s3`/`s4` carry through to the native runtime alongside `s1`/`s2`. A
- * blank [interfaceAddressV4] yields a request the service layer is expected to
- * reject -- the mapper does not invent a default address.
+ * `s1`..`s4` junk-size knobs), the identity + PSK fields, and the transport
+ * carrier ([AwgProfileForm.carrier] / [AwgProfileForm.carrierWsUrl]) come
+ * straight from [form]; `s3`/`s4` carry through to the native runtime alongside
+ * `s1`/`s2`. A blank [interfaceAddressV4] yields a request the service layer is
+ * expected to reject -- the mapper does not invent a default address.
  */
 fun AwgProfileForm.toActivationRequest(
     profileId: String,
@@ -117,6 +118,8 @@ fun AwgProfileForm.toActivationRequest(
         interfaceAddressV4 = interfaceAddressV4,
         mtu = mtu,
         persistentKeepalive = persistentKeepalive,
+        carrier = carrier,
+        carrierWsUrl = carrierWsUrl,
         obfuscation =
             AwgActivationObfuscation(
                 jc = jc,

--- a/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/awg/AwgProfileForm.kt
+++ b/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/awg/AwgProfileForm.kt
@@ -16,6 +16,11 @@ import kotlinx.serialization.Serializable
  * when they were hand-entered / imported without a match. Applying a preset
  * touches only the obfuscation group and [cohortId]; the identity group is
  * always preserved.
+ *
+ * [carrier] / [carrierWsUrl] select the transport the WireGuard datagrams
+ * egress over -- [AwgActivationRequest.CARRIER_UDP] (the default) or
+ * [AwgActivationRequest.CARRIER_WS] -- and mirror straight through
+ * [toActivationRequest]; see that request type for the wire-token contract.
  */
 @Serializable
 data class AwgProfileForm(
@@ -41,6 +46,8 @@ data class AwgProfileForm(
     val i4: String = "",
     val i5: String = "",
     val cohortId: String = CUSTOM_COHORT_ID,
+    val carrier: String = AwgActivationRequest.CARRIER_UDP,
+    val carrierWsUrl: String = "",
 ) {
     companion object {
         /** The sentinel id for a profile whose obfuscation fields match no preset. */

--- a/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/uri/ProxyUriCodec.kt
+++ b/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/uri/ProxyUriCodec.kt
@@ -243,6 +243,13 @@ object ProxyUriCodec {
             val flow = queryValue(rawQuery, "flow") ?: "xtls-rprx-vision"
             val fp = queryValue(rawQuery, "fp")
             val transportType = queryValue(rawQuery, "type")?.lowercase()
+            // RIPDPI's VLESS+REALITY client only implements the plain-TCP and xhttp
+            // wire transports. A share link advertising grpc/ws/h2/httpupgrade/etc.
+            // must be rejected rather than silently coerced to TCP Reality, which
+            // would activate the wrong wire transport against the server.
+            if (transportType != null && transportType != "tcp" && transportType != "xhttp") {
+                return null
+            }
             val xhttpPath = if (transportType == "xhttp") queryValue(rawQuery, "path") else null
             val xhttpHost = if (transportType == "xhttp") queryValue(rawQuery, "host") else null
             val xhttpMode = if (transportType == "xhttp") queryValue(rawQuery, "mode") ?: "auto" else "auto"

--- a/core/data/runtime-state/src/test/kotlin/com/poyka/ripdpi/data/awg/AwgActivationRequestTest.kt
+++ b/core/data/runtime-state/src/test/kotlin/com/poyka/ripdpi/data/awg/AwgActivationRequestTest.kt
@@ -78,4 +78,26 @@ class AwgActivationRequestTest {
         assertEquals(AwgActivationRequest.DEFAULT_MTU, request.mtu)
         assertEquals(0, request.persistentKeepalive)
     }
+
+    @Test
+    fun `carrier defaults to UDP with a blank URL`() {
+        val request = form().toActivationRequest(profileId = "awg-1", interfaceAddressV4 = "10.8.0.2/32")
+
+        assertEquals(AwgActivationRequest.CARRIER_UDP, request.carrier)
+        assertEquals("", request.carrierWsUrl)
+    }
+
+    @Test
+    fun `a WS carrier selection and its URL project verbatim`() {
+        val wsForm =
+            form().copy(
+                carrier = AwgActivationRequest.CARRIER_WS,
+                carrierWsUrl = "wss://vpn.example.com:443/path",
+            )
+
+        val request = wsForm.toActivationRequest(profileId = "awg-1", interfaceAddressV4 = "10.8.0.2/32")
+
+        assertEquals(AwgActivationRequest.CARRIER_WS, request.carrier)
+        assertEquals("wss://vpn.example.com:443/path", request.carrierWsUrl)
+    }
 }

--- a/core/data/src/test/kotlin/com/poyka/ripdpi/data/ProxyUriCodecTest.kt
+++ b/core/data/src/test/kotlin/com/poyka/ripdpi/data/ProxyUriCodecTest.kt
@@ -34,6 +34,39 @@ class ProxyUriCodecTest {
     }
 
     @Test
+    fun `rejects vless reality uri with unsupported wire transport instead of coercing to tcp`() {
+        // grpc/ws/h2/httpupgrade REALITY transports are not implemented by RIPDPI's
+        // VLESS+REALITY client; the codec must reject them rather than silently
+        // activating a plain-TCP REALITY profile that would speak the wrong wire
+        // transport to the server.
+        val grpc =
+            ProxyUriCodec.parse(
+                "vless://00000000-0000-0000-0000-000000000000@edge.example.com:443" +
+                    "?type=grpc&security=reality#grpc-node",
+            )
+        val ws =
+            ProxyUriCodec.parse(
+                "vless://00000000-0000-0000-0000-000000000000@edge.example.com:443" +
+                    "?type=ws&security=reality#ws-node",
+            )
+        val h2 =
+            ProxyUriCodec.parse(
+                "vless://00000000-0000-0000-0000-000000000000@edge.example.com:443" +
+                    "?type=h2&security=reality#h2-node",
+            )
+        val httpupgrade =
+            ProxyUriCodec.parse(
+                "vless://00000000-0000-0000-0000-000000000000@edge.example.com:443" +
+                    "?type=httpupgrade&security=reality#httpupgrade-node",
+            )
+
+        assertNull("type=grpc must be rejected", grpc)
+        assertNull("type=ws must be rejected", ws)
+        assertNull("type=h2 must be rejected", h2)
+        assertNull("type=httpupgrade must be rejected", httpupgrade)
+    }
+
+    @Test
     fun `removed legacy schemes vmess and trojan-go are rejected`() {
         // VMess and Trojan-Go were removed; their schemes now hit the else -> null
         // arm and are rejected so callers skip the line.


### PR DESCRIPTION
Two protocol-correctness improvements surfaced by a protocol audit. These are the only two audit findings **not** already independently fixed on `main` (the protect-invariant, import-false-success, and related findings were all landed on `main` in parallel and are excluded here). Branched fresh off `origin/main`.

## F7 — reject unsupported VLESS-Reality transports on import
`ProxyUriCodec.parseVless()` previously special-cased only `type=xhttp`; a `vless+reality` link with `type=grpc/ws/h2` was silently coerced into classic TCP Reality, dialing the wrong wire transport and failing opaquely. Now anything other than `tcp`/`xhttp` is rejected at parse time instead of mis-imported.

- `core/data/.../uri/ProxyUriCodec.kt` (+ `ProxyUriCodecTest.kt`)

## F8 — expose the AmneziaWG WG-over-WebSocket carrier in the editor
The WG-over-WebSocket carrier was fully implemented in the native runtime and Kotlin resolver but had **no UI path** — `AwgProfileForm` never set `carrier`/`carrierWsUrl`, so users in UDP-blocked environments couldn't select the DPI-resistant transport. Adds a UDP/WebSocket carrier picker + WS URL field, wired through `AwgProfileForm.toActivationRequest`, with activation gated on a non-blank URL when WS is selected.

- `AmneziaWgEditorState.kt` (activation now also requires a WS URL when carrier=WS), `AwgProfileForm.kt`, `AwgActivationRequest.kt`, editor screen + test tags, all 8 locales (`MissingTranslation` gate), unit tests.

## Verification
- F8 string parity verified across base + all 7 locales.
- F7 reject logic and the merged `isActivatable()` reviewed against current `main`.
- The AmneziaWG editor conflict (main added `obfuscationConsistent()` gating in parallel) was resolved to combine both conditions.
- Kotlin was verified statically locally; **CI runs the full compile + detekt/lint gates**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)