### PR TITLE
fix(ci): protect release transport asset build

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -19,6 +19,7 @@ jobs:
   pluggable-transport-assets:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    environment: release-signing
     outputs:
       manifest_sha256: ${{ steps.digest.outputs.manifest_sha256 }}
     steps:

--- a/scripts/tests/test_release_p0_contracts.py
+++ b/scripts/tests/test_release_p0_contracts.py
@@ -30,6 +30,7 @@ class ReleaseP0ContractsTest(unittest.TestCase):
         self.assertIn("-Pripdpi.pluggableTransportAssetsMode=source", producer)
         self.assertIn("-Pripdpi.pluggableTransportAssetsStrictFailures=true", producer)
         self.assertIn("manifest_sha256", producer)
+        self.assertIn("environment: release-signing", producer)
         self.assertIn("Download verified pluggable transport assets", signing)
         self.assertIn("Extract verified pluggable transport assets", signing)
         self.assertIn("ripdpi.prebuiltPluggableTransportAssetsDir", signing)


### PR DESCRIPTION
### Motivation
- Prevent an unprotected CI producer from building executable pluggable-transport assets outside the `release-signing` trust boundary so signed release artifacts cannot be poisoned by a compromised producer job.

### Description
- Add `environment: release-signing` to the `pluggable-transport-assets` job in `.github/workflows/release-candidate.yml` so the producer runs inside the same protected environment as the signing/consumer job. 
- Extend the release-contract regression test in `scripts/tests/test_release_p0_contracts.py` to assert that the producer job remains bound to `environment: release-signing`.

### Testing
- Ran the focused unit test `python3 -m unittest scripts.tests.test_release_p0_contracts.ReleaseP0ContractsTest.test_candidate_is_built_once_inside_signing_environment` and the broader suite `python3 -m unittest scripts.tests.test_release_p0_contracts scripts.tests.test_release_artifact_uploads scripts.tests.test_ci_native_dependency_graph`, and they passed.
- Verified YAML parsing with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-candidate.yml', aliases: true)"` and ran `git diff --check`; `./gradlew staticAnalysis` could not complete locally due to missing JDK 17 / tooling download restrictions in this environment which caused the Gradle toolchain to fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c9aa9ffc4832c9bef08b3d3e27cdb)