### PR TITLE
fix(ci): install nightly fuzz tool from release

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -30,7 +30,9 @@ jobs:
         with:
           toolchain: nightly-2026-06-12
       - name: Install cargo-fuzz
-        run: cargo +nightly-2026-06-12 install cargo-fuzz --version 0.13.1 --locked --quiet
+        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        with:
+          tool: cargo-fuzz@0.13.1
       - name: Run fuzz targets
         env:
           RIPDPI_FUZZ_SECONDS: ${{ inputs.fuzz_seconds || 600 }}

--- a/scripts/tests/test_ci_tool_pinning.py
+++ b/scripts/tests/test_ci_tool_pinning.py
@@ -75,6 +75,18 @@ class CiToolPinningTest(unittest.TestCase):
         for path in sources:
             self.assertNotIn("dtolnay/rust-toolchain@master", path.read_text(encoding="utf-8"), path)
 
+    def test_fuzz_nightly_uses_prebuilt_pinned_cargo_fuzz(self) -> None:
+        source = (ROOT / ".github/workflows/fuzz-nightly.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            "uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf",
+            source,
+        )
+        self.assertIn("tool: cargo-fuzz@0.13.1", source)
+        self.assertNotIn("install cargo-fuzz", source)
+
     def test_android_cli_uses_versioned_digest_verified_binary(self) -> None:
         source = (ROOT / ".github/actions/setup-android-rust/action.yml").read_text(encoding="utf-8")
         self.assertIn("android_cli_version=\"1.0.15857036\"", source)


### PR DESCRIPTION
## Summary\n\n- install the pinned cargo-fuzz 0.13.1 binary through the repository's pinned taiki-e installer\n- avoid compiling cargo-fuzz's legacy locked rustix dependency with nightly-2026-06-12\n- add a workflow contract test that prevents the broken source-install path from returning\n\n## Failure reproduced from GitHub Actions\n\nFuzz Nightly run 30686343578 failed in all six shards while compiling rustix 0.36.5 during cargo install. The pinned nightly now rejects its reserved rustc attributes before any fuzz target starts.\n\n## Validation\n\n- actionlint .github/workflows/fuzz-nightly.yml\n- pinact run --check .github/workflows/fuzz-nightly.yml\n- ruff check scripts/tests/test_ci_tool_pinning.py\n- python3 -m unittest scripts.tests.test_ci_tool_pinning scripts.tests.test_scheduled_workflow_offsets scripts.tests.test_path_filtered_pr_checks scripts.tests.test_resolve_change_routing (32 tests)