### PR TITLE
chore(deps): nightly audit 2026-07-17

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -1612,7 +1612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1747ed5fb4ab3a9f8253da3401efe7ca8f8e5ec373b2e700ff55c3304d84e31f"
 dependencies = [
  "heck",
- "indexmap 2.14.0",
+ "indexmap 1.9.3",
  "itertools 0.14.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -6478,7 +6478,7 @@ dependencies = [
  "serde",
  "serde_yaml_ng",
  "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
 ]
 
 [[package]]
@@ -6618,7 +6618,7 @@ dependencies = [
  "rustls",
  "thiserror 2.0.18",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "tor-rtcompat",
 ]
 
@@ -8312,9 +8312,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -8386,9 +8386,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tor-async-utils"
@@ -8638,7 +8638,7 @@ dependencies = [
  "serde_ignored",
  "strum",
  "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "tor-basic-utils",
  "tor-error",
  "tor-rtcompat",


### PR DESCRIPTION
## Task

N/A — automated nightly dependency/security audit (Rust `cargo audit`/`cargo outdated`/`cargo deny` + Gradle version-catalog survey), not tracked as a `docs/tasks/issues/` feature task.

## Summary

Nightly dependency/security sweep across the Rust Cargo workspace (~97 crates under `native/rust/`) and the Kotlin/Gradle build (~13 modules). Only the SAFE bucket is applied here; everything else is reported for a human decision.

### Applied

Rust:
- `toml`: `1.1.2+spec-1.1.0` → `1.1.3+spec-1.1.0` (patch; config-parsing crate only, used by `ripdpi-strategy-config` and `ripdpi-tor`, not on the crypto/network/async/FFI hot path). `toml_writer` came along transitively (`1.1.1+spec-1.1.0` → `1.1.2+spec-1.1.0`).
- Incidental lockfile-only resolver shift: `derive-deftly-macros`' `indexmap` edge moved from the `2.14.0` entry to the already-present `1.9.3` entry (both versions already coexisted in the lockfile pre-change; `derive-deftly-macros` is a compile-time-only proc-macro pulled in via `arti-client`). This is normal `cargo update` graph churn, not a new dependency or a version bump — `cargo check --locked --workspace --all-targets` and `cargo deny --locked check` both pass with it in place.

Gradle: none applied. See **Needs review** below — this session has no Android SDK/NDK and the Gradle wrapper distribution (9.6.1) is not fetchable here (it's a GitHub-hosted release outside this session's repository scope), so Gradle dependency resolution could not be verified. Two patch-level Gradle candidates that would otherwise be SAFE are listed below instead of applied blind.

### Security

RUSTSEC advisories from `cargo audit` against `native/rust/Cargo.lock` (910 dependencies, advisory DB updated 2026-07-13):

| ID | Severity | Package | Status |
|---|---|---|---|
| RUSTSEC-2023-0071 | Marvin Attack (RSA timing side-channel); CVSS 3.1 AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N | `rsa` 0.9.10 (via arti-client) and `rsa` 0.10.0-rc.18 (via russh) | Already waived in `deny.toml` / `advisory-waivers.toml`. **Waiver expires 2026-08-12 — 26 days from this run.** No upstream fix exists on either path per the existing rationale; flagging only because the SLA clock is running down. Tracked at `docs/tasks/issues/unpin-russh-after-rsa-advisory-fix.md`. |
| RUSTSEC-2025-0069 | unmaintained | `daemonize` 0.5.0 | Already waived, expires 2026-10-11. No action needed yet. |
| RUSTSEC-2024-0436 | unmaintained | `paste` 1.0.15 (via netlink-packet-core) | Already waived, expires 2026-10-11. No action needed yet. |
| RUSTSEC-2025-0141 | unmaintained | `bincode` 2.0.1 | **New, untracked.** Pulled in solely by `turmoil` 0.7.2, a `[dev-dependencies]`-only network-simulation crate used by `ripdpi-tunnel-core` and `ripdpi-dns-resolver` tests — not present in the shipped `.so`. Not blocking (`cargo deny check` still passes; unmaintained is informational-only under `deny.toml`), but it has no waiver entry yet. Needs a governance decision: add an `advisory-waivers.toml` entry (owner/expiry/tracking) or find a `turmoil` alternative without `bincode`. |

No yanked crate versions found in the current lockfile.

### Needs review

Rust — patch/minor bumps available, withheld under the crypto/networking/async-runtime/FFI rule regardless of semver level:

- `rustls` 0.23.41 → 0.23.42 (patch) — crypto.
- `tokio` 1.52.3 → 1.52.4 (patch) — async runtime.
- `mio` 1.2.1 → 1.2.2 (patch) — networking (tokio's reactor).
- `socket2` 0.6.4 → 0.6.5 (patch) — networking.
- `http-body-util` 0.1.3 → 0.1.4 (patch) — networking/HTTP, used by `ripdpi-cloudflare-origin`, `ripdpi-masque`, `ripdpi-naiveproxy`, `ripdpi-warp-android`, `ripdpi-xhttp`, `ripdpi-android-fetch-adapter`.
- `ringbuf` 0.5.0 → 0.5.1 (patch) — packet-buffer ring used directly in `ripdpi-tunnel-core`'s hot path.
- `tokio-tungstenite` 0.29.0 → 0.30.0 (minor) — networking/WebSocket.
- `tungstenite` 0.29.0 → 0.30.0 (minor) — networking/WebSocket.

Gradle — withheld because this run's environment cannot verify a Gradle build (no Android SDK/NDK installed, and the pinned Gradle 9.6.1 wrapper distribution lives on a GitHub release this session isn't scoped to fetch):

- `com.android.application` / `com.android.library` / `com.android.test` (AGP): `9.2.1` → `9.3.0` (minor — would need review regardless of verification, per the minor-bump rule).
- `io.nlopez.compose.rules:detekt` (detekt-compose-rules): `0.6.2` → `0.6.3` (patch, static-analysis tool only — would otherwise be SAFE, but held back pending a session with build verification).
- `ee.schimke.composeai.preview` (Compose preview plugin): `0.16.47` → `0.16.52` (patch, dev-tooling only — same caveat).

Not touched (out of scope, intentionally exact-pinned): `rand` is pinned via the `rand_09 = "=0.9.3"` alias for compatibility with a dependency still on the 0.9 API; a `rand` 0.10.2 stable release exists, but `rand` is explicitly on the "never auto-bump" list in `renovate.json`.

### Major

- `x25519-dalek` 2.0.1 → 3.0.0 — crypto primitive used on the WireGuard/desync key-exchange paths; the 3.0 release changes its `StaticSecret`/`PublicKey` API surface. Needs a dedicated review, not a routine bump.

### Conflicts

No Gradle cross-module version conflicts found: the project uses a single `gradle/libs.versions.toml` catalog, no module hardcodes a dependency version outside it (swept every `*.gradle.kts` for inline `group:artifact:version` coordinates — none found), and no `resolutionStrategy` / `force` / `constraints` overrides exist anywhere in the build.

Rust: `cargo deny check bans` reports the usual pre-existing duplicate-major-version warnings (e.g. `aes`, `blake2`, `base64`, `bitflags` each resolve to two coexisting majors, mostly RustCrypto crates pulled both directly and via `russh`/`ssh-key`). These are accepted under `deny.toml`'s `multiple-versions = "warn"` policy already and are not new; not listed as an actionable item here to keep this diff focused on version updates.

## Test plan

- `cd native/rust && cargo check --locked --workspace --all-targets` — host-target compile check after the `toml` bump.
- `cd native/rust && cargo deny --locked check` — advisories/bans/licenses/sources all report `ok` on the resulting lockfile.
- `cd native/rust && cargo audit --json` — 2 known/waived vulnerabilities, 3 unmaintained warnings (1 new/untracked, see Security).
- Gradle: **not run**. This environment has no Android SDK/NDK and cannot fetch the Gradle 9.6.1 wrapper distribution (GitHub-hosted release outside this session's repository scope). No Gradle file was modified in this PR, so nothing here needs a Gradle-side re-verification before merge, but CI should still confirm green on this branch.

## Checklist

- [x] No baseline files extended (detekt, lint, LoC)
- [x] `timeout-minutes` added to any new CI job — n/a, no CI job changed
- [x] Native ABI matrix not broken (if touching native builds) — lockfile-only dependency bump, no ABI/feature changes
- [x] Non-rooted device path still works (if touching VPN/root features) — n/a, no VPN/root code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYQxKhcU1BnQvZec3kM932

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYQxKhcU1BnQvZec3kM932)_