### PR TITLE
chore(deps): nightly audit 2026-07-07

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1191,18 +1191,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1210,27 +1210,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -3389,11 +3389,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -8054,7 +8054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",


### PR DESCRIPTION
## Task

Nightly dependency and security audit across the Rust Cargo workspace (`native/rust`, ~116 workspace crates / 907 locked packages) and the Kotlin/Gradle frontend (~13 modules).

## Summary

Automated nightly sweep. Only the **SAFE** bucket is applied in this PR (Rust lockfile only, no `Cargo.toml`/build-file edits). Everything else is reported below for a human decision — nothing in Needs Review or Major was touched.

**Environment note:** this run could not execute any Gradle task. There is no Android SDK in this sandbox, and the pinned Gradle 9.6.1 wrapper cannot be downloaded — `services.gradle.org/distributions/gradle-9.6.1-bin.zip` 307-redirects to a `github.com/gradle/gradle-distributions` release asset, which the environment's egress policy returns `403` for. Per that policy this is reported, not routed around. Because Gradle dependency resolution/build verification was unavailable, **no Gradle version-catalog changes were applied** this cycle, even the patch-level ones — applying an unverified build-file change would violate the "verify before applying" rule. Gradle findings below come from static analysis (single-source-of-truth check on `gradle/libs.versions.toml`) and direct Maven Central / Google Maven `maven-metadata.xml` queries for current-vs-latest-stable versions.

## Applied

Rust (`native/rust/Cargo.lock`, via targeted `cargo update -p <crate>` — no `Cargo.toml` changes needed, all satisfied by existing version requirements):

| crate | old → new |
|---|---|
| `crossbeam-epoch` | 0.9.18 → 0.9.20 (resolves RUSTSEC-2026-0204, see Security) |
| `crossbeam-channel` | 0.5.15 → 0.5.16 |
| `crossbeam-deque` | 0.8.6 → 0.8.7 |
| `crossbeam-queue` | 0.3.12 → 0.3.13 |
| `crossbeam-utils` | 0.8.21 → 0.8.22 |
| `cc` | 1.2.65 → 1.2.66 |
| `jobserver` | 0.1.34 → 0.1.35 |

All seven are patch-level and outside the crypto/networking/async-runtime/JNI-FFI carve-out (build-time tooling and general-purpose concurrency primitives, not `tokio`/TLS/JNI surfaces). Verified with `cargo check --workspace --locked --all-features --tests` (clean, only a pre-existing unrelated `dead_code` warning in `ripdpi-tunnel-core`) and `cargo deny check` (`advisories ok, bans ok, licenses ok, sources ok`).

No Gradle changes applied this cycle (see environment note above).

## Security

