### PR TITLE
chore(deps): nightly audit 2026-07-26

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.3.0"
+agp = "9.3.1"
 benchmark = "1.4.1"
 kotlin-compose = "2.4.10"
 ksp = "2.3.10"

--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -5255,9 +5255,9 @@ dependencies = [
 
 [[package]]
 name = "ringbuf"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3ecbcab081b935fb9c618b07654924f27686b4aac8818e700580a83eedcb7f"
+checksum = "a158e09ede21a14b172ca6cdd6208386c6ae2cb6acef58d774368ef8c450dfa7"
 dependencies = [
  "crossbeam-utils",
  "portable-atomic",
@@ -7471,9 +7471,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",


### PR DESCRIPTION
## Task

Nightly scheduled dependency and security audit (Rust Cargo workspace + Kotlin/Gradle frontend). No `docs/tasks/issues/` entry — this is an automated recurring job, not a planned feature task.

## Summary

Nightly audit across the `native/rust` Cargo workspace (~118 crates via `cargo audit`, `cargo deny check`, and crates.io index queries) and the Gradle version catalog (`gradle/libs.versions.toml`) plus a full dependency-resolution pass on `:app`. This PR contains only the **SAFE** bucket: patch-level bumps with no crypto/networking/async-runtime/JNI-FFI surface and no build breakage.

### Applied

**Rust**
- `serde_json`: 1.0.150 → 1.0.151 (patch)
- `ringbuf`: 0.5.0 → 0.5.1 (patch)

**Gradle**
- `agp` (Android Gradle Plugin): 9.3.0 → 9.3.1 (patch)

Two other same-day Rust patch bumps were attempted and **reverted**: `serde`/`serde_core`/`serde_derive` (1.0.228→1.0.229) and `linkme` (0.3.36→0.3.37) each transitively pulled in **`syn v3.0.3`** — a brand-new major version with zero prior track record in this lockfile — as a fresh duplicate dependency alongside the existing `syn` 1.x/2.x entries. That's not a clean patch-only diff, so both were moved to Needs review below rather than silently widening the dependency surface.

### Security

| Advisory | Severity | Crate | Path | Resolved by this PR? |
|---|---|---|---|---|
| RUSTSEC-2023-0071 (Marvin Attack timing side-channel) | CVSS 3.1 (AV:N/AC:H/C:H) | `rsa` 0.9.10 / 0.10.0-rc.18 | `arti-client` → `russh` | **No** — already waived in `advisory-waivers.toml`, tracked in `docs/tasks/issues/unpin-russh-after-rsa-advisory-fix.md`. **Waiver expires 2026-08-12 — about 2.5 weeks out.** No safe upgrade path exists on either the Arti or russh side yet; flagging so the expiry doesn't lapse silently. |
| RUSTSEC-2025-0141 (unmaintained) | — | `bincode` 2.0.1 | `arti-client` → `tor-netdir` → `typed-index-collections` → `bincode` | **No — new, unwaived.** Not present in `advisory-waivers.toml`. Same shape as the three existing waivers (unmaintained crate reached only through a well-maintained upstream's transitive tree, no direct fix available). Needs an owner decision: add a governed waiver (owner/expiry/tracking issue per `advisory-waivers.toml` convention) or wait for `arti-client` to move off it. |
| RUSTSEC-2025-0069 (unmaintained) | — | `daemonize` 0.5.0 | `ripdpi-cli` (feature-isolated) | Already waived, expires 2026-10-11. No action needed now. |
| RUSTSEC-2024-0436 (unmaintained) | — | `paste` 1.0.15 | `netlink-packet-core` | Already waived, expires 2026-10-11. No action needed now. |

No yanked crate versions found in `Cargo.lock` (`cargo deny check` — advisories/bans/licenses/sources all clean beyond the items above and pre-existing warn-level duplicate/wildcard-version lints).

### Needs review

**Rust** (minor bump, or touches crypto/networking/async-runtime/JNI-FFI regardless of semver level):
- `hdrhistogram` 7.5.4 → 7.6.0 (minor)
- `hyper` 1.10.1 → 1.11.0 (minor; networking/HTTP)
- `tokio` 1.52.3 → 1.53.1 (minor; async runtime)
- `mio` 1.2.1 → 1.2.2 (patch, but the async I/O reactor underlying tokio — networking-adjacent)
- `tokio-util` 0.7.18 → 0.7.19 (patch; async runtime utility)
- `tokio-stream` 0.1.18 → 0.1.19 (patch; async runtime utility)
- `futures` 0.3.32 → 0.3.33 (patch; async-adjacent combinators used in cancel-safety-sensitive code)
- `rustls` 0.23.41 → 0.23.42 (patch; TLS/crypto)
- `webpki-roots` 1.0.8 → 1.0.9 (patch; root-CA trust store refresh — low risk but crypto/networking by category)
- `http-body-util` 0.1.3 → 0.1.4 (patch; HTTP/networking)
- `libc` 0.2.186 → 0.2.189 (patch; FFI bindings crate)
- `russh` 0.62.2 → 0.62.4 (patch, but exact-pinned `=0.62.2` on purpose per `deny.toml` — pinned specifically because of the unstable RC-crypto chain tracked in `docs/tasks/issues/unpin-russh-after-rsa-advisory-fix.md`; do not bump without that review)
- `serde`/`serde_core`/`serde_derive` 1.0.228 → 1.0.229 (patch itself, but see "Applied" — reverted because it drags in `syn` v3.0.3)
- `linkme` 0.3.36 → 0.3.37 (same `syn` v3.0.3 issue)

**Gradle** (minor bump):
- `io.grpc:*` (grpc-okhttp/protobuf-lite/stub) 1.82.2 → 1.83.0 (minor; gRPC networking)
- `roborazzi` (library + Gradle plugin) 1.68.0 → 1.70.0 (minor)
- `compose-preview-plugin` (`ee.schimke.composeai.preview`) 0.16.47 → 0.17.26 (0.x minor-equivalent)

### Major

- `enum-map` 2.7.3 → 3.1.0 (major)
- `etherparse` 0.20.3 → 0.21.0 (0.x breaking-equivalent bump; packet-parsing crate, networking-adjacent)
- `maxminddb` 0.29.0 → 0.30.0 (0.x breaking-equivalent bump; GeoIP reader used by `ripdpi-geo`)
- `rand` (the `rand_09` exact-pinned alias, `=0.9.3`) → 0.10.2 available; this is an intentional dual-track pin coexisting with the primary `rand = "0.10"` dependency, presumably for a crate still on the old API — needs coordinated migration, not a blind bump
- `base64` 0.22.1 → 0.23.0 (major-equivalent)
- `x25519-dalek` 2.0.1 → 3.0.0 (major; X25519 key-exchange crypto)
- `tungstenite` / `tokio-tungstenite` 0.29.0 → 0.30.0 (0.x breaking-equivalent bump; WebSocket transport used by the Telegram WS tunnel)

### Conflicts

None found. `gradle/libs.versions.toml` is the single source of truth for every declared dependency across all ~13 Gradle modules — no hardcoded versions bypass the catalog. A full `:app` dependency-resolution pass (`githubFullDebugRuntimeClasspath`) confirmed every catalog-pinned artifact resolves to exactly its declared version; the many `X -> Y` lines in the resolution log are ordinary transitive dependencies being bumped up to our own pins (expected Gradle conflict resolution), not divergences we introduced.

## Test plan

- `cargo check --workspace --locked --all-targets` — clean, after the two Rust SAFE bumps (`native/rust/`)
- `cargo deny --locked check` — `advisories ok, bans ok, licenses ok, sources ok`
- `cargo audit --json` — 2 findings, both pre-existing/tracked (see Security)
- `./gradlew help --stacktrace` — `BUILD SUCCESSFUL`, after the AGP bump, across the full multi-module + native-Rust-aware configuration (this required provisioning a scratch Android SDK/NDK 29.0.14206865 in this sandboxed environment, since none was preinstalled)
- `:app:dependencies --configuration githubFullDebugRuntimeClasspath` — used for the Conflicts cross-check above

## Checklist

- [x] No baseline files extended (detekt, lint, LoC)
- [ ] `timeout-minutes` added to any new CI job — n/a, no new CI job
- [x] Native ABI matrix not broken — no ABI/toolchain changes, patch-level deps only
- [x] Non-rooted device path still works — no runtime code touched, dependency-version bumps only


---
_Generated by [Claude Code](https://claude.ai/code/session_01PztrtFQXh1QY46gkHwAo7t)_