### PR TITLE
chore(deps): nightly audit 2026-07-12

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -3594,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown 0.17.1",
 ]


### PR DESCRIPTION
## Task

Automated nightly dependency and security audit (no linked task file — scheduled routine, not a `docs/tasks/` entry).

## Summary

Ran `cargo audit`, `cargo deny check`, and a targeted `cargo update --dry-run` sweep across the ~150-crate Rust workspace (`cargo-outdated` itself could not run against this workspace — see note under Rust below), plus a static audit of the Gradle version catalog and all 16 module build files (Gradle itself could not execute in this sandbox — `services.gradle.org` is blocked by egress policy — so the Gradle side is a static-analysis pass, not a resolved-dependency-graph pass).

Only **one** change met the SAFE bar; everything else is reported below for human review.

## Applied

**Rust**
- `lru`: `0.18.0` → `0.18.1` (patch, `native/rust/Cargo.lock` only — the `Cargo.toml` requirement `"0.18"` already permitted this version). `lru` is a generic in-memory cache data structure with no crypto/networking/async/FFI surface, so it clears the SAFE bar even though two of its four call sites (`ripdpi-dns-resolver`, `ripdpi-runtime-dns-cache`) are DNS-cache-adjacent modules — the dependency itself carries no such surface.
- Verified with `cargo check --workspace --locked` after applying: `Finished` `dev` profile in 2m42s, no errors.

**Gradle**
- No SAFE changes. Every pinned version in `gradle/libs.versions.toml` (AGP 9.2.1, Kotlin/Compose-compiler 2.4.0, KSP 2.3.9, Hilt 2.60.1, Compose BOM 2026.06.01, Coroutines 1.11.0, OkHttp 5.4.0, Retrofit 3.0.0, Room 2.8.4, Robolectric 4.16.1, detekt 1.23.8, grpc 1.82.1, protobuf 4.35.1, Gradle wrapper 9.6.1, and the rest of the catalog) is already at the latest published stable release. Nothing to apply.

## Security

RustSec advisories found by `cargo audit` (1159 advisories loaded, 910 crate dependencies scanned):

| ID | Crate | Severity | Status |
|---|---|---|---|
| RUSTSEC-2023-0071 | `rsa` 0.9.10 (via Arti→ssh-key-fork-arti) and `rsa` 0.10.0-rc.18 (via `russh`→`ripdpi-ssh`) | 5.9 medium (Marvin timing sidechannel) | Already tracked and explicitly accepted in `native/rust/deny.toml` with a documented exploitability rationale (no attacker-chosen-plaintext RSA signing path in either usage). No fixed upstream release exists. Unchanged by this audit. |
| RUSTSEC-2025-0069 | `daemonize` 0.5.0 | unmaintained | Already tracked/accepted in `deny.toml` (root-helper binary only, opt-in feature). No replacement available. Unchanged. |
| RUSTSEC-2024-0436 | `paste` 1.0.15 | unmaintained | Already tracked/accepted in `deny.toml` (proc-macro, no runtime risk, pulled via `netlink-packet-core`). Unchanged. |
| RUSTSEC-2025-0141 | `bincode` 2.0.1 | unmaintained | **Not currently in `deny.toml`'s ignore list — new finding.** Pulled in transitively via `typed-index-collections` 3.5.0; no RIPDPI crate depends on `bincode` directly, so there is no targeted `Cargo.toml` fix available. A maintained `bincode` 3.0.0 exists upstream, but adopting it requires `typed-index-collections` (or whichever of its dependents) to move first. Needs either a `deny.toml` ignore entry with rationale, or an upstream tracking issue. |