| Advisory | Severity | Package | Status |
|---|---|---|---|
| [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) | Invalid pointer dereference in `fmt::Pointer` for `Atomic`/`Shared` on a null pointer | `crossbeam-epoch` 0.9.18 | **Resolved** by the Applied bump to 0.9.20. Published 2026-07-06 (one day before this run); reached via `moka → hickory-resolver → ripdpi-diagnostics-probes` (production) and `criterion → ripdpi-bench`/`ripdpi-io-uring` (dev-only). |
| [RUSTSEC-2023-0071](https://rustsec.org/advisories/RUSTSEC-2023-0071) | Marvin Attack timing sidechannel | `rsa` 0.9.10 (via Arti) and `rsa` 0.10.0-rc.18 (via russh) | Unresolved — already tracked and ignored in `native/rust/deny.toml` with a documented justification (session-identifier signing only, not attacker-chosen plaintext; no safe upgrade exists on either path). No action taken; pre-existing acceptance, not new. |
| [RUSTSEC-2025-0069](https://rustsec.org/advisories/RUSTSEC-2025-0069) | `daemonize` unmaintained | `daemonize` 0.5.0 | Unresolved — already tracked/ignored in `deny.toml` (root-helper binary only, opt-in feature). Pre-existing acceptance. |
| [RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436) | `paste` unmaintained | `paste` 1.0.15 | Unresolved — already tracked/ignored in `deny.toml` (proc-macro only, no runtime risk, no replacement upstream). Pre-existing acceptance. |
| [RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141) | `bincode` unmaintained | `bincode` 2.0.1 | **New this run** — not yet in `deny.toml`'s ignore list. A major version (3.0.0) is available; see Major bucket below. Needs a human decision: migrate to bincode 3, or add a documented `deny.toml` ignore if 2.x stays. |

## Needs review

**Rust — patch-level but crypto/networking/async/FFI-adjacent (withheld per policy regardless of semver):**

| crate | old → new | why withheld |
|---|---|---|
| `aws-lc-rs` | 1.17.0 → 1.17.1 | crypto backend (rustls) |
| `chacha20` | 0.9.1/0.10.0 → 0.10.1 | crypto cipher |
| `hybrid-array` | 0.4.12 → 0.4.13 | RustCrypto internal (crypto-adjacent) |
| `idna_adapter` | 1.2.0 → 1.2.2 | DNS/URL domain-name handling |
| `inotify` / `inotify-sys` | 0.11.2 → 0.11.3 / 0.1.5 → 0.1.7 | raw FFI binding to libc inotify |
| `pkcs5` | 0.8.0 → 0.8.1 | crypto (PKCS#5 key encryption) |
| `quinn-proto` | 0.11.15 → 0.11.16 | QUIC protocol internals (core transport) |
| `rand` / `reseeding_rng` | 0.8.6/0.9.3/0.10.1 → 0.10.2 / 0.10.6 → 0.10.7 | security-relevant RNG |
| `tun-rs` | 2.8.5 → 2.8.6 | TUN device interface (core VPN networking) |
| `zerocopy` / `zerocopy-derive` | 0.8.52 → 0.8.53 | unsafe byte-layout parsing primitives |

**Rust — minor-version bumps (100 total, withheld per policy regardless of sensitivity); highlights:**

- **Tor stack**: `arti-client` + ~34 `tor-*` crates, all 0.43.0 → 0.44.0 in lockstep (Tor client backend behind `ripdpi-tor`). Worth doing as one coordinated PR.
- **`russh` 0.61.2 → 0.62.2** (+ `russh-cryptovec`) — the SSH relay engine. `deny.toml` documents that 0.61.2 exact-pins release-candidate RustCrypto primitives (`rsa 0.10.0-rc.18`, `ed25519-dalek 3.0.0-rc.0`, `aes-gcm 0.11.0-rc.4`, etc.); worth checking whether 0.62.2 has moved off those RC pins before landing.
- `rustls-pki-types` 1.14.1 → 1.15.0, `sha3` 0.10.9/0.11.0 → 0.12.0, `rand_distr` 0.5.1 → 0.6.0, `rand_xorshift` 0.4.0 → 0.5.0, `rdrand` 0.8.3 → 0.9.0.
- Remaining ~61 minor bumps are ordinary non-sensitive transitive deps, withheld only because rule 3 blocks all minor bumps from auto-apply; full list captured in the audit run log if useful for a batch follow-up PR.

**Rust — blocked by resolver/MSRV, not actionable this cycle:**

- `proc-macro2`, `quote`, `syn` (2.x line), `unicode-ident`, `unty`, `zerofrom-derive` all have newer patch releases upstream, but `cargo update -p` could not move any of them under the current dependency graph / the `rust-toolchain.toml` 1.96.0 MSRV pin. No action possible without investigating which constraint is pinning them.
- `elliptic-curve` 0.13.8/0.14.0-rc.33 → 0.14.1: part of the same tracked RC-crypto chain as `russh` above; `deny.toml` already documents no safe upgrade exists. No new action.

**Gradle — all withheld this cycle** (see environment note; none verified against a real Gradle build):

| dependency | old → new | kind |
|---|---|---|
| `hilt` (library + Gradle plugin, shared version key) | 2.60 → 2.60.1 | patch |
| `compose-preview-plugin` (`ee.schimke.composeai.preview`) | 0.16.15 → 0.16.26 | patch |
| `androidx.test.uiautomator` | 2.3.0 → 2.4.0 | minor |
| `roborazzi` (library + Gradle plugin) | 1.65.0 → 1.66.0 | minor |
| `androidx-hilt` (`hilt-work` etc.) | 1.3.0 → 1.4.0 | minor |

## Major

**Rust:**

| crate | old → new | note |
|---|---|---|
| `bincode` | 2.0.1 → 3.0.0 | also unmaintained, see Security |
| `x25519-dalek` | 2.0.1 → 3.0.0 | core VPN/relay key-exchange primitive; breaking API expected |
| `icu_collections`, `icu_locid`, `icu_locid_transform`, `icu_normalizer`, `icu_normalizer_data`, `icu_properties`, `icu_properties_data`, `icu_provider` | 1.5.x → 2.x | Unicode/ICU data crates (transitive via `idna`/`url`), coordinated major bump |
| `ordered-float` | 2.10.1 → 5.3.0 | |
| `os_str_bytes` | 6.6.1 → 7.2.0 | |
| `enum-ordinalize` | 3.1.15 → 4.4.1 | |
| `env_filter` | 0.1.4 → 2.0.0 | |
| `hash32` | 0.3.1 → 1.0.0 | |
| `quick-error` | 1.2.3 → 2.0.1 | |
| `r-efi` | 5.3.0/6.0.0 → 7.0.0 | |
| `radium` | 0.7.0 → 1.1.1 | |
| `rusticata-macros` | 4.1.0 → 5.0.0 | |

No advisories on any of the above beyond `bincode` (already called out in Security).

**Gradle:** no stable major bumps pending — AGP's only newer release is `9.4.0-alpha03` (pre-release), Kotlin/Compose-compiler's only newer release is `2.4.20-Beta1` (pre-release). Current pins (AGP 9.2.1, Kotlin 2.4.0) are already the latest stable.

## Conflicts

- **Gradle**: none found. All ~13 modules and the `build-logic` convention plugins source every dependency and plugin version through the single `gradle/libs.versions.toml` catalog — grepped every `build.gradle.kts` for hardcoded `"group:artifact:version"` literals outside the catalog and found none. No cross-module version divergence to resolve.
- **Rust**: `cargo deny check` reports pre-existing `multiple-versions` warnings (configured as `warn`, not `deny`) across roughly 50 crypto crates — this is the already-documented RC-crypto duplication caused by `russh`'s exact-pinned RustCrypto release candidates (see `deny.toml` comments). Not a new conflict; not itemized here.

## Test plan

- `cargo check --workspace --locked --all-features` — clean (pre-existing unrelated warning only)
- `cargo check --workspace --locked --all-features --tests` — clean
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok` (confirms RUSTSEC-2026-0204 resolved)
- Gradle: **not run** — no Android SDK and no way to fetch the pinned Gradle 9.6.1 distribution in this environment (see note above). No Gradle files were changed, so nothing needed verifying on that side this cycle.

## Checklist

- [x] No baseline files extended (detekt, lint, LoC) — Rust-only lockfile change
- [ ] `timeout-minutes` added to any new CI job — N/A, no CI job added
- [x] Native ABI matrix not broken — lockfile-only change, no target/feature/ABI changes
- [ ] Non-rooted device path still works — N/A, no VPN/root code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDLA5eNWsQepDwxRJGLaVQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDLA5eNWsQepDwxRJGLaVQ)_