### PR TITLE
fix(ci): restore full CI execution

### DIFF
--- a/.github/actions/setup-android-rust/action.yml
+++ b/.github/actions/setup-android-rust/action.yml
@@ -133,10 +133,10 @@ runs:
 
     # Cache both Android CLI state and the actual package directories under the
     # runner SDK root. Caching ~/.android alone can produce a false cache hit:
-    # the CLI metadata is restored while CMake/NDK remain absent from
-    # $ANDROID_HOME. The verification steps below also fail closed when a cache
-    # archive is incomplete.
-    - name: Cache Android SDK and NDK
+    # the CLI metadata is restored while installed packages remain absent from
+    # $ANDROID_HOME. Keep the large native toolchain in its own conditional
+    # cache so Kotlin-only jobs never archive or restore an NDK.
+    - name: Cache Android SDK baseline
       if: inputs.skip-android-sdk-ndk != 'true'
       id: cache-android-sdk
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -145,9 +145,17 @@ runs:
           ~/.android
           ${{ steps.native-toolchain.outputs.sdk-root }}/platform-tools
           ${{ steps.native-toolchain.outputs.sdk-root }}/platforms/android-${{ steps.native-toolchain.outputs.compile-sdk }}
+        key: android-sdk-${{ runner.os }}-${{ steps.native-toolchain.outputs.compile-sdk }}-${{ hashFiles('.github/actions/setup-android-rust/action.yml') }}
+
+    - name: Cache Android NDK and CMake
+      if: inputs.skip-android-sdk-ndk != 'true' && inputs.setup-android-ndk == 'true'
+      id: cache-android-native
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
           ${{ steps.native-toolchain.outputs.sdk-root }}/ndk/${{ steps.native-toolchain.outputs.ndk }}
           ${{ steps.native-toolchain.outputs.sdk-root }}/cmake/${{ steps.native-toolchain.outputs.cmake }}
-        key: android-sdk-${{ runner.os }}-${{ steps.native-toolchain.outputs.compile-sdk }}-${{ steps.native-toolchain.outputs.ndk }}-cmake-${{ steps.native-toolchain.outputs.cmake }}-ndk-${{ inputs.setup-android-ndk }}-${{ hashFiles('.github/actions/setup-android-rust/action.yml') }}
+        key: android-native-${{ runner.os }}-${{ steps.native-toolchain.outputs.ndk }}-cmake-${{ steps.native-toolchain.outputs.cmake }}-${{ hashFiles('.github/actions/setup-android-rust/action.yml') }}
 
     - name: Ensure Android SDK baseline via android CLI
       if: inputs.skip-android-sdk-ndk != 'true'