`cargo deny check` result: **advisories ok, bans ok, licenses ok, sources ok** (consistent with the above — the three pre-tracked advisories are the only ones its policy currently accounts for; the new `bincode` warning isn't blocking because `cargo-deny`'s default policy doesn't hard-fail on `unmaintained` warnings, only on denied advisories).

**Noteworthy for `deny.toml`'s existing RC-crypto tracking note:** `curve25519-dalek` (5.0.0), `ed25519-dalek` (3.0.0), `p256`/`p384`/`p521` (0.14.0) have all now shipped **stable** (non-RC) releases upstream — these are exactly the primitives `deny.toml`'s "Known RC-crypto exposure" comment has been waiting on. They're pulled in transitively (via Arti/`russh`), not directly by any RIPDPI crate, so RIPDPI can't pick them up by itself. `russh` has a new patch release available (`0.62.1` → `0.62.2`, we're exact-pinned at `0.62.1`); worth checking as a follow-up whether `0.62.2` (or whatever comes after) has moved off the RC pins, since that would close out the tracked TODO in `native/rust/deny.toml`.

No CVEs or advisories found against any Gradle/Kotlin dependency (OkHttp, grpc-java, protobuf-javalite, Retrofit, `androidx.security:security-crypto`, Hilt/Dagger — the crypto/networking-adjacent set for this VPN app).

## Needs review

Rust, direct dependencies with an available bump that is either crypto/networking/async/FFI-adjacent or crosses a minor version (regardless of sensitivity), per project policy — **none applied**:

- `md5` `0.8.0` → `0.8.1` (patch; crypto hash — used in 6 crates including `ripdpi-shadowsocks`, `ripdpi-anytls`)
- `rand` `0.10.1` → `0.10.2` (patch; CSPRNG/crypto-adjacent — used in 8 crates for keys/nonces)
- `tun-rs` `2.8.6` → `2.8.7` (patch; TUN device driver — core to the VPN packet path, used in `ripdpi-tun-driver`, `ripdpi-tunnel-core`)
- `russh` `=0.62.1` → `0.62.2` (patch; exact-pinned SSH transport + crypto, `ripdpi-ssh`) — the exact pin itself is a deliberate, documented decision (see RC-crypto note above); bumping it needs a human call, not just a version bump
- `sha1` transitive line `0.10.6` → `0.10.7` (patch; crypto hash, not directly declared by any RIPDPI crate — RIPDPI's own direct `sha1 = "0.11"` requirement in `ripdpi-shadowsocks` is already at latest `0.11.0`)

Also transitive-only (not directly declared by any RIPDPI crate, so no targeted `Cargo.toml` edit is possible without a dependent crate updating first) but worth having on record given their crypto/networking role: `aws-lc-rs` `1.17.0`→`1.17.1`, `chacha20` `0.10.0`→`0.10.1`, `der` `0.8.0`→`0.8.1`, `idna_adapter` `1.2.0`→`1.2.2` (DNS/URL-adjacent), `pkcs5` `0.8.0`→`0.8.1`, `poly1305` `0.9.0`→`0.9.1`, `polyval` `0.7.1`→`0.7.2`, `quinn-proto` `0.11.15`→`0.11.16`, `quinn-udp` `0.5.14`→`0.5.15` (QUIC), `regex` `1.12.4`→`1.13.0` (minor), `reseeding_rng` `0.10.6`→`0.10.7`, `rustls-pki-types` `1.14.1`→`1.15.0` (minor), `zerocopy`/`zerocopy-derive` `0.8.52`→`0.8.54` (FFI-adjacent byte-layout casts).

Gradle: none — every crypto/networking/async/FFI-adjacent library (OkHttp, grpc, Retrofit, protobuf-javalite, `security-crypto`, coroutines, `zstd-jni`, `brotli-dec`) is already at latest, so there's nothing pending a review-gated bump this cycle.

## Major

Rust, direct dependencies with an available major (or 0.x-breaking) bump — **none applied**:

- `x25519-dalek` `2.0.1` → `3.0.0` (major; X25519 key exchange, used in `ripdpi-vless` for Reality)
- `tokio-tungstenite` `0.29.0` → `0.30.0` and `tungstenite` `0.29.0` → `0.30.0` (0.x-line bump = breaking under Cargo semver; WebSocket transport, used in `ripdpi-ws-tunnel`, `ripdpi-warp-core`, `ripdpi-wireguard-ws`, `ripdpi-diagnostics-transport`)
- `pollster` `0.4.0` → `1.0.1` (0.x→1.0 major; blocks on futures synchronously, used in `ripdpi-io-uring`)

Transitive-only major availability, informational: `icu_collections` and the wider `icu4x` 1.5.x family have 2.2.0 releases available upstream (surfaced only via an unscoped `cargo update`, which is exactly the kind of broad multi-package churn this audit intentionally avoided applying — see Rust tooling note below).

Gradle: none — nothing outdated at any semver level.

## Notes on tooling limitations this run

- `cargo outdated --workspace` failed outright (`failed to load source for dependency 'boring-sys' ... Unable to update .../vendor/boring-sys`) — a known interaction between `cargo-outdated`'s temp-workspace-copy mechanism and this workspace's `[patch.crates-io] boring-sys = { path = "vendor/boring-sys" }` pin. Substituted a per-crate `cargo update -p <crate> --dry-run` sweep (authoritative, uses real Cargo resolution) to find in-range bumps, cross-referenced against `cargo metadata` to separate directly-declared crates (actionable) from purely transitive ones (not actionable via a targeted `Cargo.toml` edit).
- `./gradlew` could not download its distribution (`services.gradle.org` returned HTTP 403 — blocked by this sandbox's egress policy), so no Gradle task could run. The Gradle findings above are a static-analysis pass over `gradle/libs.versions.toml` and every module's `build.gradle.kts` (all 16 modules use catalog accessors exclusively — no hardcoded versions, no `resolutionStrategy`/`force`/`constraints` blocks found anywhere in the build), cross-checked against `dl.google.com`'s Maven metadata directly where reachable and WebSearch otherwise. This is a heuristic pass, not a resolved dependency graph — transitive-dependency conflicts (e.g. two unrelated libraries pulling different `okio`/`kotlin-stdlib` versions) cannot be ruled out without running `./gradlew :app:dependencies`.

## Test plan

- `cargo check --workspace --locked` (native/rust) — `Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 2m 42s`, no errors, after applying the `lru` bump.
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`.
- No Gradle changes were made, so no Gradle build verification was needed.

## Checklist

- [x] No baseline files extended (detekt, lint, LoC)
- [x] `timeout-minutes` added to any new CI job — n/a, no CI changes
- [x] Native ABI matrix not broken (if touching native builds) — `Cargo.lock`-only patch bump, verified via workspace `cargo check`
- [x] Non-rooted device path still works (if touching VPN/root features) — n/a, no VPN/root code touched


---
_Generated by [Claude Code](https://claude.ai/code/session_013xqV9m7eFpTpHFD849vXTE)_