### PR TITLE
fix: integrate remaining CI, VLESS, and VPN recovery fixes

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -19,6 +19,7 @@ jobs:
   pluggable-transport-assets:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    environment: release-signing
     outputs:
       manifest_sha256: ${{ steps.digest.outputs.manifest_sha256 }}
     steps:

--- a/core/service/src/main/kotlin/com/poyka/ripdpi/services/VpnServiceSessionLifecycle.kt
+++ b/core/service/src/main/kotlin/com/poyka/ripdpi/services/VpnServiceSessionLifecycle.kt
@@ -10,6 +10,7 @@ import com.poyka.ripdpi.data.Sender
 import com.poyka.ripdpi.data.ServiceStateStore
 import com.poyka.ripdpi.service.runtime.vpn.VpnServiceRuntimeCoordinator
 import dagger.hilt.EntryPoints
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Provider
 
 internal class VpnServiceSessionLifecycle(
@@ -145,11 +146,14 @@ internal suspend inline fun recoverProfileMutationsAndAwaitUnderlayThenStart(
     crossinline recoverProfileMutations: suspend () -> Unit,
     crossinline awaitRecoveryUnderlay: suspend () -> Unit,
     crossinline startRuntime: suspend () -> Unit,
+    underlayTimeoutMillis: Long = RecoveryUnderlayTimeoutMs,
 ) {
     recoverProfileMutations()
-    awaitRecoveryUnderlay()
+    withTimeoutOrNull(underlayTimeoutMillis) { awaitRecoveryUnderlay() }
     startRuntime()
 }
+
+internal const val RecoveryUnderlayTimeoutMs = 3_000L
 
 internal interface HardKillSwitchRefreshLifecycle : AutoCloseable {
     fun start()

--- a/core/service/src/test/kotlin/com/poyka/ripdpi/services/VpnServiceSessionLifecycleTest.kt
+++ b/core/service/src/test/kotlin/com/poyka/ripdpi/services/VpnServiceSessionLifecycleTest.kt
@@ -1,5 +1,6 @@
 package com.poyka.ripdpi.services
 
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -102,8 +103,22 @@ class VpnServiceSessionLifecycleTest {
                     )
                 }.exceptionOrNull()
 
-            assertSame(failure, thrown)
+            assertEquals(failure::class, thrown?.let { it::class })
+            assertEquals(failure.message, thrown?.message)
             assertEquals(listOf(Event.ProfileRecover, Event.UnderlayReady), events)
+        }
+
+    @Test
+    fun `recovery starts runtime when underlay readiness times out`() =
+        runTest {
+            recoverProfileMutationsAndAwaitUnderlayThenStart(
+                recoverProfileMutations = { events += Event.ProfileRecover },
+                awaitRecoveryUnderlay = { awaitCancellation() },
+                startRuntime = { events += Event.RuntimeStart },
+                underlayTimeoutMillis = 1L,
+            )
+
+            assertEquals(listOf(Event.ProfileRecover, Event.RuntimeStart), events)
         }
 
     /**

--- a/native/rust/crates/local-network-fixture/src/vless.rs
+++ b/native/rust/crates/local-network-fixture/src/vless.rs
@@ -251,7 +251,7 @@ async fn handle_connection(
             return Err(io::Error::new(io::ErrorKind::InvalidData, "XUDP frame arrived before VLESS response"));
         }
         tls.write_all(&encode_response(&[])?).await?;
-        return serve_xudp_carrier(VisionStream::new_vision(FixtureRealityTlsStream(tls), header.uuid)).await;
+        return serve_xudp_carrier(VisionStream::new_vision_tls_only(FixtureRealityTlsStream(tls), header.uuid)).await;
     }
 
     // 3. A Sager mux carrier has a fixed reserved VLESS destination. It is

--- a/native/rust/crates/ripdpi-vless/src/lib.rs
+++ b/native/rust/crates/ripdpi-vless/src/lib.rs
@@ -185,7 +185,11 @@ impl VlessRealityClient {
         let stream = match config.flow {
             crate::addons::VlessFlow::None => VisionStream::new_passthrough(response),
             crate::addons::VlessFlow::Vision | crate::addons::VlessFlow::VisionUdp443 => {
-                VisionStream::new_vision(response, config.uuid)
+                if command == wire::VlessCommand::Mux {
+                    VisionStream::new_vision_tls_only(response, config.uuid)
+                } else {
+                    VisionStream::new_vision(response, config.uuid)
+                }
             }
         };
         Ok(stream)

--- a/native/rust/crates/ripdpi-vless/src/vision.rs
+++ b/native/rust/crates/ripdpi-vless/src/vision.rs
@@ -24,10 +24,12 @@
 //!
 //! RIPDPI writes the VLESS request header eagerly before this wrapper engages,
 //! so the xray "hide-header" zero-content chunk is not emitted. The UUID still
-//! prefixes the first real chunk. `Direct` switches reads and writes to the
-//! transport beneath the outer Reality TLS stream, matching xray's raw-conn
-//! splice; `End` keeps the outer layer. The owner-only live test exercises a
-//! complete HTTPS exchange against a Vision-enforcing Xray server.
+//! prefixes the first real chunk. For inner TLS, `Direct` switches reads and
+//! writes to the transport beneath the outer Reality TLS stream, matching
+//! xray's raw-conn splice; `End` keeps the outer layer. Non-TLS XUDP carriers
+//! disable that splice so datagrams remain protected by Reality TLS. The
+//! owner-only live test exercises a complete HTTPS exchange against a
+//! Vision-enforcing Xray server.
 
 use std::io;
 use std::pin::Pin;
@@ -92,6 +94,8 @@ pub struct VisionStream<S> {
     inner: S,
     /// `false` for `flow=none`: transparent passthrough in both directions.
     vision: bool,
+    /// Whether Vision may bypass the outer Reality TLS transport.
+    allow_direct: bool,
     /// 16-byte user UUID, prefixed on the first chunk of each direction.
     uuid: [u8; 16],
     rng: SystemRandom,
@@ -127,18 +131,25 @@ impl<S> VisionStream<S> {
     /// `uuid` is the binary 16-byte VLESS user id (the same bytes used in the
     /// VLESS request header).
     pub fn new_vision(inner: S, uuid: [u8; 16]) -> Self {
-        Self::with_mode(inner, uuid, true)
+        Self::with_mode(inner, uuid, true, true)
+    }
+
+    /// Wrap a non-TLS payload stream with Vision framing while keeping every
+    /// byte inside the outer Reality TLS transport.
+    pub fn new_vision_tls_only(inner: S, uuid: [u8; 16]) -> Self {
+        Self::with_mode(inner, uuid, true, false)
     }
 
     /// Wrap `inner` as a transparent passthrough (`flow=none`).
     pub fn new_passthrough(inner: S) -> Self {
-        Self::with_mode(inner, [0u8; 16], false)
+        Self::with_mode(inner, [0u8; 16], false, false)
     }
 
-    fn with_mode(inner: S, uuid: [u8; 16], vision: bool) -> Self {
+    fn with_mode(inner: S, uuid: [u8; 16], vision: bool, allow_direct: bool) -> Self {
         Self {
             inner,
             vision,
+            allow_direct,
             uuid,
             rng: SystemRandom::new(),
             w_padding: vision,
@@ -302,7 +313,7 @@ impl<S> VisionStream<S> {
                     // End keeps the outer transport; Direct bypasses Reality
                     // TLS as well. In both cases Vision padding stops.
                     self.r_padding = false;
-                    self.r_direct = self.r_cur_cmd == CMD_DIRECT;
+                    self.r_direct = self.allow_direct && self.r_cur_cmd == CMD_DIRECT;
                     let rest = self.r_inbuf.split_off(i);
                     self.r_out.extend_from_slice(&rest);
                     self.r_inbuf.clear();
@@ -418,7 +429,8 @@ impl<S: XtlsDirectWrite> AsyncWrite for VisionStream<S> {
 
         this.w_chunks += 1;
         let reached_appdata = this.note_records(buf);
-        let stop = reached_appdata || (!this.w_seen_handshake && this.w_chunks >= NON_TLS_CHUNK_LIMIT);
+        let stop =
+            this.allow_direct && (reached_appdata || (!this.w_seen_handshake && this.w_chunks >= NON_TLS_CHUNK_LIMIT));
         let cmd = if stop { CMD_DIRECT } else { CMD_CONTINUE };
         this.encode_outgoing(buf, cmd);
         if stop {
@@ -651,6 +663,23 @@ mod tests {
 
         let expected = [appdata.as_slice(), raw].concat();
         assert_eq!(recovered, expected, "post-Direct downlink must bypass outer TLS");
+    }
+
+    #[tokio::test]
+    async fn tls_only_vision_never_writes_non_tls_payload_directly() {
+        let mut writer =
+            VisionStream::new_vision_tls_only(WriteModeSpy { outer_tls: Vec::new(), direct: Vec::new() }, TEST_UUID);
+
+        for payload in [b"xudp-one".as_slice(), b"xudp-two", b"xudp-three", b"xudp-four", b"xudp-secret-five"] {
+            writer.write_all(payload).await.expect("write XUDP payload");
+        }
+        writer.flush().await.expect("flush outer TLS transport");
+
+        assert!(writer.inner.direct.is_empty(), "XUDP payload must never bypass Reality TLS");
+        assert!(
+            writer.inner.outer_tls.windows(b"xudp-secret-five".len()).any(|window| window == b"xudp-secret-five"),
+            "the fifth payload must remain on the outer TLS write path"
+        );
     }
 
     #[tokio::test]

--- a/scripts/tests/test_release_p0_contracts.py
+++ b/scripts/tests/test_release_p0_contracts.py
@@ -32,6 +32,7 @@ class ReleaseP0ContractsTest(unittest.TestCase):
         self.assertIn("-Pripdpi.pluggableTransportAssetsMode=source", producer)
         self.assertIn("-Pripdpi.pluggableTransportAssetsStrictFailures=true", producer)
         self.assertIn("manifest_sha256", producer)
+        self.assertIn("environment: release-signing", producer)
         self.assertIn("Download verified pluggable transport assets", signing)
         self.assertIn("Extract verified pluggable transport assets", signing)
         self.assertIn("ripdpi.prebuiltPluggableTransportAssetsDir", signing)


### PR DESCRIPTION
Integrates the remaining unique changes from #338, #339, and #340 as three atomic commits.

Superseded CI PRs #335, #336, and #337 are already represented by newer commits on `main`; they will be closed after this integration lands and post-merge CI is green.

Local validation:
- `./gradlew staticAnalysis -Pripdpi.skipNativeBuild=true`
- targeted `VpnServiceSessionLifecycleTest`, ktlint, and detekt
- `cargo test -p ripdpi-vless --locked`
- `cargo clippy -p ripdpi-vless --all-targets --locked -- -D warnings`
- `cargo fmt --all --check`
- 84 workflow/release contract tests
- `actionlint` and `pinact --check`
- architecture health: 0 new indicators
- `cargo metadata --locked --no-deps`