### PR TITLE
chore(deps): nightly audit 2026-07-25

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.3.0"
+agp = "9.3.1"
 benchmark = "1.4.1"
 kotlin-compose = "2.4.10"
 ksp = "2.3.10"

--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -3498,22 +3498,22 @@ dependencies = [
 
 [[package]]
 name = "linkme"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+checksum = "3045e122bd98aef8ec3ad58ce84f0791f64e70163d1a02710af4aa11a4d54cc5"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+checksum = "77060ebe535362c3da75682cd17b0431017b6e7c5661e714fc69a7ad017d1301"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7421,9 +7421,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -7441,22 +7441,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7986,6 +7986,17 @@ name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Task

Nightly automated dependency and security audit — no linked task file (recurring scheduled maintenance run).

## Summary

Full sweep of the Rust Cargo workspace (`native/rust/`, ~90+ member crates) and the Kotlin/Gradle build (~13 modules) via `cargo audit`, `cargo deny check`, `cargo update --dry-run` (cargo-outdated could not run on this workspace — see Conflicts), and a version-catalog + Maven-metadata cross-check on the Gradle side. Findings are classified below; **only the SAFE bucket is applied in this PR.**

Deliberately excluded from this audit (already covered by their own open Dependabot PRs, not touched here to avoid duplicate/conflicting diffs): Rust `ringbuf`, `futures`, `serde_json`, `time`, `tokio`, `hdrhistogram`, `thiserror`, `uuid`; Gradle `ee.schimke.composeai.preview`, `roborazzi`.

### Applied

**Rust** (`native/rust/Cargo.lock`, via `cargo update -p <crate> --precise <version>` — lockfile only, no manifest edits, no unrelated crates touched):
- `linkme`: 0.3.36 → 0.3.37 (patch; pulls in a new transitive `syn v3.0.3` build-dep for `linkme-impl`, coexisting with the existing `syn v2.0.119` used elsewhere — expected, proc-macro-only, no runtime effect)
- `serde` / `serde_core` / `serde_derive`: 1.0.228 → 1.0.229 (patch)

**Gradle** (`gradle/libs.versions.toml`):
- `agp`: 9.3.0 → 9.3.1 (patch; confirmed published via `dl.google.com/android/maven2` metadata, `lastUpdated` 2026-07-23)

None of the applied crates touch crypto, networking, async runtime, or JNI/FFI surfaces.

### Security

- **RUSTSEC-2023-0071** (RSA "Marvin Attack" timing side-channel), severity 5.9/medium — affects `rsa 0.9.10` and `rsa 0.10.0-rc.18` (Arti/russh crypto path). **No patched version exists upstream.** Already waived in `native/rust/deny.toml`'s `[advisories].ignore` list with documented rationale — unresolved, no action possible until upstream fixes the `rsa` crate.
- **RUSTSEC-2025-0141** (`bincode 2.0.1`, unmaintained), published 2025-12-16 — reached via `arti-client → tor-netdir → typed-index-collections → bincode`, i.e. it's in the shipped runtime graph (via `ripdpi-tor`), not test-only. **Not currently in `deny.toml`'s waiver list — untriaged.** No fixed version exists (unmaintained flag only, not a CVE). Needs a human decision: wait for `tor-netdir` to drop it, vendor/fork, or add a documented `deny.toml` waiver. Note: `cargo deny check` does **not** surface this advisory at all (no `unmaintained =` policy configured in `deny.toml`), only `cargo audit` does — worth reconciling the two tools' advisory policies.
- **RUSTSEC-2025-0069** (`daemonize`, unmaintained) and **RUSTSEC-2024-0436** (`paste`, unmaintained) — both already waived in `deny.toml` with documented rationale, no action needed.
- `cargo deny check` (native/rust): `advisories ok, bans ok, licenses ok, sources ok` — clean, both before and after the applied bumps. One hygiene note (not a version issue, not applied here): `deny.toml`'s license allow-list entry `"OpenSSL"` (added for `aws-lc-sys`) currently matches nothing in the dependency graph — appears stale and worth pruning in a future `deny.toml` cleanup pass.
- No yanked crate versions found in `native/rust/Cargo.lock`.

### Needs review

Withheld regardless of semver level per policy (crypto / networking / async runtime / JNI-FFI-adjacent):

**Rust:**
| Crate | Current | Available | Bump | Why withheld |
|---|---|---|---|---|
| `russh` | 0.62.2 (exact-pinned `=`) | 0.62.4 | patch | SSH/crypto transport; also the in-repo comment claiming 0.62.2 is "the latest release" is now stale |
| `libc` | 0.2.186 | 0.2.189 | patch | JNI/FFI-adjacent |
| `mio` | 1.2.1 | 1.2.2 | patch | async runtime |
| `rustls` | 0.23.41 | 0.23.42 | patch | crypto/TLS |
| `tokio-util` | 0.7.18 | 0.7.19 | patch | async runtime |
| `tokio-stream` | 0.1.18 | 0.1.19 | patch | async runtime |
| `tun-rs` | 2.8.7 | 2.8.8 | patch | networking/TUN |
| `webpki-roots` | 1.0.8 | 1.0.9 | patch | crypto/cert roots |
| `http-body-util` | 0.1.3 | 0.1.4 | patch | networking |
| `hyper` | 1.10.1 | 1.11.0 | minor | networking (also minor) |

Transitive-only crypto/net bumps surfaced by `cargo update --dry-run` (not directly declared in `[workspace.dependencies]`, so not independently applied): `aws-lc-rs` 1.17.0→1.17.3, `aws-lc-sys` 0.41.0→0.43.0, `der` 0.8.0→0.8.1, `num-bigint` 0.4.6→0.4.8, `pkcs5` 0.8.0→0.8.1, `poly1305` 0.9.0→0.9.1, `polyval` 0.7.1→0.7.3, `rustls-pki-types` 1.14.1→1.15.1, `sha1` 0.10.6→0.10.7, `sha3` (new pull-in, 0.12.0), `webpki-root-certs` 1.0.8→1.0.9, `quinn-proto` 0.11.15→0.11.16, `quinn-udp` 0.5.14→0.5.15, `route_manager` 0.2.11→0.2.12, `http-body` 1.0.1→1.1.0, `chacha20` 0.10.0→0.10.1.

**Gradle:**
| Dep | Current | Available | Bump | Why withheld |
|---|---|---|---|---|
| `grpc` (grpc-okhttp/grpc-protobuf-lite/grpc-stub) | 1.82.2 | 1.83.0 | minor | networking; release notes not reviewed in depth this run — recommend a changelog check given grpc's history of ABI-sensitive changes |

### Major

**Rust** (breaking changes, not applied):
- `enum-map`: 2.7.3 → 3.1.0 — major
- `etherparse`: 0.20.3 → 0.21.0 — breaking 0.x bump; also networking/packet-parsing
- `maxminddb`: 0.29.0 → 0.30.0 — breaking 0.x bump
- `base64`: 0.22.1 → 0.23.0 — major
- `x25519-dalek`: 2.0.1 → 3.0.0 — major; crypto/ECDH
- `tungstenite`: 0.29.0 → 0.30.0 — breaking 0.x bump; networking/websocket
- `tokio-tungstenite`: 0.29.0 → 0.30.0 — breaking 0.x bump; async + networking

**Gradle:** none found — AGP/Gradle wrapper/Kotlin/Compose BOM/KSP are all at latest stable or the one patch bump above; every other catalog entry is already at latest stable.

### Conflicts

- Static grep across every `build.gradle.kts` (app/, core/**, quality/**, baselineprofile/, build-logic/**, testing/**, root) found **zero** hardcoded dependency versions bypassing the version catalog, and no library pinned to divergent versions across modules.
- `./gradlew :app:dependencies` (to check for transitive-resolution override arrows) could **not** be run to completion in the audit sandbox — no Android SDK / `local.properties` available there, so Gradle fails at project configuration before reaching dependency resolution. Static analysis found no catalog bypasses (the main source of such conflicts), so residual risk is low but **not independently verified via a full Gradle resolution this run** — flagging for the reviewer to close out with a local/CI Gradle sync.

## Test plan

- `rustup run 1.96.0 cargo check --workspace --locked` (pinned toolchain per `native/rust/rust-toolchain.toml`) — clean pass after the `linkme`/`serde` bump.
- `rustup run 1.96.0 cargo deny check` (`native/rust/deny.toml`) — clean pass (`advisories ok, bans ok, licenses ok, sources ok`) after the bump.
- AGP 9.3.1 confirmed as a real published release via `dl.google.com/android/maven2/.../maven-metadata.xml`.
- **Gap:** could not run a full Gradle build / dependency-resolution pass in this sandbox (no Android SDK, no `ANDROID_HOME`/`local.properties`). Recommend a Gradle sync in CI or locally before merge to close this out.

## Checklist

- [x] No baseline files extended (detekt, lint, LoC)
- [ ] `timeout-minutes` added to any new CI job — n/a, no CI job changes
- [x] Native ABI matrix not broken — lockfile-only Rust bumps, no target/profile changes
- [x] Non-rooted device path still works — no behavior-affecting changes in this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01LppZGAkubE6cAgDzhvu6bg)_