### PR TITLE
chore(deps): nightly audit 2026-07-27

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -3441,9 +3441,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"


### PR DESCRIPTION
## Task

Nightly automated dependency and security audit (no task file — recurring scheduled routine).

## Summary

Nightly sweep of the Rust Cargo workspace (`native/rust/`, ~100 crates via `cargo audit`/`cargo deny`/`cargo update --dry-run`/crates.io index) and the Gradle version catalog (`gradle/libs.versions.toml`, ~13 modules, checked against Google Maven / Maven Central / Gradle Plugin Portal). Findings are split into Applied (this PR), Security, Needs review, and Major, per the classification rules for a DPI-evasion project where crypto/networking/async/FFI surfaces are behavior-sensitive and never auto-applied.

`cargo-outdated` could not run against the full workspace — it fails to resolve the `[patch.crates-io] boring-sys = { path = "vendor/boring-sys" }` vendor patch when copying the workspace to a scratch dir (upstream tooling limitation with local path patches, not a project misconfiguration). Outdated-version data below was instead produced via `cargo update --dry-run` (in-range bumps) plus a manual crates.io sparse-index comparison of every entry in `[workspace.dependencies]` (out-of-range/major bumps).

### Applied

**Rust**
- `libc`: `0.2.186` → `0.2.189` — patch-level, transitive-only (no `Cargo.toml` change), foundational libc syscall bindings with no crypto/networking/async/JNI-FFI-boundary role.

**Gradle**
- None. Every entry in `gradle/libs.versions.toml` (AGP 9.3.1, Kotlin/Compose 2.4.10, KSP 2.3.10, Gradle wrapper 9.6.1, Compose BOM 2026.06.01, and the rest) is already at its latest stable release. No cross-module hardcoded version overrides were found outside the catalog, so there was nothing to align.

### Security

- **RUSTSEC-2023-0071** (rsa Marvin Attack timing side-channel, severity 5.9/medium) — present via both `rsa 0.9.10` (Arti) and `rsa 0.10.0-rc.18` (russh). Already tracked in `deny.toml`/`advisory-waivers.toml`; no fixed upgrade exists on either path. **The waiver expires 2026-08-12 — 16 days from this run.** Per the project's RUSTSEC triage SLA (medium severity = 30-day SLA), this is inside the window but close; flagging now so it gets re-evaluated before the waiver lapses and `cargo deny check` starts failing. Tracking: `docs/tasks/issues/unpin-russh-after-rsa-advisory-fix.md`.
- **RUSTSEC-2025-0069** (`daemonize 0.5.0`, unmaintained) — already waived, expires 2026-10-11. No action needed yet.
- **RUSTSEC-2024-0436** (`paste 1.0.15`, unmaintained) — already waived, expires 2026-10-11. No action needed yet.
- **RUSTSEC-2025-0141** (`bincode 2.0.1`, unmaintained, published 2025-12-16) — **new, not yet in `deny.toml`'s ignore list or `advisory-waivers.toml`.** Pulled transitively via `tor-netdir → typed-index-collections → bincode` (Arti/Tor stack). No fix available upstream (unmaintained, warning-level, not an exploitable vulnerability). Needs a human-authored waiver entry (owner, reason, tracking issue, expiry) following the existing waiver format before `cargo audit`/`cargo deny` triage can close it out — not something this run should silently add.
- `cargo deny --locked check` passed clean (`advisories ok, bans ok, licenses ok, sources ok`); the only output was the existing baseline of `warn`-level duplicate-version/wildcard-dependency notices already permitted by `deny.toml`'s `multiple-versions = "warn"` policy — no new duplicates introduced by this run.

### Needs review

Minor-version bumps and anything touching crypto/networking/async-runtime/JNI-FFI, regardless of semver level — withheld per policy:

**Rust**
| Crate | Current → Available | Why withheld |
|---|---|---|
| `rustls` | 0.23.41 → 0.23.42 | TLS/crypto |
| `aws-lc-rs` / `aws-lc-sys` | 1.17.0 → 1.17.3 / 0.41.0 → 0.43.0 | crypto backend |
| `chacha20`, `poly1305`, `polyval`, `der`, `pkcs5`, `sha1` | patch bumps | crypto primitives |
| `webpki-roots` / `webpki-root-certs` | 1.0.8 → 1.0.9 | TLS root store (crypto) |
| `hyper`, `http-body`, `http-body-util` | 1.10.1→1.11.0 / 1.0.1→1.1.0 / 1.0.1→1.0.4→1.1.0(patch) | networking |
| `quinn-proto`, `quinn-udp` | 0.11.15→0.11.16 / 0.5.14→0.5.15 | networking (QUIC) |
| `route_manager` | 0.2.11 → 0.2.12 | networking (OS routing table) |
| `tun-rs` | 2.8.7 → 2.8.8 | core VPN tunnel driver |
| `tokio-macros`, `tokio-stream`, `tokio-util`, `mio` | patch bumps | async runtime (tokio/mio) |
| `foreign-types-macros` | 0.2.3 → 0.2.4 | FFI wrapper macros for the boring/openssl bindings |
| `idna_adapter` | 1.2.0 → 1.2.2 | domain-name handling (networking-adjacent) |
| `rand` (0.8.x line, transitive via Arti), `reseeding_rng` | patch bumps | Tor/Arti CSPRNG path — security-relevant randomness |
| `etherparse` | 0.20 → 0.21.0 | packet parsing (core to tun/IP handling); 0.x minor bump |
| `maxminddb` | 0.29 → 0.30.0 | 0.x minor bump |
| `base64` | 0.22 → 0.23.0 | 0.x minor bump |
| `tokio-tungstenite` / `tungstenite` | 0.29 → 0.30.0 (pair, bump together) | WebSocket/networking (MTProto WS tunnel path) |
| `bstr`, `cc`, `either`, `fastrand`, `humantime`, `portable-atomic`, `rapidhash`, `regex`, `simd_cesu8`, `tinyvec` | minor bumps | minor-version rule alone (no sensitive category, but still not patch-level) |

**Gradle**
| Dependency | Current → Available | Why withheld |
|---|---|---|
| `grpc` (io.grpc) | 1.82.2 → 1.83.0 | minor bump + networking |
| `compose-preview-plugin` | 0.16.59 → 0.18.2 | minor bump, Compose preview rendering (covered by `compose-preview` rule) |
| `zstd-jni` | 1.5.7-11 → 1.5.7-12 | JNI-bound native library — withheld regardless of patch-level per policy |

### Major

| Crate | Current → Available | Note |
|---|---|---|
| `x25519-dalek` | 2 → 3.0.0 | Crypto key-exchange primitive (Diffie-Hellman). Major bump, needs a dedicated review — do not bump opportunistically. |
| `rand` (pinned `rand_09` alias) | `=0.9.3` → 0.10.2 | Exact-pinned; a separate direct `rand = "0.10"` dependency already coexists for other consumers. Bumping the pin is a deliberate multi-version-alignment decision, not a drive-by update. |
| `enum-map` | 2 → 3.1.0 | Breaking major bump. |
| icu4x family (`icu_collections`, `icu_normalizer`, `icu_properties`, `icu_provider`, etc.) | 1.5.x → 2.2.x | Coordinated major-version cascade in the Unicode/locale-data crates pulled in via the `idna`/`url` chain; `icu_locid` is replaced by `icu_locale_core`. Restructures locale-ID types — needs its own review, not a patch-level drive-by. |

### Conflicts

No cross-module Gradle version divergence found: every dependency in the ~13 Gradle modules resolves through the single `gradle/libs.versions.toml` catalog via `version.ref`, and a repo-wide search found no hardcoded off-catalog version strings in any `build.gradle.kts`. This sandboxed audit environment has no Android SDK/NDK installed, so a full `./gradlew :app:dependencies` transitive-resolution pass (which would also catch a transitive constraint diverging from a declared one) could not be run here — recommend running it in CI or locally as a periodic follow-up if deeper transitive-conflict coverage is wanted; nothing in this run's static catalog check depended on it.

## Test plan

- `cargo check --workspace --locked` (native/rust) — clean, 0 errors/0 warnings, after the `libc` bump.
- `cargo deny --locked check` (native/rust) — `advisories ok, bans ok, licenses ok, sources ok`.
- `cargo audit --file Cargo.lock` (native/rust) — output captured above; no new exploitable vulnerabilities beyond the already-waived ones.
- Gradle: no changes applied, so no Gradle build/test run was required for this diff; version-catalog values were verified against Google Maven / Maven Central / Gradle Plugin Portal metadata directly.

## Checklist

- [x] No baseline files extended (detekt, lint, LoC)
- [ ] `timeout-minutes` added to any new CI job — n/a, no CI changes
- [x] Native ABI matrix not broken (if touching native builds) — Rust workspace `cargo check` verified; no ABI-affecting change
- [x] Non-rooted device path still works (if touching VPN/root features) — n/a, dependency-only change with no code touching VPN/root paths

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gw1Fd6LkkjYxoSqCPpGphw)_