### PR TITLE
chore(deps): nightly audit 2026-07-04

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -1525,14 +1525,14 @@ version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
 dependencies = [
- "defmt 1.1.0",
+ "defmt 1.1.1",
 ]
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -1540,12 +1540,11 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -4799,28 +4798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4857,7 +4834,7 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7134,9 +7111,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -8135,9 +8112,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "js-sys",
@@ -8156,9 +8133,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Task

N/A — automated nightly dependency and security audit (Rust workspace + Kotlin/Gradle frontend), no linked task file.

## Summary

Nightly sweep of the ~116-crate Rust workspace (`cargo audit`, `cargo update --dry-run --workspace --verbose`, `cargo deny check`) and the Kotlin/Gradle frontend (manual version-catalog cross-check against upstream latest, since live `./gradlew` dependency resolution could not run — see Conflicts). Only the SAFE bucket below was applied.

### Applied

**Rust** (`native/rust/Cargo.lock`, via targeted `cargo update -p <crate> --precise <version>` — no `Cargo.toml` changes, no semver-range crossing):

| Crate | Old → New |
|---|---|
| `rustc-hash` | 2.1.2 → 2.1.3 |
| `time` | 0.3.51 → 0.3.53 |
| `time-macros` | 0.2.30 → 0.2.31 |
| `defmt` | 1.1.0 → 1.1.1 |
| `defmt-macros` | 1.1.0 → 1.1.1 |

The `defmt`/`defmt-macros` bump (transitive, via `smoltcp`) drops the dependency on `proc-macro-error2` / `proc-macro-error-attr2` entirely, which incidentally resolves an unmaintained-crate advisory (see Security).

Incidental resolver side-effect noted for transparency: `pwd-grp`'s transitive `thiserror` selection shifted from 2.0.18 → 1.0.69 (both versions already present in the lockfile pre-change; `thiserror` is a proc-macro-only derive crate with no runtime behavior difference between majors). `cargo check --workspace --locked` passed cleanly after all bumps.

**Gradle** — nothing applied. Every dependency spot-checked (Gradle wrapper, AGP, Kotlin, KSP, Compose BOM, Hilt, Room, Coroutines, OkHttp, gRPC, Protobuf, Detekt, Retrofit, Robolectric, `security-crypto`, CameraX) is already at latest stable. This is consistent with yesterday's nightly audit (#228) and the repo's Renovate config already keeping the catalog current.

