### PR TITLE
fix(ci): restore routed builds and release verification

### DIFF
--- a/.github/actions/setup-android-rust/action.yml
+++ b/.github/actions/setup-android-rust/action.yml
@@ -123,6 +123,7 @@ runs:
         echo "ndk=$(grep '^ripdpi.nativeNdkVersion=' gradle.properties | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
         echo "cmake=$(grep '^ripdpi.nativeCmakeVersion=' gradle.properties | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
         echo "compile-sdk=$(grep '^ripdpi.compileSdk=' gradle.properties | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
+        echo "compile-sdk-package=$(grep '^ripdpi.compileSdkPackage=' gradle.properties | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
 
     # Cache the Android CLI state directory as an installation accelerator only.
     # Every job still reconciles the packages below because Gradle consumes them
@@ -143,7 +144,7 @@ runs:
         set -euo pipefail
         bash scripts/ci/android-sdk-install.sh \
           "platform-tools" \
-          "platforms/android-${{ steps.native-toolchain.outputs.compile-sdk }}"
+          "platforms/android-${{ steps.native-toolchain.outputs.compile-sdk-package }}"
 
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       if: inputs.setup-rust == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,8 +606,13 @@ jobs:
   # artifacts. The rust-native Gradle plugin copies these inputs instead of
   # running Cargo, so the shards can execute independently.
   build-android-debug:
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     needs: [change-routing, rust-native-packaging, rust-native-x86_64, pluggable-transport-assets]
+    if: >-
+      !cancelled() &&
+      needs.rust-native-packaging.result == 'success' &&
+      needs.rust-native-x86_64.result == 'success' &&
+      needs.pluggable-transport-assets.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:
@@ -867,8 +872,14 @@ jobs:
         run: bash scripts/ci/check-owned-stack-tls-fingerprint.sh
 
   release-verification:
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     needs: [change-routing, rust-native-packaging, rust-native-x86_64, owned-stack-tls-fingerprint, pluggable-transport-assets]
+    if: >-
+      !cancelled() &&
+      needs.rust-native-packaging.result == 'success' &&
+      needs.rust-native-x86_64.result == 'success' &&
+      needs.owned-stack-tls-fingerprint.result == 'success' &&
+      needs.pluggable-transport-assets.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     # Three two-build shards bound Kotlin heap use without serializing all six
     # variants in one runner. Stop Gradle between variants and emit each build
@@ -1925,8 +1936,12 @@ jobs:
   # The dedicated x86_64 native shard is staged via
   # -Pripdpi.prebuilt*Dir so cargo is skipped.
   android-instrumented-tests:
-    if: github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     needs: [change-routing, rust-native-x86_64, pluggable-transport-assets]
+    if: >-
+      !cancelled() &&
+      needs.rust-native-x86_64.result == 'success' &&
+      needs.pluggable-transport-assets.result == 'success' &&
+      github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,7 @@ jobs:
   rust-native-packaging:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -451,7 +451,7 @@ jobs:
   rust-native-x86_64:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -546,7 +546,7 @@ jobs:
   pluggable-transport-assets:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       (github.event_name != 'schedule' ||
       github.event.schedule == '11 4 * * 4' || github.event.schedule == '27 4 * * 5')
@@ -718,7 +718,7 @@ jobs:
   build-android-tests:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -805,7 +805,7 @@ jobs:
   verify-roborazzi:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -849,7 +849,7 @@ jobs:
 
   owned-stack-tls-fingerprint:
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     needs: [change-routing, ci-preflight]
     runs-on: ubuntu-latest
@@ -1040,7 +1040,7 @@ jobs:
   native-bloat:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       github.event_name != 'schedule' &&
       (
@@ -1103,7 +1103,7 @@ jobs:
   rust-miri:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -1170,7 +1170,7 @@ jobs:
   diagnostics-probes-facade:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1213,7 +1213,7 @@ jobs:
   rust-lint:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1250,7 +1250,7 @@ jobs:
   rust-cross-check:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1278,7 +1278,7 @@ jobs:
   rust-workspace-tests:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1327,7 +1327,7 @@ jobs:
   rust-fuzz-smoke:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1359,7 +1359,7 @@ jobs:
   runtime-api-snapshot:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true'
     name: JNI API snapshot check
     runs-on: ubuntu-latest
@@ -1444,7 +1444,7 @@ jobs:
   rust-network-e2e:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1474,7 +1474,7 @@ jobs:
   relay-interoperability:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1504,7 +1504,7 @@ jobs:
   cli-packet-smoke:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -1540,7 +1540,7 @@ jobs:
   rust-turmoil:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -1569,7 +1569,7 @@ jobs:
   kotlin-coverage:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_kotlin_coverage == 'true' &&
       github.event_name != 'schedule' &&
       (
@@ -1624,7 +1624,7 @@ jobs:
   rust-coverage:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_rust_coverage == 'true' &&
       github.event_name != 'schedule' &&
       (
@@ -1674,7 +1674,7 @@ jobs:
   rust-criterion-bench:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' &&
       ((github.event_name == 'schedule' && github.event.schedule == '7 4 * * 1') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.run_rust_criterion_bench == 'true') ||
@@ -2138,7 +2138,7 @@ jobs:
   rust-loom:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       github.event_name != 'schedule' && needs.change-routing.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -2164,7 +2164,7 @@ jobs:
   rust-native-soak:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '19 4 * * 2') || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_native_soak == 'true'))
     runs-on: ubuntu-latest
     steps:
