### PR TITLE
chore(deps): nightly audit 2026-07-10

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -329,7 +329,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -341,7 +341,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -388,7 +388,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -535,7 +535,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -626,7 +626,7 @@ checksum = "e0b121a9fe0df916e362fb3271088d071159cdf11db0e4182d02152850756eff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1377,7 +1377,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1443,7 +1443,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1456,7 +1456,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1478,7 +1478,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1489,7 +1489,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1526,7 +1526,7 @@ dependencies = [
  "defmt-parser",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1546,7 +1546,7 @@ checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1619,7 +1619,7 @@ dependencies = [
  "quote",
  "sha3 0.11.0",
  "strum",
- "syn 2.0.106",
+ "syn 2.0.118",
  "unicode-ident",
  "void",
 ]
@@ -1674,7 +1674,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.106",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1749,7 +1749,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1936,7 +1936,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1949,7 +1949,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1961,7 +1961,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1982,7 +1982,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2200,7 +2200,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2333,7 +2333,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2473,7 +2473,7 @@ checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3110,7 +3110,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3343,7 +3343,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3362,7 +3362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3513,7 +3513,7 @@ checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4074,7 +4074,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4157,7 +4157,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4457,7 +4457,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4501,7 +4501,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4779,9 +4779,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -4892,9 +4892,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -5121,7 +5121,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5138,9 +5138,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -7434,7 +7434,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7507,7 +7507,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7939,7 +7939,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7961,9 +7961,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7987,7 +7987,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8065,7 +8065,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8076,7 +8076,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8214,7 +8214,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9500,7 +9500,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9560,7 +9560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9658,9 +9658,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -9779,7 +9779,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9888,7 +9888,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -10099,7 +10099,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10110,7 +10110,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10490,7 +10490,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -10511,7 +10511,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10531,7 +10531,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -10552,7 +10552,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10584,7 +10584,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.118",
 ]
 
 [[package]]


### PR DESCRIPTION
## Task

Automated nightly dependency and security audit across the Rust Cargo workspace (`native/rust`, ~116 crates) and the Kotlin/Gradle frontend (~16 modules) — not linked to a `docs/tasks/` entry.

## Summary

Ran `cargo audit`, `cargo deny check`, and a targeted outdated-dependency sweep (`cargo update --dry-run` plus per-crate registry lookups) on the Rust side, and a version-catalog freshness + cross-module conflict sweep on the Gradle side. Classified every finding into SAFE / NEEDS REVIEW / MAJOR per the project's crypto/networking/async/FFI-sensitivity policy, and applied only the SAFE bucket.

Because RIPDPI's Rust dependency graph is almost entirely crypto/TLS/QUIC/SSH-adjacent by design (rustls, aws-lc, quinn, boring, russh, tor stack), the SAFE bucket this run is small and consists only of compile-time-only tooling crates with zero runtime/crypto/network surface.

**No Gradle changes were applied.** This sandboxed session's network policy blocks the Gradle wrapper distribution download (`services.gradle.org` → 403), so `./gradlew` could not be run to verify a build — the one Gradle SAFE candidate (KSP patch bump) is listed under Needs review instead of being landed unverified.

## Applied

Rust (`native/rust/Cargo.lock`, verified with `cargo check --workspace --locked`):

- `proc-macro2`: 1.0.103 → 1.0.106 (patch)
- `quote`: 1.0.40 → 1.0.46 (patch)
- `syn`: 2.0.106 → 2.0.118 (patch)
- `unicode-ident`: 1.0.22 → 1.0.24 (patch)
- `regex-automata`: 0.4.14 → 0.4.15 (patch)

All five are compile-time-only proc-macro/parsing/text-matching support crates with no crypto, networking, async-runtime, or JNI/FFI surface, and each moved by patch version only within the existing `Cargo.toml` requirement — no manifest changes needed, `Cargo.lock` only.

Gradle: none (see Needs review).

## Security

- **RUSTSEC-2025-0141 (bincode 2.0.1, "unmaintained") — new, not yet tracked.** Transitive via `arti-client → tor-netdir → typed-index-collections` (optional `bincode` feature). The bincode team ceased development after a doxxing/harassment incident; there is no fixed version in the 2.x line, and a `bincode` 3.0.0 exists on crates.io but its maintainer/provenance is unverified — not eligible for auto-adoption. No downstream-fixable path exists without an upstream Arti release dropping/bumping this transitive dep. Recommend either accepting + documenting in `native/rust/deny.toml`'s `[advisories].ignore` (matching the existing entries below) or tracking upstream Arti's `typed-index-collections` pin.
- RUSTSEC-2023-0071 (rsa, Marvin timing sidechannel, medium 5.9) — already tracked and extensively documented in `deny.toml` (`rsa` 0.9.10 via Arti, `rsa` 0.10.0-rc.18 via russh; no safe upgrade exists on either path). Unresolved by design, no new action.
- RUSTSEC-2025-0069 (`daemonize`, unmaintained) — already tracked/ignored in `deny.toml` (root-helper binary, opt-in, no replacement).
- RUSTSEC-2024-0436 (`paste`, unmaintained) — already tracked/ignored in `deny.toml` (proc-macro only, transitive via `netlink-packet-core`).
- `cargo deny check`: **advisories ok, bans ok, licenses ok, sources ok.** No new license or ban violations; only pre-existing informational `wildcard`/`multiple-versions=warn` notices on internal workspace path-dependencies (not third-party crates).

## Needs review