@@ -162,6 +170,8 @@ runs:
         if (( ${#packages[@]} > 0 )); then
           bash scripts/ci/android-sdk-install.sh "${packages[@]}"
         fi
+        [[ -x "$sdk_root/platform-tools/adb" ]]
+        [[ -f "$sdk_root/platforms/android-${{ steps.native-toolchain.outputs.compile-sdk }}/android.jar" ]]
 
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       if: inputs.setup-rust == 'true'
@@ -190,6 +200,8 @@ runs:
         if (( ${#packages[@]} > 0 )); then
           bash scripts/ci/android-sdk-install.sh "${packages[@]}"
         fi
+        [[ -f "$sdk_root/ndk/${{ steps.native-toolchain.outputs.ndk }}/source.properties" ]]
+        [[ -x "$sdk_root/cmake/${{ steps.native-toolchain.outputs.cmake }}/bin/cmake" ]]
 
     - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       if: inputs.setup-rust == 'true' && inputs.setup-sccache == 'true'

--- a/.github/actions/setup-android-rust/action.yml
+++ b/.github/actions/setup-android-rust/action.yml
@@ -120,33 +120,48 @@ runs:
       id: native-toolchain
       shell: bash
       run: |
+        set -euo pipefail
+        sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+        if [[ -z "$sdk_root" ]]; then
+          echo "ANDROID_SDK_ROOT or ANDROID_HOME must point to the Android SDK" >&2
+          exit 1
+        fi
+        echo "sdk-root=$sdk_root" >> "$GITHUB_OUTPUT"
         echo "ndk=$(grep '^ripdpi.nativeNdkVersion=' gradle.properties | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
         echo "cmake=$(grep '^ripdpi.nativeCmakeVersion=' gradle.properties | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
         echo "compile-sdk=$(grep '^ripdpi.compileSdk=' gradle.properties | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
 
-    # Cache the android CLI's SDK+NDK directory (~/.android). The android CLI
-    # writes platform-tools, platforms, and NDK packages here, not to
-    # $ANDROID_HOME (/usr/local/lib/android/sdk). Cache key includes the
-    # compile-sdk, NDK version, and NDK setup mode so a Kotlin-only job cannot
-    # save an SDK-only cache that a later native job treats as NDK-complete.
-    # A hash of this action file also invalidates the cache when installation
-    # commands change.
+    # Cache both Android CLI state and the actual package directories under the
+    # runner SDK root. Caching ~/.android alone can produce a false cache hit:
+    # the CLI metadata is restored while CMake/NDK remain absent from
+    # $ANDROID_HOME. The verification steps below also fail closed when a cache
+    # archive is incomplete.
     - name: Cache Android SDK and NDK
       if: inputs.skip-android-sdk-ndk != 'true'
       id: cache-android-sdk
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
-        path: ~/.android
+        path: |
+          ~/.android
+          ${{ steps.native-toolchain.outputs.sdk-root }}/platform-tools
+          ${{ steps.native-toolchain.outputs.sdk-root }}/platforms/android-${{ steps.native-toolchain.outputs.compile-sdk }}
+          ${{ steps.native-toolchain.outputs.sdk-root }}/ndk/${{ steps.native-toolchain.outputs.ndk }}
+          ${{ steps.native-toolchain.outputs.sdk-root }}/cmake/${{ steps.native-toolchain.outputs.cmake }}
         key: android-sdk-${{ runner.os }}-${{ steps.native-toolchain.outputs.compile-sdk }}-${{ steps.native-toolchain.outputs.ndk }}-cmake-${{ steps.native-toolchain.outputs.cmake }}-ndk-${{ inputs.setup-android-ndk }}-${{ hashFiles('.github/actions/setup-android-rust/action.yml') }}
 
-    - name: Install Android SDK baseline via android CLI
-      if: inputs.skip-android-sdk-ndk != 'true' && steps.cache-android-sdk.outputs.cache-hit != 'true'
+    - name: Ensure Android SDK baseline via android CLI
+      if: inputs.skip-android-sdk-ndk != 'true'
       shell: bash
       run: |
         set -euo pipefail
-        bash scripts/ci/android-sdk-install.sh \
-          "platform-tools" \
-          "platforms/android-${{ steps.native-toolchain.outputs.compile-sdk }}"
+        sdk_root="${{ steps.native-toolchain.outputs.sdk-root }}"
+        packages=()
+        [[ -x "$sdk_root/platform-tools/adb" ]] || packages+=("platform-tools")
+        [[ -f "$sdk_root/platforms/android-${{ steps.native-toolchain.outputs.compile-sdk }}/android.jar" ]] || \
+          packages+=("platforms/android-${{ steps.native-toolchain.outputs.compile-sdk }}")
+        if (( ${#packages[@]} > 0 )); then
+          bash scripts/ci/android-sdk-install.sh "${packages[@]}"
+        fi
 
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       if: inputs.setup-rust == 'true'
@@ -161,13 +176,20 @@ runs:
       shell: bash
       run: rustup target add ${{ inputs.rust-targets }}
 
-    - name: Install native toolchain via android CLI
-      if: inputs.skip-android-sdk-ndk != 'true' && inputs.setup-android-ndk == 'true' && steps.cache-android-sdk.outputs.cache-hit != 'true'
+    - name: Ensure native toolchain via android CLI
+      if: inputs.skip-android-sdk-ndk != 'true' && inputs.setup-android-ndk == 'true'
       shell: bash
-      run: >-
-        bash scripts/ci/android-sdk-install.sh
-        "ndk/${{ steps.native-toolchain.outputs.ndk }}"
-        "cmake/${{ steps.native-toolchain.outputs.cmake }}"
+      run: |
+        set -euo pipefail
+        sdk_root="${{ steps.native-toolchain.outputs.sdk-root }}"
+        packages=()
+        [[ -f "$sdk_root/ndk/${{ steps.native-toolchain.outputs.ndk }}/source.properties" ]] || \
+          packages+=("ndk/${{ steps.native-toolchain.outputs.ndk }}")
+        [[ -x "$sdk_root/cmake/${{ steps.native-toolchain.outputs.cmake }}/bin/cmake" ]] || \
+          packages+=("cmake/${{ steps.native-toolchain.outputs.cmake }}")
+        if (( ${#packages[@]} > 0 )); then
+          bash scripts/ci/android-sdk-install.sh "${packages[@]}"
+        fi
 
     - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       if: inputs.setup-rust == 'true' && inputs.setup-sccache == 'true'

--- a/.github/actions/setup-android-rust/action.yml
+++ b/.github/actions/setup-android-rust/action.yml
@@ -130,6 +130,7 @@ runs:
         echo "ndk=$(grep '^ripdpi.nativeNdkVersion=' gradle.properties | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
         echo "cmake=$(grep '^ripdpi.nativeCmakeVersion=' gradle.properties | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
         echo "compile-sdk=$(grep '^ripdpi.compileSdk=' gradle.properties | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
+        echo "compile-sdk-package=$(grep '^ripdpi.compileSdkPackage=' gradle.properties | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
 
     # Cache both Android CLI state and the actual package directories under the
     # runner SDK root. Caching ~/.android alone can produce a false cache hit:
@@ -144,8 +145,8 @@ runs:
         path: |
           ~/.android
           ${{ steps.native-toolchain.outputs.sdk-root }}/platform-tools
-          ${{ steps.native-toolchain.outputs.sdk-root }}/platforms/android-${{ steps.native-toolchain.outputs.compile-sdk }}
-        key: android-sdk-${{ runner.os }}-${{ steps.native-toolchain.outputs.compile-sdk }}-${{ hashFiles('.github/actions/setup-android-rust/action.yml') }}
+          ${{ steps.native-toolchain.outputs.sdk-root }}/platforms/android-${{ steps.native-toolchain.outputs.compile-sdk-package }}
+        key: android-sdk-${{ runner.os }}-${{ steps.native-toolchain.outputs.compile-sdk-package }}-${{ hashFiles('.github/actions/setup-android-rust/action.yml') }}
 
     - name: Cache Android NDK and CMake
       if: inputs.skip-android-sdk-ndk != 'true' && inputs.setup-android-ndk == 'true'
@@ -165,13 +166,13 @@ runs:
         sdk_root="${{ steps.native-toolchain.outputs.sdk-root }}"
         packages=()
         [[ -x "$sdk_root/platform-tools/adb" ]] || packages+=("platform-tools")
-        [[ -f "$sdk_root/platforms/android-${{ steps.native-toolchain.outputs.compile-sdk }}/android.jar" ]] || \
-          packages+=("platforms/android-${{ steps.native-toolchain.outputs.compile-sdk }}")
+        [[ -f "$sdk_root/platforms/android-${{ steps.native-toolchain.outputs.compile-sdk-package }}/android.jar" ]] || \
+          packages+=("platforms/android-${{ steps.native-toolchain.outputs.compile-sdk-package }}")
         if (( ${#packages[@]} > 0 )); then
           bash scripts/ci/android-sdk-install.sh "${packages[@]}"
         fi
         [[ -x "$sdk_root/platform-tools/adb" ]]
-        [[ -f "$sdk_root/platforms/android-${{ steps.native-toolchain.outputs.compile-sdk }}/android.jar" ]]
+        [[ -f "$sdk_root/platforms/android-${{ steps.native-toolchain.outputs.compile-sdk-package }}/android.jar" ]]
 
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       if: inputs.setup-rust == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,9 @@ jobs:
   # the separately-produced x86_64 shard below and can start sooner.
   rust-native-packaging:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -463,7 +465,9 @@ jobs:
   # Keeping it outside the packaging matrix removes the wait for arm/x86 jobs.
   rust-native-x86_64:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -557,6 +561,7 @@ jobs:
   pluggable-transport-assets:
     needs: [change-routing, ci-preflight]
     if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       (github.event_name != 'schedule' ||
       github.event.schedule == '11 4 * * 4' || github.event.schedule == '27 4 * * 5')
@@ -722,7 +727,9 @@ jobs:
   # Rust dependency chain that preBuild normally pulls in.
   build-android-tests:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -807,7 +814,9 @@ jobs:
   # Roborazzi screenshot tests run in parallel; they don't load JNI either.
   verify-roborazzi:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -849,8 +858,10 @@ jobs:
           retention-days: 7
 
   owned-stack-tls-fingerprint:
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     needs: [change-routing, ci-preflight]
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1033,6 +1044,7 @@ jobs:
   native-bloat:
     needs: [change-routing, ci-preflight]
     if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       github.event_name != 'schedule' &&
       (
@@ -1094,7 +1106,9 @@ jobs:
 
   rust-miri:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1159,7 +1173,9 @@ jobs:
 
   diagnostics-probes-facade:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -1200,7 +1216,9 @@ jobs:
 
   rust-lint:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -1235,7 +1253,9 @@ jobs:
 
   rust-cross-check:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -1261,7 +1281,9 @@ jobs:
 
   rust-workspace-tests:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -1308,7 +1330,9 @@ jobs:
 
   rust-fuzz-smoke:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -1338,7 +1362,9 @@ jobs:
 
   runtime-api-snapshot:
     needs: [change-routing, ci-preflight]
-    if: needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      needs.change-routing.outputs.run_full_ci == 'true'
     name: JNI API snapshot check
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1421,7 +1447,9 @@ jobs:
 
   rust-network-e2e:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -1449,7 +1477,9 @@ jobs:
 
   relay-interoperability:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -1477,7 +1507,9 @@ jobs:
 
   cli-packet-smoke:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1511,7 +1543,9 @@ jobs:
 
   rust-turmoil:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1539,6 +1573,7 @@ jobs:
   kotlin-coverage:
     needs: [change-routing, ci-preflight]
     if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_kotlin_coverage == 'true' &&
       github.event_name != 'schedule' &&
       (
@@ -1594,6 +1629,7 @@ jobs:
   rust-coverage:
     needs: [change-routing, ci-preflight]
     if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_rust_coverage == 'true' &&
       github.event_name != 'schedule' &&
       (
@@ -1644,6 +1680,7 @@ jobs:
   rust-criterion-bench:
     needs: [change-routing, ci-preflight]
     if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       ((github.event_name == 'schedule' && github.event.schedule == '7 4 * * 1') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.run_rust_criterion_bench == 'true') ||
@@ -2106,7 +2143,9 @@ jobs:
 
   rust-loom:
     needs: [change-routing, ci-preflight]
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -2131,6 +2170,7 @@ jobs:
   rust-native-soak:
     needs: [change-routing, ci-preflight]
     if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       ((github.event_name == 'schedule' && github.event.schedule == '19 4 * * 2') ||
       (github.event_name == 'workflow_dispatch' &&
@@ -2180,6 +2220,7 @@ jobs:
   rust-native-load:
     needs: [change-routing, ci-preflight]
     if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       ((github.event_name == 'schedule' && github.event.schedule == '19 4 * * 2') ||
       (github.event_name == 'workflow_dispatch' &&
@@ -2229,6 +2270,7 @@ jobs:
   nightly-kotlin-coverage:
     needs: [change-routing, ci-preflight]
     if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       ((github.event_name == 'schedule' && github.event.schedule == '43 4 * * 3') ||
       (github.event_name == 'workflow_dispatch' &&
@@ -2267,6 +2309,7 @@ jobs:
   nightly-rust-coverage:
     needs: [change-routing, ci-preflight]
     if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       ((github.event_name == 'schedule' && github.event.schedule == '43 4 * * 3') ||
       (github.event_name == 'workflow_dispatch' &&
@@ -2616,7 +2659,12 @@ jobs:
 
   linux-tun-e2e:
     needs: [change-routing, ci-preflight]
-    if: needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '27 4 * * 5') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tun-e2e')))
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      needs.change-routing.outputs.run_full_ci == 'true' &&
+      ((github.event_name == 'schedule' && github.event.schedule == '27 4 * * 5') ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tun-e2e')))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -2653,7 +2701,12 @@ jobs:
 
   so-bindtodevice-e2e:
     needs: [change-routing, ci-preflight]
-    if: needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '27 4 * * 5') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tun-e2e')))
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      needs.change-routing.outputs.run_full_ci == 'true' &&
+      ((github.event_name == 'schedule' && github.event.schedule == '27 4 * * 5') ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tun-e2e')))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -2736,7 +2789,11 @@ jobs:
 
   linux-tun-soak:
     needs: [change-routing, ci-preflight]
-    if: needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '19 4 * * 2') || github.event_name == 'workflow_dispatch')
+    if: >-
+      !cancelled() && needs.ci-preflight.result == 'success' &&
+      needs.change-routing.outputs.run_full_ci == 'true' &&
+      ((github.event_name == 'schedule' && github.event.schedule == '19 4 * * 2') ||
+      github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,8 +621,13 @@ jobs:
   # artifacts. The rust-native Gradle plugin copies these inputs instead of
   # running Cargo, so the shards can execute independently.
   build-android-debug:
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     needs: [change-routing, rust-native-packaging, rust-native-x86_64, pluggable-transport-assets]
+    if: >-
+      !cancelled() &&
+      needs.rust-native-packaging.result == 'success' &&
+      needs.rust-native-x86_64.result == 'success' &&
+      needs.pluggable-transport-assets.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:
@@ -882,8 +887,14 @@ jobs:
         run: bash scripts/ci/check-owned-stack-tls-fingerprint.sh
 
   release-verification:
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     needs: [change-routing, rust-native-packaging, rust-native-x86_64, owned-stack-tls-fingerprint, pluggable-transport-assets]
+    if: >-
+      !cancelled() &&
+      needs.rust-native-packaging.result == 'success' &&
+      needs.rust-native-x86_64.result == 'success' &&
+      needs.owned-stack-tls-fingerprint.result == 'success' &&
+      needs.pluggable-transport-assets.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     # Three two-build shards bound Kotlin heap use without serializing all six
     # variants in one runner. Stop Gradle between variants and emit each build
@@ -1802,6 +1813,7 @@ jobs:
     # snapshot manual to avoid paying for the same native work twice per cycle.
     needs: [change-routing, pluggable-transport-assets]
     if: >-
+      !cancelled() && needs.pluggable-transport-assets.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       github.event_name == 'workflow_dispatch' &&
       (github.event.inputs.coverage_phase0_mode == 'phase0-baseline' ||
@@ -1865,7 +1877,11 @@ jobs:
     # already tolerates emulator runs (androidx.benchmark.suppressErrors includes
     # EMULATOR) and the regression check is warn-only.
     needs: [change-routing, pluggable-transport-assets]
-    if: needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '11 4 * * 4') || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_android_macrobenchmark == 'true'))
+    if: >-
+      !cancelled() && needs.pluggable-transport-assets.result == 'success' &&
+      needs.change-routing.outputs.run_full_ci == 'true' &&
+      ((github.event_name == 'schedule' && github.event.schedule == '11 4 * * 4') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_android_macrobenchmark == 'true'))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -1946,8 +1962,12 @@ jobs:
   # The dedicated x86_64 native shard is staged via
   # -Pripdpi.prebuilt*Dir so cargo is skipped.
   android-instrumented-tests:
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     needs: [change-routing, rust-native-x86_64, pluggable-transport-assets]
+    if: >-
+      !cancelled() &&
+      needs.rust-native-x86_64.result == 'success' &&
+      needs.pluggable-transport-assets.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -2355,6 +2375,7 @@ jobs:
   android-network-e2e:
     needs: [change-routing, pluggable-transport-assets]
     if: >-
+      !cancelled() && needs.pluggable-transport-assets.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       ((github.event_name == 'workflow_dispatch' && github.event.inputs.run_android_network_e2e == 'true') ||
       (
@@ -2489,6 +2510,7 @@ jobs:
   android-journeys:
     needs: [change-routing, pluggable-transport-assets]
     if: >-
+      !cancelled() && needs.pluggable-transport-assets.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       ((github.event_name == 'workflow_dispatch' &&
       (github.event.inputs.android_extended_mode == 'journeys' ||
@@ -2578,6 +2600,7 @@ jobs:
   android-relay-emulator-smoke:
     needs: [change-routing, pluggable-transport-assets]
     if: >-
+      !cancelled() && needs.pluggable-transport-assets.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       ((github.event_name == 'schedule' && github.event.schedule == '27 4 * * 5') ||
       (github.event_name == 'workflow_dispatch' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,21 +26,26 @@ on:
         required: false
         default: false
         type: boolean
-      run_native_soak:
-        description: Run native Rust soak suites
+      native_stress_mode:
+        description: Select native Rust stress suites
         required: false
-        default: false
-        type: boolean
-      run_native_load:
-        description: Run native Rust load suites
+        default: none
+        type: choice
+        options:
+          - none
+          - soak
+          - load
+          - soak-and-load
+      coverage_phase0_mode:
+        description: Select nightly coverage and/or Phase 0 baseline
         required: false
-        default: false
-        type: boolean
-      run_nightly_coverage:
-        description: Run full nightly coverage flow
-        required: false
-        default: false
-        type: boolean
+        default: none
+        type: choice
+        options:
+          - none
+          - nightly-coverage
+          - phase0-baseline
+          - nightly-and-phase0
       run_rust_criterion_bench:
         description: Run Rust criterion benchmarks
         required: false
@@ -61,21 +66,16 @@ on:
         required: false
         default: false
         type: boolean
-      run_android_journeys:
-        description: Run Android CLI Journeys emulator suite
+      android_extended_mode:
+        description: Select Android Journeys and/or relay emulator smoke
         required: false
-        default: false
-        type: boolean
-      run_android_relay_smoke:
-        description: Run Android relay emulator smoke suite
-        required: false
-        default: false
-        type: boolean
-      run_phase0_baseline:
-        description: Capture the full Phase 0 baseline snapshot
-        required: false
-        default: false
-        type: boolean
+        default: none
+        type: choice
+        options:
+          - none
+          - journeys
+          - relay
+          - journeys-and-relay
   schedule:
     # Daily security signal; each expensive lane gets its own weekly window so
     # scheduled runs stay actionable instead of repeating the entire suite.
@@ -1543,7 +1543,8 @@ jobs:
       github.event_name != 'schedule' &&
       (
         github.event_name != 'workflow_dispatch' ||
-        github.event.inputs.run_nightly_coverage != 'true'
+        github.event.inputs.coverage_phase0_mode != 'nightly-coverage' &&
+        github.event.inputs.coverage_phase0_mode != 'nightly-and-phase0'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -1597,7 +1598,8 @@ jobs:
       github.event_name != 'schedule' &&
       (
         github.event_name != 'workflow_dispatch' ||
-        github.event.inputs.run_nightly_coverage != 'true'
+        github.event.inputs.coverage_phase0_mode != 'nightly-coverage' &&
+        github.event.inputs.coverage_phase0_mode != 'nightly-and-phase0'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -1762,7 +1764,11 @@ jobs:
     # the recurring lanes already execute independently. Keep the composite
     # snapshot manual to avoid paying for the same native work twice per cycle.
     needs: [change-routing, pluggable-transport-assets]
-    if: needs.change-routing.outputs.run_full_ci == 'true' && github.event_name == 'workflow_dispatch' && github.event.inputs.run_phase0_baseline == 'true'
+    if: >-
+      needs.change-routing.outputs.run_full_ci == 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.coverage_phase0_mode == 'phase0-baseline' ||
+      github.event.inputs.coverage_phase0_mode == 'nightly-and-phase0')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -2124,7 +2130,12 @@ jobs:
 
   rust-native-soak:
     needs: [change-routing, ci-preflight]
-    if: needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '19 4 * * 2') || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_native_soak == 'true'))
+    if: >-
+      needs.change-routing.outputs.run_full_ci == 'true' &&
+      ((github.event_name == 'schedule' && github.event.schedule == '19 4 * * 2') ||
+      (github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.native_stress_mode == 'soak' ||
+      github.event.inputs.native_stress_mode == 'soak-and-load')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -2168,7 +2179,12 @@ jobs:
 
   rust-native-load:
     needs: [change-routing, ci-preflight]
-    if: needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '19 4 * * 2') || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_native_load == 'true'))
+    if: >-
+      needs.change-routing.outputs.run_full_ci == 'true' &&
+      ((github.event_name == 'schedule' && github.event.schedule == '19 4 * * 2') ||
+      (github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.native_stress_mode == 'load' ||
+      github.event.inputs.native_stress_mode == 'soak-and-load')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -2212,7 +2228,12 @@ jobs:
 
   nightly-kotlin-coverage:
     needs: [change-routing, ci-preflight]
-    if: needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '43 4 * * 3') || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_coverage == 'true'))
+    if: >-
+      needs.change-routing.outputs.run_full_ci == 'true' &&
+      ((github.event_name == 'schedule' && github.event.schedule == '43 4 * * 3') ||
+      (github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.coverage_phase0_mode == 'nightly-coverage' ||
+      github.event.inputs.coverage_phase0_mode == 'nightly-and-phase0')))
     runs-on: ubuntu-latest
     timeout-minutes: 50
     steps:
@@ -2245,7 +2266,12 @@ jobs:
 
   nightly-rust-coverage:
     needs: [change-routing, ci-preflight]
-    if: needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '43 4 * * 3') || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_coverage == 'true'))
+    if: >-
+      needs.change-routing.outputs.run_full_ci == 'true' &&
+      ((github.event_name == 'schedule' && github.event.schedule == '43 4 * * 3') ||
+      (github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.coverage_phase0_mode == 'nightly-coverage' ||
+      github.event.inputs.coverage_phase0_mode == 'nightly-and-phase0')))
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -2421,7 +2447,9 @@ jobs:
     needs: [change-routing, pluggable-transport-assets]
     if: >-
       needs.change-routing.outputs.run_full_ci == 'true' &&
-      ((github.event_name == 'workflow_dispatch' && github.event.inputs.run_android_journeys == 'true') ||
+      ((github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.android_extended_mode == 'journeys' ||
+      github.event.inputs.android_extended_mode == 'journeys-and-relay')) ||
       (
         github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'run-android-journeys')
@@ -2506,7 +2534,12 @@ jobs:
 
   android-relay-emulator-smoke:
     needs: [change-routing, pluggable-transport-assets]
-    if: needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '27 4 * * 5') || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_android_relay_smoke == 'true'))
+    if: >-
+      needs.change-routing.outputs.run_full_ci == 'true' &&
+      ((github.event_name == 'schedule' && github.event.schedule == '27 4 * * 5') ||
+      (github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.android_extended_mode == 'relay' ||
+      github.event.inputs.android_extended_mode == 'journeys-and-relay')))
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -2829,7 +2862,7 @@ jobs:
           RUN_WORKFLOW_CI: ${{ needs.change-routing.outputs.run_workflow_ci }}
           RUN_KOTLIN_COVERAGE: ${{ needs.change-routing.outputs.run_kotlin_coverage }}
           RUN_RUST_COVERAGE: ${{ needs.change-routing.outputs.run_rust_coverage }}
-          RUN_NIGHTLY_COVERAGE: ${{ (github.event_name == 'schedule' && github.event.schedule == '43 4 * * 3') || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_coverage == 'true') }}
+          RUN_NIGHTLY_COVERAGE: ${{ (github.event_name == 'schedule' && github.event.schedule == '43 4 * * 3') || (github.event_name == 'workflow_dispatch' && (github.event.inputs.coverage_phase0_mode == 'nightly-coverage' || github.event.inputs.coverage_phase0_mode == 'nightly-and-phase0')) }}
           NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
           python3 - <<'PY'

--- a/app/src/main/kotlin/com/poyka/ripdpi/debug/PacketSmokeNetworkSupport.kt
+++ b/app/src/main/kotlin/com/poyka/ripdpi/debug/PacketSmokeNetworkSupport.kt
@@ -34,8 +34,33 @@ const val PacketSmokeProbeResultFileName = "probe-result.json"
 private const val AdGuardUnfilteredHost = "unfiltered.adguard-dns.com"
 private const val AdGuardUnfilteredDoHUrl = "https://unfiltered.adguard-dns.com/dns-query"
 private const val AdGuardUnfilteredDnsCryptStamp =
-    "sdns://AQMAAAAAAAAAEjk0LjE0MC4xNC4xNDA6NTQ0MyC16ETWuDo-PhJo62gfvqcN48X6aNvWiBQdvy7AZrLa-iUyLmRuc2NyeXB0LnVuZmlsdGVyZWQubnMxLmFkZ3VhcmQuY29t"
+    "sdns://AQMAAAAAAAAAEjk0LjE0MC4xNC4xNDA6NTQ0MyC16ETWuDo-PhJo62gfvqcN48X6" +
+        "aNvWiBQdvy7AZrLa-iUyLmRuc2NyeXB0LnVuZmlsdGVyZWQubnMxLmFkZ3VhcmQuY29t"
 private val AdGuardUnfilteredBootstrapIps = listOf("94.140.14.140", "94.140.14.141")
+
+private const val DnsCryptProtocolPropertiesSizeBytes = 8
+private const val DnsHeaderSizeBytes = 12
+private const val DnsRecursionDesiredFlags = 0x0100
+private const val DnsMaxLabelSizeBytes = 63
+private const val DnsFlagsOffset = 2
+private const val DnsResponseCodeMask = 0x000F
+private const val DnsQuestionCountOffset = 4
+private const val DnsAnswerCountOffset = 6
+private const val DnsQuestionFooterSizeBytes = 4
+private const val DnsResourceRecordHeaderSizeBytes = 10
+private const val DnsResourceDataLengthOffset = 8
+private const val DnsRecordTypeA = 1
+private const val DnsRecordTypeCname = 5
+private const val DnsRecordTypePtr = 12
+private const val DnsRecordTypeAaaa = 28
+private const val Ipv4AddressSizeBytes = 4
+private const val Ipv6AddressSizeBytes = 16
+private const val BitsPerByte = 8
+private const val UnsignedByteMask = 0xFF
+private const val DnsCompressionPointerMask = 0xC0
+private const val DnsCompressionPointerPayloadMask = 0x3F
+private const val DnsCompressionPointerSizeBytes = 2
+private const val DnsCompressionPointerJumpLimit = 16
 
 data class PacketSmokeEncryptedDnsPreset(
     val providerId: String,
@@ -297,7 +322,7 @@ fun decodeDnsCryptStamp(value: String): PacketSmokeDnsCryptStamp {
     require(bytes.isNotEmpty()) { "DNSCrypt stamp payload is empty" }
     require(bytes[0].toInt() == 0x01) { "Unsupported DNS stamp protocol byte: ${bytes[0].toInt()}" }
 
-    var index = 1 + 8
+    var index = 1 + DnsCryptProtocolPropertiesSizeBytes
     val serverAddress = readLengthPrefixedString(bytes, index)
     index += 1 + serverAddress.length
     val publicKeyBytes = readLengthPrefixedBytes(bytes, index)
@@ -323,14 +348,16 @@ object DebugDnsPacketCodec {
         require(hostname.isNotBlank()) { "hostname must not be blank" }
         val output = ArrayList<Byte>()
         output.writeU16(requestId)
-        output.writeU16(0x0100)
+        output.writeU16(DnsRecursionDesiredFlags)
         output.writeU16(1)
         output.writeU16(0)
         output.writeU16(0)
         output.writeU16(0)
         hostname.split('.').forEach { label ->
             require(label.isNotEmpty()) { "hostname contains an empty label: $hostname" }
-            require(label.length <= 63) { "hostname label exceeds 63 octets: $label" }
+            require(label.length <= DnsMaxLabelSizeBytes) {
+                "hostname label exceeds $DnsMaxLabelSizeBytes octets: $label"
+            }
             output.add(label.length.toByte())
             label.encodeToByteArray().forEach(output::add)
         }
@@ -344,50 +371,54 @@ object DebugDnsPacketCodec {
         packet: ByteArray,
         expectedRequestId: Int,
     ): DebugDnsProbeDecodedResponse {
-        require(packet.size >= 12) { "DNS packet too short: ${packet.size}" }
+        require(packet.size >= DnsHeaderSizeBytes) { "DNS packet too short: ${packet.size}" }
         val requestId = packet.readU16(0)
         require(requestId == expectedRequestId) {
             "Unexpected DNS request ID: expected=$expectedRequestId actual=$requestId"
         }
-        val flags = packet.readU16(2)
-        val rcode = flags and 0x000F
-        val questionCount = packet.readU16(4)
-        val answerCount = packet.readU16(6)
-        var offset = 12
+        val flags = packet.readU16(DnsFlagsOffset)
+        val rcode = flags and DnsResponseCodeMask
+        val questionCount = packet.readU16(DnsQuestionCountOffset)
+        val answerCount = packet.readU16(DnsAnswerCountOffset)
+        var offset = DnsHeaderSizeBytes
         repeat(questionCount) {
             offset = skipName(packet, offset)
-            require(offset + 4 <= packet.size) { "DNS question section truncated" }
-            offset += 4
+            require(offset + DnsQuestionFooterSizeBytes <= packet.size) {
+                "DNS question section truncated"
+            }
+            offset += DnsQuestionFooterSizeBytes
         }
 
         val answers = mutableListOf<String>()
         repeat(answerCount) {
             offset = skipName(packet, offset)
-            require(offset + 10 <= packet.size) { "DNS answer section truncated" }
+            require(offset + DnsResourceRecordHeaderSizeBytes <= packet.size) {
+                "DNS answer section truncated"
+            }
             val type = packet.readU16(offset)
-            val dataLength = packet.readU16(offset + 8)
-            offset += 10
+            val dataLength = packet.readU16(offset + DnsResourceDataLengthOffset)
+            offset += DnsResourceRecordHeaderSizeBytes
             require(offset + dataLength <= packet.size) { "DNS rdata section truncated" }
             when (type) {
-                1 -> {
-                    if (dataLength == 4) {
+                DnsRecordTypeA -> {
+                    if (dataLength == Ipv4AddressSizeBytes) {
                         answers +=
                             InetAddress
-                                .getByAddress(packet.copyOfRange(offset, offset + 4))
+                                .getByAddress(packet.copyOfRange(offset, offset + Ipv4AddressSizeBytes))
                                 .hostAddress
                     }
                 }
 
-                28 -> {
-                    if (dataLength == 16) {
+                DnsRecordTypeAaaa -> {
+                    if (dataLength == Ipv6AddressSizeBytes) {
                         answers +=
                             InetAddress
-                                .getByAddress(packet.copyOfRange(offset, offset + 16))
+                                .getByAddress(packet.copyOfRange(offset, offset + Ipv6AddressSizeBytes))
                                 .hostAddress
                     }
                 }
 
-                5, 12 -> {
+                DnsRecordTypeCname, DnsRecordTypePtr -> {
                     answers += readName(packet, offset).name
                 }
             }
@@ -440,12 +471,13 @@ private fun isIpLiteral(value: String): Boolean {
 }
 
 private fun MutableList<Byte>.writeU16(value: Int) {
-    add(((value ushr 8) and 0xFF).toByte())
-    add((value and 0xFF).toByte())
+    add(((value ushr BitsPerByte) and UnsignedByteMask).toByte())
+    add((value and UnsignedByteMask).toByte())
 }
 
 private fun ByteArray.readU16(offset: Int): Int =
-    ((this[offset].toInt() and 0xFF) shl 8) or (this[offset + 1].toInt() and 0xFF)
+    ((this[offset].toInt() and UnsignedByteMask) shl BitsPerByte) or
+        (this[offset + 1].toInt() and UnsignedByteMask)
 
 private fun JsonObjectBuilder.putOptionalString(
     key: String,
@@ -504,7 +536,7 @@ private fun readName(
 
     while (true) {
         require(cursor < packet.size) { "DNS name exceeds packet bounds" }
-        val length = packet[cursor].toInt() and 0xFF
+        val length = packet[cursor].toInt() and UnsignedByteMask
         when {
             length == 0 -> {
                 if (!jumped) {
@@ -516,17 +548,21 @@ private fun readName(
                 )
             }
 
-            length and 0xC0 == 0xC0 -> {
+            length and DnsCompressionPointerMask == DnsCompressionPointerMask -> {
                 require(cursor + 1 < packet.size) { "DNS compression pointer is truncated" }
-                val pointer = ((length and 0x3F) shl 8) or (packet[cursor + 1].toInt() and 0xFF)
+                val pointer =
+                    ((length and DnsCompressionPointerPayloadMask) shl BitsPerByte) or
+                        (packet[cursor + 1].toInt() and UnsignedByteMask)
                 require(pointer < packet.size) { "DNS compression pointer exceeds packet size" }
                 if (!jumped) {
-                    consumedOffset = cursor + 2
+                    consumedOffset = cursor + DnsCompressionPointerSizeBytes
                     jumped = true
                 }
                 cursor = pointer
                 jumps += 1
-                require(jumps < 16) { "DNS compression pointer recursion limit exceeded" }
+                require(jumps < DnsCompressionPointerJumpLimit) {
+                    "DNS compression pointer recursion limit exceeded"
+                }
             }
 
             else -> {

--- a/core/service/src/main/kotlin/com/poyka/ripdpi/services/SubprocessRelayBinaryExtractor.kt
+++ b/core/service/src/main/kotlin/com/poyka/ripdpi/services/SubprocessRelayBinaryExtractor.kt
@@ -2,6 +2,7 @@ package com.poyka.ripdpi.services
 
 import android.content.Context
 import android.os.Build
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.jsonArray
@@ -71,29 +72,19 @@ internal fun resolvePluggableTransportUpstreamAsset(
     availableAssets: Set<String>,
 ): String? {
     val legacyUpstream = "$binaryName.upstream"
-    if (manifestPayload == null) {
-        throw IllegalArgumentException("Pluggable transport manifest is unavailable")
-    }
-
-    val artifact =
-        try {
-            Json
-                .parseToJsonElement(manifestPayload)
-                .jsonObject
-                .getValue("artifacts")
-                .jsonArray
-                .asSequence()
-                .map { it.jsonObject }
-                .singleOrNull { candidate ->
-                    candidate["abi"]?.jsonPrimitive?.content == abi &&
-                        candidate["outputName"]?.jsonPrimitive?.content == binaryName
-                }
-                ?: throw IllegalArgumentException("Manifest has no unique artifact for $binaryName/$abi")
-        } catch (error: IllegalArgumentException) {
-            throw error
-        } catch (error: RuntimeException) {
-            throw IllegalArgumentException("Malformed pluggable transport manifest", error)
+    val manifest =
+        requireNotNull(manifestPayload) {
+            "Pluggable transport manifest is unavailable"
         }
+    val artifact =
+        parsePluggableTransportArtifacts(manifest)
+            .asSequence()
+            .map { it.jsonObject }
+            .singleOrNull { candidate ->
+                candidate["abi"]?.jsonPrimitive?.content == abi &&
+                    candidate["outputName"]?.jsonPrimitive?.content == binaryName
+            }
+            ?: throw IllegalArgumentException("Manifest has no unique artifact for $binaryName/$abi")
 
     val upstreamElement = artifact["upstreamBinary"]
     if (upstreamElement == null || upstreamElement is JsonNull) {
@@ -108,6 +99,24 @@ internal fun resolvePluggableTransportUpstreamAsset(
         .firstOrNull(availableAssets::contains)
         ?: throw IllegalArgumentException("Upstream asset is missing for $binaryName/$abi")
 }
+
+private fun parsePluggableTransportArtifacts(manifestPayload: String) =
+    try {
+        Json
+            .parseToJsonElement(manifestPayload)
+            .jsonObject
+            .getValue("artifacts")
+            .jsonArray
+    } catch (error: SerializationException) {
+        malformedPluggableTransportManifest(error)
+    } catch (error: NoSuchElementException) {
+        malformedPluggableTransportManifest(error)
+    } catch (error: IllegalArgumentException) {
+        malformedPluggableTransportManifest(error)
+    }
+
+private fun malformedPluggableTransportManifest(error: Exception): Nothing =
+    throw IllegalArgumentException("Malformed pluggable transport manifest", error)
 
 internal fun removeStalePluggableTransportFile(file: File) {
     check(!file.exists() || file.delete()) { "Unable to remove stale pluggable transport file: $file" }

--- a/core/service/src/test/kotlin/com/poyka/ripdpi/services/SubprocessRelayBinaryExtractorTest.kt
+++ b/core/service/src/test/kotlin/com/poyka/ripdpi/services/SubprocessRelayBinaryExtractorTest.kt
@@ -35,7 +35,11 @@ class SubprocessRelayBinaryExtractorTest {
     @Test
     fun `legacy per-launcher upstream remains supported`() {
         val manifest =
-            """{"artifacts":[{"abi":"arm64-v8a","outputName":"ripdpi-snowflake","upstreamBinary":"ripdpi-snowflake.upstream"}]}"""
+            """
+            {"artifacts":[
+              {"abi":"arm64-v8a","outputName":"ripdpi-snowflake","upstreamBinary":"ripdpi-snowflake.upstream"}
+            ]}
+            """.trimIndent()
 
         assertEquals(
             "ripdpi-snowflake.upstream",
@@ -66,7 +70,11 @@ class SubprocessRelayBinaryExtractorTest {
     @Test
     fun `single-output transport keeps its existing upstream name`() {
         val manifest =
-            """{"artifacts":[{"abi":"x86_64","outputName":"ripdpi-webtunnel","upstreamBinary":"ripdpi-webtunnel.upstream"}]}"""
+            """
+            {"artifacts":[
+              {"abi":"x86_64","outputName":"ripdpi-webtunnel","upstreamBinary":"ripdpi-webtunnel.upstream"}
+            ]}
+            """.trimIndent()
 
         assertEquals(
             "ripdpi-webtunnel.upstream",

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,6 +40,8 @@ android.nonFinalResIds=true
 # triggers (ProfilingTrigger.TRIGGER_TYPE_OOM / TRIGGER_TYPE_ANOMALY, API 37).
 # targetSdk stays 35: bumping runtime-behavior target is a separate, tested change.
 ripdpi.compileSdk=37
+# Android CLI 1.0 uses the 37.0 package/directory suffix for compileSdk 37.
+ripdpi.compileSdkPackage=37.0
 ripdpi.minSdk=27
 ripdpi.targetSdk=35
 # r29 is the current stable NDK (non-LTS). r30 is still beta as of 2026-06;

--- a/scripts/tests/test_ci_tool_pinning.py
+++ b/scripts/tests/test_ci_tool_pinning.py
@@ -66,6 +66,12 @@ class CiToolPinningTest(unittest.TestCase):
             "${{ steps.native-toolchain.outputs.cmake }}",
             action,
         )
+        self.assertIn("id: cache-android-native", action)
+        self.assertIn(
+            "if: inputs.skip-android-sdk-ndk != 'true' && "
+            "inputs.setup-android-ndk == 'true'",
+            action,
+        )
         self.assertIn(
             '[[ -x "$sdk_root/cmake/${{ steps.native-toolchain.outputs.cmake }}/bin/cmake" ]]',
             action,

--- a/scripts/tests/test_ci_tool_pinning.py
+++ b/scripts/tests/test_ci_tool_pinning.py
@@ -60,6 +60,20 @@ class CiToolPinningTest(unittest.TestCase):
         self.assertIn("steps.native-toolchain.outputs.cmake", action)
         self.assertIn('"cmake/${{ steps.native-toolchain.outputs.cmake }}"', action)
         self.assertIn("-cmake-${{ steps.native-toolchain.outputs.cmake }}-", action)
+        self.assertIn('echo "sdk-root=$sdk_root" >> "$GITHUB_OUTPUT"', action)
+        self.assertIn(
+            "${{ steps.native-toolchain.outputs.sdk-root }}/cmake/"
+            "${{ steps.native-toolchain.outputs.cmake }}",
+            action,
+        )
+        self.assertIn(
+            '[[ -x "$sdk_root/cmake/${{ steps.native-toolchain.outputs.cmake }}/bin/cmake" ]]',
+            action,
+        )
+        self.assertNotIn(
+            "steps.cache-android-sdk.outputs.cache-hit != 'true'",
+            action,
+        )
 
     def test_github_actions_do_not_execute_floating_rust_toolchain_action(self) -> None:
         sources = [ROOT / ".github/actions/setup-android-rust/action.yml"]

--- a/scripts/tests/test_ci_tool_pinning.py
+++ b/scripts/tests/test_ci_tool_pinning.py
@@ -81,6 +81,20 @@ class CiToolPinningTest(unittest.TestCase):
             action,
         )
 
+    def test_android_sdk_install_uses_the_pinned_cli_package_suffix(self) -> None:
+        action = (
+            ROOT / ".github/actions/setup-android-rust/action.yml"
+        ).read_text(encoding="utf-8")
+        properties = (ROOT / "gradle.properties").read_text(encoding="utf-8")
+
+        self.assertIn("ripdpi.compileSdk=37", properties)
+        self.assertIn("ripdpi.compileSdkPackage=37.0", properties)
+        self.assertIn("steps.native-toolchain.outputs.compile-sdk-package", action)
+        self.assertIn(
+            '"platforms/android-${{ steps.native-toolchain.outputs.compile-sdk-package }}"',
+            action,
+        )
+
     def test_github_actions_do_not_execute_floating_rust_toolchain_action(self) -> None:
         sources = [ROOT / ".github/actions/setup-android-rust/action.yml"]
         sources.extend(sorted((ROOT / ".github/workflows").glob("*.yml")))

--- a/scripts/tests/test_nightly_coverage_selection.py
+++ b/scripts/tests/test_nightly_coverage_selection.py
@@ -85,8 +85,12 @@ class NightlyCoverageSelectionTest(unittest.TestCase):
     def test_android_sdk_cache_is_separated_by_ndk_installation_mode(self) -> None:
         source = SETUP_ACTION.read_text(encoding="utf-8")
 
-        self.assertIn("NDK setup mode so a Kotlin-only job cannot", source)
         self.assertIn("-ndk-${{ inputs.setup-android-ndk }}-", source)
+        self.assertIn(
+            "${{ steps.native-toolchain.outputs.sdk-root }}/ndk/"
+            "${{ steps.native-toolchain.outputs.ndk }}",
+            source,
+        )
 
     def test_rust_coverage_skips_android_and_gradle_setup(self) -> None:
         for job_name in ("rust-coverage", "nightly-rust-coverage"):

--- a/scripts/tests/test_nightly_coverage_selection.py
+++ b/scripts/tests/test_nightly_coverage_selection.py
@@ -82,10 +82,12 @@ class NightlyCoverageSelectionTest(unittest.TestCase):
         self.assertIn("if: inputs.setup-rust == 'true'", source)
         self.assertIn("inputs.setup-android-ndk == 'true'", source)
 
-    def test_android_sdk_cache_is_separated_by_ndk_installation_mode(self) -> None:
+    def test_android_native_toolchain_uses_a_separate_conditional_cache(self) -> None:
         source = SETUP_ACTION.read_text(encoding="utf-8")
 
-        self.assertIn("-ndk-${{ inputs.setup-android-ndk }}-", source)
+        self.assertIn("id: cache-android-sdk", source)
+        self.assertIn("id: cache-android-native", source)
+        self.assertIn("key: android-native-${{ runner.os }}-", source)
         self.assertIn(
             "${{ steps.native-toolchain.outputs.sdk-root }}/ndk/"
             "${{ steps.native-toolchain.outputs.ndk }}",

--- a/scripts/tests/test_nightly_coverage_selection.py
+++ b/scripts/tests/test_nightly_coverage_selection.py
@@ -116,7 +116,50 @@ class NightlyCoverageSelectionTest(unittest.TestCase):
         for job in (kotlin_job, rust_job):
             self.assertNotIn("run-heavy-ci", job)
             self.assertNotIn("run-coverage", job)
-            self.assertIn("run_nightly_coverage != 'true'", job)
+            self.assertIn("coverage_phase0_mode != 'nightly-coverage'", job)
+            self.assertIn("coverage_phase0_mode != 'nightly-and-phase0'", job)
+
+    def test_manual_dispatch_stays_within_input_limit_and_preserves_lanes(self) -> None:
+        source = CI_WORKFLOW.read_text(encoding="utf-8")
+        dispatch = source.split("  workflow_dispatch:\n", maxsplit=1)[1].split(
+            "  schedule:\n", maxsplit=1
+        )[0]
+        inputs = re.findall(r"(?m)^      ([a-z0-9_]+):$", dispatch)
+
+        self.assertLessEqual(len(inputs), 10)
+        self.assertIn("native_stress_mode", inputs)
+        self.assertIn("coverage_phase0_mode", inputs)
+        self.assertIn("android_extended_mode", inputs)
+
+        expected_modes = {
+            "rust-native-soak": ("native_stress_mode == 'soak'", "soak-and-load"),
+            "rust-native-load": ("native_stress_mode == 'load'", "soak-and-load"),
+            "nightly-kotlin-coverage": (
+                "coverage_phase0_mode == 'nightly-coverage'",
+                "nightly-and-phase0",
+            ),
+            "nightly-rust-coverage": (
+                "coverage_phase0_mode == 'nightly-coverage'",
+                "nightly-and-phase0",
+            ),
+            "phase0-baseline": (
+                "coverage_phase0_mode == 'phase0-baseline'",
+                "nightly-and-phase0",
+            ),
+            "android-journeys": (
+                "android_extended_mode == 'journeys'",
+                "journeys-and-relay",
+            ),
+            "android-relay-emulator-smoke": (
+                "android_extended_mode == 'relay'",
+                "journeys-and-relay",
+            ),
+        }
+        for job_name, expected_fragments in expected_modes.items():
+            with self.subTest(job=job_name):
+                job = workflow_job(source, job_name)
+                for fragment in expected_fragments:
+                    self.assertIn(fragment, job)
 
     def test_nightly_coverage_runs_kotlin_and_rust_lanes_separately(self) -> None:
         source = CI_WORKFLOW.read_text(encoding="utf-8")

--- a/scripts/tests/test_resolve_change_routing.py
+++ b/scripts/tests/test_resolve_change_routing.py
@@ -273,9 +273,12 @@ class ResolveChangeRoutingTest(unittest.TestCase):
             "linux-tun-soak",
         ):
             with self.subTest(job=job):
+                job_source = ci_job_source(job)
+                self.assertIn("needs: [change-routing, ci-preflight]", job_source)
+                self.assertIn("!cancelled()", job_source)
                 self.assertIn(
-                    "needs: [change-routing, ci-preflight]",
-                    ci_job_source(job),
+                    "needs.ci-preflight.result == 'success'",
+                    job_source,
                 )
 
         aggregate = ci_job_source("ci-required")

--- a/scripts/tests/test_resolve_change_routing.py
+++ b/scripts/tests/test_resolve_change_routing.py
@@ -281,6 +281,38 @@ class ResolveChangeRoutingTest(unittest.TestCase):
                     job_source,
                 )
 
+        downstream_dependencies = {
+            "build-android-debug": (
+                "rust-native-packaging",
+                "rust-native-x86_64",
+                "pluggable-transport-assets",
+            ),
+            "release-verification": (
+                "rust-native-packaging",
+                "rust-native-x86_64",
+                "owned-stack-tls-fingerprint",
+                "pluggable-transport-assets",
+            ),
+            "android-instrumented-tests": (
+                "rust-native-x86_64",
+                "pluggable-transport-assets",
+            ),
+            "phase0-baseline": ("pluggable-transport-assets",),
+            "android-macrobenchmark": ("pluggable-transport-assets",),
+            "android-network-e2e": ("pluggable-transport-assets",),
+            "android-journeys": ("pluggable-transport-assets",),
+            "android-relay-emulator-smoke": ("pluggable-transport-assets",),
+        }
+        for job, dependencies in downstream_dependencies.items():
+            with self.subTest(job=job):
+                job_source = ci_job_source(job)
+                self.assertIn("!cancelled()", job_source)
+                for dependency in dependencies:
+                    self.assertIn(
+                        f"needs.{dependency}.result == 'success'",
+                        job_source,
+                    )
+
         aggregate = ci_job_source("ci-required")
         self.assertIn("      - ci-preflight\n", aggregate)
         self.assertIn('"ci-preflight",', aggregate)


### PR DESCRIPTION
## What changed

- keep workflow_dispatch within the GitHub 10-input limit while preserving all manual lane modes
- fix Detekt failures in packet-smoke and subprocess relay sources
- make routed and artifact-consuming jobs tolerate unrelated skipped needs while still requiring their dependencies to succeed
- cache Android SDK packages from the actual SDK root and verify required files after restore or install
- pin the Android CLI platform package suffix for compileSdk 37 and isolate the large NDK/CMake cache from Kotlin-only jobs

## Root causes

The workflow exceeded the workflow_dispatch input limit, newly shared Kotlin sources failed Detekt, and GitHub skip propagation prevented the expensive and artifact-consuming jobs from running after successful preflight dependencies. A metadata-only Android cache then produced false hits: CMake was absent from ANDROID_HOME, and Android CLI 1.0 exposes API 37 as platforms/android-37.0 rather than platforms/android-37.

## Validation

- actionlint and pinact
- 82 workflow and release contract unit tests
- targeted app and service unit and Detekt gates
- ./gradlew staticAnalysis -Pripdpi.skipNativeBuild=true
- exact-head GitHub CI run 30640748426: 44 success, 14 expected manual-mode skips, 0 failures
- all native ABI packaging, PT assets, debug APK, release verification, Roborazzi, and managed-device API 27/33/35 lanes completed successfully