### PR TITLE
chore(deps): nightly audit 2026-08-01

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -8143,9 +8143,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "js-sys",


### PR DESCRIPTION
## Task

N/A — automated nightly dependency/security audit (no `docs/tasks/issues/` entry).

## Summary

Nightly scan of both dependency ecosystems (native Rust workspace, ~90 crates; Gradle/Kotlin, ~17 modules). Applies only the SAFE bucket; everything else is reported below for manual review.

## Applied

Rust:
- `time`: 0.3.54 → 0.3.55 (patch; no crypto/networking/async-runtime/FFI surface)

Gradle: none this run.

## Security

- **RUSTSEC-2023-0071** (rsa "Marvin Attack" timing side-channel, `rsa` 0.9.10 / 0.10.0-rc.18) — already tracked and waived in `native/rust/advisory-waivers.toml` (expires 2026-08-12, owner: Native security maintainer). No safe upgrade path exists on the Arti/russh paths that pull it in. Not resolved by this PR; already tracked in `docs/tasks/issues/unpin-russh-after-rsa-advisory-fix.md`.
- **RUSTSEC-2025-0141** (`bincode` 2.0.1, unmaintained) — transitive via `arti-client` → `tor-netdir` → `typed-index-collections`. Not previously waived. **Unresolved**: no patched version exists (bincode ceased development); the only path forward is `arti-client` dropping/replacing its dependency on `typed-index-collections`/`bincode` upstream, or us pinning a fork. Recommend a tracked follow-up.
- **RUSTSEC-2026-0221** (`event-listener` 5.4.1, unsound — `!Send` tags can cross thread boundaries via `StackSlot`, causing a data race in safe code) — transitive via `tun-rs` (async-channel → blocking) and `arti-client` → `tor-dirmgr`. **Not previously waived.** A patched release exists (`>=5.4.2`) but is withheld from auto-apply because `event-listener` is a foundational async-concurrency primitive reachable from the TUN driver's async stack — falls under the "async runtime" review-required category regardless of semver level. Recommend `cargo update -p event-listener --precise 5.4.2` after a maintainer reviews the fix (PR: smol-rs/event-listener#163).

`cargo deny check` passed clean (advisories/bans/licenses/sources all ok) — the pre-existing 90 `duplicate`/87 `wildcard` warnings are baseline state, not new findings.

## Needs review

Rust (crypto / networking / async-runtime / FFI-adjacent, or minor+ bump — held regardless of semver level per policy):
- `russh`: 0.62.4 → 0.62.5 (patch; exact-pinned SSH/RustCrypto relay dependency, see the pin comment in `Cargo.toml`)
- `aes`: 0.9.1 → 0.9.2 (patch; crypto primitive)
- `mio`: 1.2.1 → 1.2.2 (patch; async I/O reactor underlying Tokio)
- `rustls`: 0.23.42 → 0.23.43 (patch; TLS)
- `tokio-util`: 0.7.18 → 0.7.19 (patch; async runtime)
- `etherparse`: 0.20.3 → 0.21.0 (minor; packet parsing used by the desync/packet-manipulation path)
- `http`: 1.4.2 → 1.5.0 (minor; networking primitive types)

Gradle:
- `io.grpc:grpc-okhttp`: 1.83.0 → 1.83.1 (patch; networking library)

## Major

- `tungstenite` / `tokio-tungstenite`: 0.29.0 → 0.30.0 (pre-1.0 minor-as-breaking bump; WebSocket networking used by the WS tunnel / Telegram MTProto transport (`ripdpi-ws-tunnel`). Changelog not yet reviewed for breaking surface — needs a dedicated PR.)

## Test plan

- `cd native/rust && cargo check --locked --workspace --all-targets` — pass (full workspace, ~90 crates)
- `cd native/rust && cargo deny check` — pass (advisories/bans/licenses/sources ok)
- `cd native/rust && cargo audit --json` — 2 vulnerabilities (both RUSTSEC-2023-0071, waived), 4 warnings (see Security section)
- Gradle: `:app:dependencies --configuration githubFullDebugRuntimeClasspath` resolved cleanly against a freshly-provisioned SDK — every artifact converges to exactly one version across the full runtime classpath, zero conflicts, zero resolution failures (no `## Conflicts` findings this run)
- Gradle catalog entries checked against Google Maven / Maven Central metadata directly (`gradlew dependencyUpdates`-equivalent not configured in this repo)

## Checklist

- [x] No baseline files extended (detekt, lint, LoC)
- [ ] `timeout-minutes` added to any new CI job — N/A, no CI changes
- [x] Native ABI matrix not broken (workspace-wide `cargo check` passed; no native ABI files touched)
- [x] Non-rooted device path still works — N/A, no VPN/root code touched


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZqACDDiWmU9a3CBcQdehf)_