Rust — crypto/networking/async-runtime/FFI-adjacent or minor-version bumps, withheld regardless of semver level per policy:

| crate | current → available | why withheld |
|---|---|---|
| `aws-lc-rs` | 1.17.0 → 1.17.1 (patch) | TLS crypto backend |
| `aws-lc-sys` | 0.41.0 → 0.42.0 (0.x minor) | TLS crypto backend (native bindings) |
| `chacha20` | 0.10.0 → 0.10.1 (patch) | crypto cipher |
| `der` | 0.8.0 → 0.8.1 (patch) | crypto/cert encoding |
| `pkcs5` | 0.8.0 → 0.8.1 (patch) | crypto key derivation |
| `poly1305` | 0.9.0 → 0.9.1 (patch) | crypto MAC |
| `md5` | 0.8.0 → 0.8.1 (patch) | crypto hash |
| `num-bigint` / `num-iter` | 0.4.6→0.4.8 / 0.1.45→0.1.46 (patch) | RSA bigint arithmetic |
| `rand` | 0.10.1 → 0.10.2 (patch) | crypto RNG (key generation) |
| `rand` (pinned as `rand_09`, exact `=0.9.3`) | 0.9.3 → 0.9.4 (patch) | crypto RNG, exact-pinned |
| `reseeding_rng` | 0.10.6 → 0.10.7 (patch) | RNG/crypto-adjacent |
| `rustls-pki-types` | 1.14.1 → 1.15.0 (minor) | TLS/PKI types |
| `quinn-proto` / `quinn-udp` | 0.11.15→0.11.16 / 0.5.14→0.5.15 (patch) | QUIC networking |
| `zerocopy` / `zerocopy-derive` | 0.8.52 → 0.8.54 (patch) | used via `nix`'s `zerocopy` feature on packet code paths |
| `idna_adapter` | 1.2.0 → 1.2.2 (patch) | hostname/IDNA encoding, networking-adjacent |
| `russh` | exact `=0.62.1` → 0.62.2 available (patch) | SSH crypto/network relay (`ripdpi-ssh`); exact-pinned by design, already has an RC-crypto tracking note in `deny.toml` |
| `rapidhash` | 4.4.2 → 4.5.1 (minor) | minor-bump rule (non-crypto) |
| `humantime` | 2.3.0 → 2.4.0 (minor) | minor-bump rule (non-crypto) |

Gradle:

- `ksp`: 2.3.9 → 2.3.10 (patch, KSP is pure Kotlin-compiler tooling, no crypto/network/async/FFI surface) — **SAFE by classification but withheld**: this session's network policy blocks the Gradle distribution download, so `./gradlew` could not run to verify the build. Recommend landing via the normal weekly Dependabot run or a follow-up PR from a network-unrestricted environment.
- `roborazzi`: 1.66.0 → 1.67.0 (minor) — screenshot-testing tool, not crypto/network, withheld solely by the minor-bump rule.
- `grpc` (`io.grpc`): 1.82.1 → 1.82.2 (patch) — core networking surface (gRPC), withheld regardless of patch level.
- `ee.schimke.composeai.preview` (compose-preview-plugin, currently 0.16.27): latest version could not be confirmed via Maven Central / Gradle Plugin Portal in this session (indexing/access issue) — flagged for manual check, not classified as outdated.

## Major

- `bincode`: 2.0.1 → 3.0.0 available, transitive via `arti-client → tor-netdir → typed-index-collections`. See Security section — abandoned crate, major-bump provenance unverified, not eligible for auto-adoption.
- Coordinated Unicode/ICU stack bump (`icu_collections`, `icu_normalizer`(+`_data`), `icu_properties`(+`_data`), `icu_provider`, `litemap`, `writeable`, `yoke`(+`-derive`), `zerofrom-derive`, new `zerotrie`/`itertools`/`potential_utf`): 1.5.x → 2.2.x, all pulled in as a single atomic `cargo update` resolution (part of the `idna`/`url` hostname-normalization stack used transitively by networking crates). These crates cannot be cherry-picked individually — landing this requires isolated evaluation plus a full workspace test pass, not a mechanical bump.

## Conflicts

Gradle cross-module audit found **zero** hardcoded/duplicated dependency coordinates outside `gradle/libs.versions.toml` — every module resolves through the version catalog, single source of truth confirmed across all 16 modules. Nothing to report.

## Test plan

- `cargo check --workspace --locked` — passes, full workspace (all crates) after the Applied bumps.
- `cargo deny check` (native/rust) — `advisories ok, bans ok, licenses ok, sources ok`.
- `cargo audit` (native/rust) — 2 vulnerabilities / 3 warnings reported, all pre-existing/tracked except RUSTSEC-2025-0141 (documented above, no code change made).
- Gradle: **not verified this run** — `./gradlew` cannot download its pinned distribution in this sandboxed session (network policy blocks `services.gradle.org`, confirmed via direct `curl` 403). No Gradle files were changed as a result, so there is nothing to regress; CI should independently confirm the Kotlin/Gradle side is green as usual.

## Checklist

- [x] No baseline files extended (detekt, lint, LoC)
- [x] `timeout-minutes` — n/a, no CI job changes
- [x] Native ABI matrix not broken — n/a, no native build config changed (Cargo.lock version bumps only)
- [x] Non-rooted device path still works — n/a, no VPN/root code touched


---
_Generated by [Claude Code](https://claude.ai/code/session_016fHyTi6C5HAYyZco9kF5Uh)_