### PR TITLE
fix(ci): document MASQUE fixture drop order

### DIFF
--- a/native/rust/crates/local-network-fixture/src/masque_h3.rs
+++ b/native/rust/crates/local-network-fixture/src/masque_h3.rs
@@ -122,6 +122,8 @@ impl Drop for MasqueH3ClassicConnectFixture {
 /// The caller owns the injected UDP socket, which lets PMTUD tests place the
 /// production MASQUE client behind an observable black-hole fault without
 /// weakening the strict classic-CONNECT oracle above.
+// Drop order: cancel signals shutdown before server_task and target_task are
+// aborted; this prevents either task from outliving the fixture endpoint.
 pub struct MasqueH3ConnectUdpFixture {
     address: SocketAddr,
     target: String,

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/state.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant as StdInstant;
@@ -17,68 +17,13 @@ use super::packet::TcpFlowKey;
 use super::retransmit::RetransmitTracker;
 use super::udp_assoc::{UdpAssociation, UdpEvent, UdpEvictionEntry};
 
+mod pending_uid;
 mod runtime;
 
+pub(in crate::io_loop) use pending_uid::PendingUidUdpPackets;
+#[cfg(test)]
+pub(in crate::io_loop) use pending_uid::{PENDING_UID_UDP_CAPACITY, PENDING_UID_UDP_POOL_CAPACITY};
 pub(in crate::io_loop) use runtime::LoopRuntime;
-
-pub(in crate::io_loop) const PENDING_UID_UDP_CAPACITY: usize = 256;
-pub(in crate::io_loop) const PENDING_UID_UDP_POOL_CAPACITY: usize = PENDING_UID_UDP_CAPACITY + 1;
-
-pub(in crate::io_loop) struct PendingUidUdpPackets {
-    queued: VecDeque<Vec<u8>>,
-    free: Vec<Vec<u8>>,
-    packet_capacity: usize,
-}
-
-impl PendingUidUdpPackets {
-    pub(in crate::io_loop) fn new(packet_capacity: usize) -> Self {
-        let free = (0..PENDING_UID_UDP_POOL_CAPACITY).map(|_| Vec::with_capacity(packet_capacity)).collect();
-        Self { queued: VecDeque::with_capacity(PENDING_UID_UDP_CAPACITY), free, packet_capacity }
-    }
-
-    pub(in crate::io_loop) fn retain(&mut self, packet: &[u8]) -> bool {
-        if packet.len() > self.packet_capacity {
-            return false;
-        }
-        let buffer =
-            if self.queued.len() == PENDING_UID_UDP_CAPACITY { self.queued.pop_front() } else { self.free.pop() };
-        let Some(mut buffer) = buffer else {
-            return false;
-        };
-        buffer.clear();
-        buffer.extend_from_slice(packet);
-        self.queued.push_back(buffer);
-        true
-    }
-
-    pub(in crate::io_loop) fn pop_front(&mut self) -> Option<Vec<u8>> {
-        self.queued.pop_front()
-    }
-
-    pub(in crate::io_loop) fn recycle(&mut self, mut packet: Vec<u8>) {
-        packet.clear();
-        self.free.push(packet);
-    }
-
-    pub(in crate::io_loop) fn len(&self) -> usize {
-        self.queued.len()
-    }
-
-    #[cfg(test)]
-    pub(in crate::io_loop) fn is_empty(&self) -> bool {
-        self.queued.is_empty()
-    }
-
-    #[cfg(test)]
-    pub(in crate::io_loop) fn free_len(&self) -> usize {
-        self.free.len()
-    }
-
-    #[cfg(test)]
-    pub(in crate::io_loop) fn back_ptr(&self) -> Option<*const u8> {
-        self.queued.back().map(Vec::as_ptr)
-    }
-}
 
 pub(in crate::io_loop) struct LoopState {
     pub(in crate::io_loop) device: TunDevice,

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/state/pending_uid.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/state/pending_uid.rs
@@ -1,0 +1,60 @@
+use std::collections::VecDeque;
+
+pub(in crate::io_loop) const PENDING_UID_UDP_CAPACITY: usize = 256;
+pub(in crate::io_loop) const PENDING_UID_UDP_POOL_CAPACITY: usize = PENDING_UID_UDP_CAPACITY + 1;
+
+pub(in crate::io_loop) struct PendingUidUdpPackets {
+    queued: VecDeque<Vec<u8>>,
+    free: Vec<Vec<u8>>,
+    packet_capacity: usize,
+}
+
+impl PendingUidUdpPackets {
+    pub(in crate::io_loop) fn new(packet_capacity: usize) -> Self {
+        let free = (0..PENDING_UID_UDP_POOL_CAPACITY).map(|_| Vec::with_capacity(packet_capacity)).collect();
+        Self { queued: VecDeque::with_capacity(PENDING_UID_UDP_CAPACITY), free, packet_capacity }
+    }
+
+    pub(in crate::io_loop) fn retain(&mut self, packet: &[u8]) -> bool {
+        if packet.len() > self.packet_capacity {
+            return false;
+        }
+        let buffer =
+            if self.queued.len() == PENDING_UID_UDP_CAPACITY { self.queued.pop_front() } else { self.free.pop() };
+        let Some(mut buffer) = buffer else {
+            return false;
+        };
+        buffer.clear();
+        buffer.extend_from_slice(packet);
+        self.queued.push_back(buffer);
+        true
+    }
+
+    pub(in crate::io_loop) fn pop_front(&mut self) -> Option<Vec<u8>> {
+        self.queued.pop_front()
+    }
+
+    pub(in crate::io_loop) fn recycle(&mut self, mut packet: Vec<u8>) {
+        packet.clear();
+        self.free.push(packet);
+    }
+
+    pub(in crate::io_loop) fn len(&self) -> usize {
+        self.queued.len()
+    }
+
+    #[cfg(test)]
+    pub(in crate::io_loop) fn is_empty(&self) -> bool {
+        self.queued.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(in crate::io_loop) fn free_len(&self) -> usize {
+        self.free.len()
+    }
+
+    #[cfg(test)]
+    pub(in crate::io_loop) fn back_ptr(&self) -> Option<*const u8> {
+        self.queued.back().map(Vec::as_ptr)
+    }
+}


### PR DESCRIPTION
Restores the Rust lint gate by documenting the existing shutdown order for the CONNECT-UDP MASQUE test fixture.\n\nValidated locally:\n- `python3 -m unittest discover -s scripts/ci/tests -p 'test_check_drop_order.py' -v`\n- `python3 scripts/ci/check_drop_order.py`