@@ -2210,7 +2210,7 @@ jobs:
   rust-native-load:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '19 4 * * 2') || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_native_load == 'true'))
     runs-on: ubuntu-latest
     steps:
@@ -2256,7 +2256,7 @@ jobs:
   nightly-kotlin-coverage:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '43 4 * * 3') || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_coverage == 'true'))
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -2291,7 +2291,7 @@ jobs:
   nightly-rust-coverage:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '43 4 * * 3') || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_coverage == 'true'))
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -2631,7 +2631,7 @@ jobs:
   linux-tun-e2e:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '27 4 * * 5') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tun-e2e')))
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -2670,7 +2670,7 @@ jobs:
   so-bindtodevice-e2e:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '27 4 * * 5') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tun-e2e')))
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -2755,7 +2755,7 @@ jobs:
   linux-tun-soak:
     needs: [change-routing, ci-preflight]
     if: >-
-      !cancelled() &&
+      !cancelled() && needs.ci-preflight.result == 'success' &&
       needs.change-routing.outputs.run_full_ci == 'true' && ((github.event_name == 'schedule' && github.event.schedule == '19 4 * * 2') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -236,7 +236,7 @@ jobs:
           test -x "$apksigner"
           for apk in "$candidate"/*.apk; do
             name="$(basename "$apk")"
-            if ! output="$($apksigner verify --verbose --print-certs "$apk" 2>&1)"; then
+            if ! output="$($apksigner verify --verbose --print-certs-pem "$apk" 2>&1)"; then
               echo "::error file=$name::APK signature verification failed."
               exit 1
             fi

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,6 +40,8 @@ android.nonFinalResIds=true
 # triggers (ProfilingTrigger.TRIGGER_TYPE_OOM / TRIGGER_TYPE_ANOMALY, API 37).
 # targetSdk stays 35: bumping runtime-behavior target is a separate, tested change.
 ripdpi.compileSdk=37
+# Android CLI 1.0 uses the 37.0 package suffix for compileSdk 37.
+ripdpi.compileSdkPackage=37.0
 ripdpi.minSdk=27
 ripdpi.targetSdk=35
 # r29 is the current stable NDK (non-LTS). r30 is still beta as of 2026-06;

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/dns_intercept/direct_dns.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/dns_intercept/direct_dns.rs
@@ -199,6 +199,25 @@ mod tests {
         response.to_vec().expect("response")
     }
 
+    fn bind_udp_tcp_fixture() -> (tokio::net::UdpSocket, tokio::net::TcpListener) {
+        for _ in 0..32 {
+            let tcp = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("TCP fixture");
+            tcp.set_nonblocking(true).expect("nonblocking TCP fixture");
+            let port = tcp.local_addr().expect("TCP address").port();
+            let udp = match std::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, port)) {
+                Ok(udp) => udp,
+                Err(error) if error.kind() == io::ErrorKind::AddrInUse => continue,
+                Err(error) => panic!("UDP fixture: {error}"),
+            };
+            udp.set_nonblocking(true).expect("nonblocking UDP fixture");
+            return (
+                tokio::net::UdpSocket::from_std(udp).expect("Tokio UDP fixture"),
+                tokio::net::TcpListener::from_std(tcp).expect("Tokio TCP fixture"),
+            );
+        }
+        panic!("could not reserve a shared UDP/TCP fixture port");
+    }
+
     #[test]
     fn response_validation_requires_exact_id_and_question() {
         let query = build_query("direct.example", 0x1234);
@@ -264,9 +283,8 @@ mod tests {
             assert_eq!(success.response_bytes, response_bytes(&query, false));
             udp_task.await.expect("UDP fixture task");
 
-            let udp = tokio::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.expect("UDP fixture");
+            let (udp, tcp) = bind_udp_tcp_fixture();
             let port = udp.local_addr().expect("UDP address").port();
-            let tcp = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, port)).await.expect("TCP fixture");
             let udp_task = tokio::spawn(async move {
                 let mut buffer = [0_u8; 512];
                 let (len, peer) = udp.recv_from(&mut buffer).await.expect("UDP query");
@@ -290,9 +308,8 @@ mod tests {
             udp_task.await.expect("UDP truncation task");
             tcp_task.await.expect("TCP fixture task");
 
-            let udp = tokio::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.expect("UDP fixture");
+            let (udp, tcp) = bind_udp_tcp_fixture();
             let port = udp.local_addr().expect("UDP address").port();
-            let tcp = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, port)).await.expect("TCP fixture");
             let udp_task = tokio::spawn(async move {
                 let mut buffer = [0_u8; 512];
                 let (len, peer) = udp.recv_from(&mut buffer).await.expect("UDP query");

--- a/scripts/ci/release_signature_fingerprint.py
+++ b/scripts/ci/release_signature_fingerprint.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import base64
+import binascii
+import hashlib
 import re
 import sys
 
@@ -8,9 +11,29 @@ import sys
 APK_LABEL = "Signer #1 certificate SHA-256 digest:"
 KEYTOOL_LABEL = "SHA256:"
 SHA256_RE = re.compile(r"[0-9a-f]{64}")
+PEM_CERTIFICATE_RE = re.compile(
+    r"-----BEGIN CERTIFICATE-----\s*(?P<body>[A-Za-z0-9+/=\s]+?)"
+    r"\s*-----END CERTIFICATE-----",
+)
 
 
 def extract_certificate_sha256(output: str) -> str:
+    pem_certificates = list(PEM_CERTIFICATE_RE.finditer(output))
+    if pem_certificates:
+        if len(pem_certificates) != 1:
+            raise ValueError(
+                "expected exactly one PEM signing certificate, "
+                f"found {len(pem_certificates)}",
+            )
+        encoded = re.sub(r"\s", "", pem_certificates[0].group("body"))
+        try:
+            certificate_der = base64.b64decode(encoded, validate=True)
+        except binascii.Error as error:
+            raise ValueError("invalid PEM signing certificate") from error
+        if not certificate_der:
+            raise ValueError("empty PEM signing certificate")
+        return hashlib.sha256(certificate_der).hexdigest()
+
     candidates: list[str] = []
     for line in output.splitlines():
         stripped = line.strip()

--- a/scripts/tests/test_ci_native_dependency_graph.py
+++ b/scripts/tests/test_ci_native_dependency_graph.py
@@ -66,6 +66,32 @@ class NativeDependencyGraphTest(unittest.TestCase):
             job_source("release-verification"),
         )
 
+    def test_packaging_consumers_run_after_intentional_ancestor_skips(self) -> None:
+        expected_results = {
+            "build-android-debug": (
+                "needs.rust-native-packaging.result == 'success'",
+                "needs.rust-native-x86_64.result == 'success'",
+                "needs.pluggable-transport-assets.result == 'success'",
+            ),
+            "release-verification": (
+                "needs.rust-native-packaging.result == 'success'",
+                "needs.rust-native-x86_64.result == 'success'",
+                "needs.owned-stack-tls-fingerprint.result == 'success'",
+                "needs.pluggable-transport-assets.result == 'success'",
+            ),
+            "android-instrumented-tests": (
+                "needs.rust-native-x86_64.result == 'success'",
+                "needs.pluggable-transport-assets.result == 'success'",
+            ),
+        }
+
+        for job_name, result_guards in expected_results.items():
+            with self.subTest(job=job_name):
+                source = job_source(job_name)
+                self.assertIn("!cancelled()", source)
+                for result_guard in result_guards:
+                    self.assertIn(result_guard, source)
+
     def test_debug_apks_build_in_independent_distribution_shards(self) -> None:
         source = job_source("build-android-debug")
 

--- a/scripts/tests/test_ci_tool_pinning.py
+++ b/scripts/tests/test_ci_tool_pinning.py
@@ -69,6 +69,20 @@ class CiToolPinningTest(unittest.TestCase):
             action,
         )
 
+    def test_android_sdk_install_uses_the_pinned_cli_package_suffix(self) -> None:
+        action = (
+            ROOT / ".github/actions/setup-android-rust/action.yml"
+        ).read_text(encoding="utf-8")
+        properties = (ROOT / "gradle.properties").read_text(encoding="utf-8")
+
+        self.assertIn("ripdpi.compileSdk=37", properties)
+        self.assertIn("ripdpi.compileSdkPackage=37.0", properties)
+        self.assertIn("steps.native-toolchain.outputs.compile-sdk-package", action)
+        self.assertIn(
+            '"platforms/android-${{ steps.native-toolchain.outputs.compile-sdk-package }}"',
+            action,
+        )
+
     def test_github_actions_do_not_execute_floating_rust_toolchain_action(self) -> None:
         sources = [ROOT / ".github/actions/setup-android-rust/action.yml"]
         sources.extend(sorted((ROOT / ".github/workflows").glob("*.yml")))

--- a/scripts/tests/test_release_p0_contracts.py
+++ b/scripts/tests/test_release_p0_contracts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import re
 import unittest
@@ -63,6 +65,7 @@ class ReleaseP0ContractsTest(unittest.TestCase):
         self.assertLess(signing_key, signing_identity)
         self.assertLess(signing_identity, native_build)
         self.assertGreaterEqual(signing.count("release_signature_fingerprint.py"), 3)
+        self.assertIn("--print-certs-pem", signing)
         self.assertIn("APK signature verification failed", signing)
         self.assertIn("AAB signature verification failed", signing)
         self.assertIn("release_candidate_manifest.py create", signing)
@@ -86,6 +89,21 @@ class ReleaseP0ContractsTest(unittest.TestCase):
             extract_certificate_sha256(f"  SHA256: {colon_delimited}  \n"),
         )
 
+    def test_release_signature_fingerprint_hashes_pem_certificate_der(self) -> None:
+        certificate_der = b"release-certificate-der"
+        encoded = base64.b64encode(certificate_der).decode("ascii")
+        output = (
+            "Signer #1 certificate DN: CN=RIPDPI\n"
+            "-----BEGIN CERTIFICATE-----\n"
+            f"{encoded}\n"
+            "-----END CERTIFICATE-----\n"
+        )
+
+        self.assertEqual(
+            hashlib.sha256(certificate_der).hexdigest(),
+            extract_certificate_sha256(output),
+        )
+
     def test_release_signature_fingerprint_rejects_ambiguous_or_malformed_output(
         self,
     ) -> None:
@@ -94,6 +112,9 @@ class ReleaseP0ContractsTest(unittest.TestCase):
             "",
             "SHA256: not-a-digest",
             f"SHA256: {valid}\nSHA256: {valid}\n",
+            "-----BEGIN CERTIFICATE-----\n***\n-----END CERTIFICATE-----\n",
+            "-----BEGIN CERTIFICATE-----\nYWJj\n-----END CERTIFICATE-----\n"
+            "-----BEGIN CERTIFICATE-----\nZGVm\n-----END CERTIFICATE-----\n",
         ):
             with self.subTest(output=output):
                 with self.assertRaises(ValueError):

--- a/scripts/tests/test_resolve_change_routing.py
+++ b/scripts/tests/test_resolve_change_routing.py
@@ -301,6 +301,10 @@ class ResolveChangeRoutingTest(unittest.TestCase):
                     source,
                     r"(?ms)^    if: >-\n      !cancelled\(\) &&",
                 )
+                self.assertIn(
+                    "needs.ci-preflight.result == 'success'",
+                    source,
+                )
 
         aggregate = ci_job_source("ci-required")
         self.assertIn("      - ci-preflight\n", aggregate)


### PR DESCRIPTION
## Summary
- install the Android CLI 1.0 compile SDK package as `platforms/android-37.0` while keeping AGP `compileSdk=37`
- run APK/release/emulator artifact consumers after successful direct producers even when unrelated routed ancestors were skipped
- fail closed when the CI preflight barrier does not succeed
- compute APK signer continuity from PEM certificate DER instead of parsing `apksigner` display text
- reserve DNS test fixture ports across TCP and UDP to eliminate the `rust-coverage` `AddrInUse` flake

## Validation
- final PR CI run 30657349749: success (40 successful jobs, 17 expected routed skips, 0 failures)
- all 9 routed consumers ran and passed: 3 debug APK, 3 release-verification, 3 managed-device jobs
- CodeQL, Secret Scan, and Labeler: success
- actionlint and pinact: success
- 86 workflow/release contract tests: success
- `ripdpi-tunnel-core`: 301 unit tests + 7 integration tests passed; clippy `-D warnings` passed
- flaky DNS fixture scenario passed 50 consecutive runs
- published v0.1.3 APK passes the new PEM/DER fingerprint path
- Android CLI inventory contains `platforms/android-37.0`

## Remaining acceptance
After explicit approval to integrate this draft PR, rerun main CI and Android release candidate; the latest main release-candidate run was externally cancelled during the signed build.