**Attempted but blocked** (Rust): `proc-macro2`, `quote`, `syn`, `unicode-ident`, `zerofrom-derive` all have newer versions, but bumping them fails — `c2rust-bitfields-derive` (pulled in transitively via `tun-rs`'s `c2rust-bitfields` build dependency) exact-pins `proc-macro2 =1.0.103` / `quote =1.0.40` / `syn =2.0.106` / `unicode-ident =1.0.22`. These can't move until `tun-rs` itself is bumped (see Needs review), so left untouched.

### Security

| Advisory | Severity | Crate | Status |
|---|---|---|---|
| RUSTSEC-2023-0071 (Marvin Attack, rsa timing side-channel) | informational (already tracked) | `rsa` 0.9.10 / 0.10.0-rc.18 | Pre-existing, already accepted + documented with rationale in `native/rust/deny.toml`. Not newly introduced; no safe upgrade exists on either path (Arti / russh). |
| RUSTSEC-2025-0141 (bincode unmaintained) | informational, unresolved | `bincode` 2.0.1 (via `ripdpi-tor` → `typed-index-collections`) | **Unresolved.** Upstream ceased development after a doxxing/harassment incident; no newer version exists to bump to. Flagging for human decision (accept via `deny.toml` ignore + rationale, or migrate `typed-index-collections`'s usage upstream). |
| RUSTSEC-2026-0173 (proc-macro-error2 unmaintained) | informational | `proc-macro-error2` 2.0.1 (via `defmt-macros`) | **Resolved by this PR** — the `defmt` 1.1.1 bump above drops this dependency entirely. |
| — | — | — | `cargo deny check`: advisories/bans/licenses/sources all pass. No yanked versions found in the lockfile. |

### Needs review

Withheld per policy — minor-version bumps and any crypto/networking/async/FFI-adjacent crate, regardless of semver level (anti-DPI project, these surfaces are behavior-sensitive):

| Crate | Old → New | Why withheld |
|---|---|---|
| `tun-rs` | 2.8.5 → 2.8.6 | Core TUN driver — the VPN tunnel surface itself |
| `arti-client`, `tor-rtcompat` | 0.43.0 → 0.44.0 (minor) | Tor networking stack |
| `russh` | 0.61.2 → 0.62.1 (minor) | SSH transport; already a tracked RC-crypto-pin item in `deny.toml` |
| `aws-lc-rs`, `chacha20`, `curve25519-dalek`, `ecdsa`, `ed25519-dalek`, `elliptic-curve`, `p256`, `p384`, `p521`, `pkcs5`, `primefield`, `primeorder`, `ssh-cipher`, `ssh-encoding`, `ssh-key` | various (patch → RC-to-stable) | Crypto primitives |
| `rand` (0.9.3→0.9.4, 0.10.1→0.10.2), `reseeding_rng` | patch | RNG — feeds crypto key/nonce generation |
| `rustls-pki-types` | 1.14.1 → 1.15.0 (minor) | TLS/PKI |
| `generic-array`, `hybrid-array` | patch | Foundational byte-array types used directly by the AES-GCM/cipher stack (`ripdpi-shadowsocks`) |
| `num-bigint` | 0.4.6 → 0.4.7 | Pulled in via the Tor (`arti-client`) dependency chain |
| `idna_adapter` | 1.2.0 → 1.2.2 | Domain-name/IDNA processing (via `hickory-resolver`) — DPI-relevant (SNI/hostname handling) |
| `inotify-sys`, `libredox` | patch | Raw syscall/FFI bindings |
| `lua-src`, `luajit-src` | patch/minor | Vendored Lua C source, linked via FFI into `ripdpi-strategy-lua` |
| `js-sys`, `web-sys`, `wasm-bindgen`, `wasm-bindgen-futures`, `wasm-bindgen-macro`, `wasm-bindgen-macro-support`, `wasm-bindgen-shared` | patch | WASM/JS FFI bindings |
| `humantime` | 2.3.0 → 2.4.0 (minor) | Minor bump |
| `rapidhash` | 4.4.1 → 4.5.1 (minor) | Minor bump |

### Major

None found — no major-version bumps available for any workspace dependency (Rust or Gradle) as of this run.

### Conflicts

- **Gradle**: no cross-module version divergence found — every module resolves dependency versions exclusively through the single `gradle/libs.versions.toml` catalog (verified: no hardcoded Maven coordinates with inline versions in any module `build.gradle.kts`), which structurally prevents the "same dep pinned differently per module" failure mode.
- Could **not** run live `./gradlew` dependency resolution to check for *transitive* conflicts: this session's network policy returned 403 on the Gradle 9.6.1 distribution download (`services.gradle.org` → redirects to a `github.com` release asset, which this environment's egress policy denies). Not routed around per policy; flagging so a human with full network access can run `./gradlew :app:dependencies` if a transitive conflict is suspected.

## Test plan

- `cargo audit` (native/rust) — 2 vulnerabilities found, both pre-existing/tracked `rsa` Marvin entries; 4 unmaintained-crate warnings (2 pre-existing/tracked, 1 resolved by this PR, 1 newly flagged and unresolved — see Security).
- `cargo deny check` (native/rust) — advisories/bans/licenses/sources all `ok`.
- `cargo update --dry-run --workspace --verbose` (native/rust) — used in place of `cargo outdated`, which fails on this workspace's vendored `[patch.crates-io] boring-sys` path dependency.
- `cargo check --workspace --locked` (native/rust) — passed after applying the SAFE bumps (116 crates, `Finished dev profile ... in 1m 59s`).
- Gradle version catalog (`gradle/libs.versions.toml`) spot-checked against upstream release pages/changelogs for every pinned library and plugin.

## Checklist

- [x] No baseline files extended (detekt, lint, LoC)
- [x] `timeout-minutes` added to any new CI job — N/A, no CI changes
- [x] Native ABI matrix not broken (if touching native builds) — lockfile-only change, verified via `cargo check --workspace`
- [x] Non-rooted device path still works (if touching VPN/root features) — N/A, no VPN/root code touched


---
_Generated by [Claude Code](https://claude.ai/code/session_014DG487P8Kx1Cu9xNUP42qy)_