### PR TITLE
chore(deps): nightly audit 2026-08-02

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -958,18 +958,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -1598,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "derive-deftly"
-version = "1.11.4"
+version = "1.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1367f9dc01ce4c697898b2f8660b834bc201e45feae4b80a78e634916b72a827"
+checksum = "98e02cd118058400797c74550dca132b57cf2e6af0e9ea0672a83eb186fd655e"
 dependencies = [
  "derive-deftly-macros",
  "heck",
@@ -1608,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "derive-deftly-macros"
-version = "1.11.4"
+version = "1.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e338c793f9c79f33f4f9009fe16dd2d7c6bb308afcba56b386149ac507479dc7"
+checksum = "ba91f619216e76a5eb2515783f7ec2e271938b51aadac592f4930517f4626863"
 dependencies = [
  "heck",
  "indexmap 1.9.3",
@@ -1618,9 +1618,9 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "sha3 0.12.0",
+ "sha3 0.11.0",
  "strum",
- "syn 2.0.119",
+ "syn 3.0.3",
  "unicode-ident",
  "void",
 ]
@@ -8086,7 +8086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",


### PR DESCRIPTION
## Task

Scheduled nightly dependency and security audit (no `docs/tasks/issues/` entry — routine automated sweep of the Rust Cargo workspace and Gradle/Kotlin frontend).

## Summary

Nightly `cargo audit` / `cargo outdated` / `cargo deny` (Rust) and version-catalog sweep (Gradle) across the workspace. Only the **Applied** section below was auto-applied; everything else is reported for a human decision, per policy.

### Applied

**Rust**
- `clap`: 4.6.4 → 4.6.5 (patch; dev-only, reached via `criterion` → `ripdpi-bench`/`ripdpi-io-uring`)
- `clap_builder`: 4.6.2 → 4.6.5 (patch; follows `clap`)
- `derive-deftly`: 1.11.4 → 1.11.5 (patch; build-time proc-macro tooling, reached via `arti-client`/Tor stack)
- `derive-deftly-macros`: 1.11.4 → 1.11.5 (patch)

Note: the `derive-deftly` bump pulled in `syn` 3.0.3 and `sha3` 0.11.0 as new *additive* duplicate lockfile entries used only by `derive-deftly-macros` — the existing `syn` 2.0.119 and `sha3` 0.12.0 used by the rest of the graph are untouched. `tempfile`'s `getrandom` link also shifted from the already-present 0.4.3 duplicate to the already-present 0.3.4 duplicate. All four updated crates, their full reverse-dependency chain (`ripdpi-bench`, `ripdpi-io-uring`, `ripdpi-tor`), and `cargo check --workspace --locked --all-targets` were verified to build clean after the bump.

**Gradle**
None. Every entry in `gradle/libs.versions.toml` (Gradle wrapper, AGP, Kotlin, KSP, Compose BOM, Hilt, and 45+ other pins) was already at its latest stable release as of tonight's audit — no SAFE Gradle changes were available to apply.

### Security

- **RUSTSEC-2026-0221** (unsound, published 2026-07-13) — `event-listener` 5.4.1 allows `!Send` types to cross thread boundaries via `StackSlot`. A patch release, 5.4.2, is available and likely resolves it. `event-listener` is an async/concurrency-primitive crate (reached via `notify` → `tor-config` → `arti-client`), so per policy this stays in **Needs review** despite being patch-level — but since it's a soundness fix rather than a feature release, recommend fast-tracking `cargo update -p event-listener --precise 5.4.2`.
- **RUSTSEC-2025-0141** (unmaintained, published 2025-12-16) — the `bincode` 2.0.1 project is unmaintained. Verified via `cargo metadata` that every path pulling `bincode` into the graph (`icu_provider`, `smallvec`, `typed-index-collections`, `enum-map`, and others) does so as a dev-dependency or a disabled-by-default optional feature — `bincode` does not compile into any shipped RIPDPI target. Low urgency, but neither this advisory nor RUSTSEC-2026-0221 above has a waiver entry in `deny.toml`/`advisory-waivers.toml` yet; `cargo deny check` doesn't fail on either today only because its configured policy enforces the `vulnerability` advisory category, not `unmaintained`/`unsound`. Recommend a maintainer decide whether to add tracked waivers for both, in the existing format.
- **RUSTSEC-2023-0071** (Marvin Attack, `rsa` timing side-channel) — already tracked and waived (owner: Native security maintainer; tracking: `docs/tasks/issues/unpin-russh-after-rsa-advisory-fix.md`). Flagging because **the waiver expires 2026-08-12 — 10 days from this audit** — `scripts/ci/check_rust_advisory_waivers.py` fails closed once it lapses, and no safe upgrade path exists yet (`russh` 0.62.4 still exact-pins the affected RC-crypto graph). The waiver needs renewal or the underlying stack needs re-pinning before it expires.
- `cargo deny --locked check` passes cleanly today: `advisories ok, bans ok, licenses ok, sources ok`. It reports ~140 pre-existing "duplicate crate version" bans warnings, all accepted under the repo's `bans.multiple-versions = "warn"` policy; none were introduced by tonight's SAFE changes.

### Needs review

**Rust** — withheld solely because they touch crypto, networking, async-runtime, or FFI (regardless of semver level), or because they are minor-version bumps:

- `rustls` 0.23.42 → 0.23.43 (patch; TLS core — rustls patch releases often carry security fixes, recommend fast review)
- `aws-lc-rs` 1.17.0 → 1.17.3 (patch; TLS crypto backend)
- `aes` 0.9.1 → 0.9.2, `chacha20` 0.10.0 → 0.10.1, `der` 0.8.0 → 0.8.1, `pkcs5` 0.8.0 → 0.8.1, `poly1305` 0.9.0 → 0.9.1, `polyval` 0.7.1 → 0.7.3, `sha1` 0.10.6 → 0.10.7, `rand` 0.8.6 → 0.8.7, `num-bigint` 0.4.6 → 0.4.8, `reseeding_rng` 0.10.6 → 0.10.7, `hybrid-array` 0.4.13 → 0.4.14, `webpki-root-certs` 1.0.8 → 1.0.9, `rustls-pki-types` 1.14.1 → 1.15.1 (patch/minor; crypto or TLS-adjacent)
- `event-listener` 5.4.1 → 5.4.2 (see Security above)
- `mio` 1.2.1 → 1.2.2, `tokio-macros` 2.7.0 → 2.7.2, `tokio-util` 0.7.18 → 0.7.19, `portable-atomic` 1.13.1 → 1.14.0 (async-runtime / concurrency primitives)
- `async-compression` 0.4.42 → 0.4.43, `quinn-proto` 0.11.15 → 0.11.16, `quinn-udp` 0.5.14 → 0.5.15, `http` 1.4.2 → 1.5.0, `http-body` 1.0.1 → 1.1.0, `route_manager` 0.2.11 → 0.2.13, `idna_adapter` 1.2.0 → 1.2.2 (networking / DNS / domain-handling)
- `etherparse` 0.20.3 → 0.21.0 (minor; core packet-header parsing crate for the desync/DPI pipeline — requires a `Cargo.toml` edit, not just a lockfile bump)
- `tokio-tungstenite` 0.29.0 → 0.30.0, `tungstenite` 0.29.0 → 0.30.0 (minor; WebSocket transport used by `ripdpi-ws-tunnel` for the Telegram MTProto tunnel — requires a `Cargo.toml` edit)
- `russh` 0.62.4 → 0.62.5 (patch, but exact-pinned; the SSH relay's RC-crypto graph is under active governance per `deny.toml`'s "Known RC-crypto exposure" note — re-pin only through that tracked process)
- `clang-sys` 1.8.1 → 1.9.1, `foreign-types-macros` 0.2.3 → 0.2.4, `cc` 1.2.67 → 1.4.0 (FFI / native-build-adjacent)
- `bstr` 1.12.3 → 1.13.0, `either` 1.16.0 → 1.17.0, `fastrand` 2.4.1 → 2.5.0, `humantime` 2.3.0 → 2.4.0, `rapidhash` 4.4.2 → 4.5.1, `regex` 1.12.4 → 1.13.1, `simd_cesu8` 1.1.1 → 1.2.0, `tinyvec` 1.11.0 → 1.12.0 (minor bumps, otherwise low-risk)

**Gradle**:

- `grpc` (`io.grpc:*`) 1.83.0 → 1.83.1 (patch, but networking/RPC — withheld per policy regardless of semver level)
- `compose-preview-plugin` (`ee.schimke.composeai.preview`) 0.18.4 → 0.19.17 (minor; build-time-only preview-rendering plugin, zero runtime impact per `.claude/rules/compose-preview.md`, but still a minor bump)

### Major

- `icu_collections` / `icu_normalizer` / `icu_normalizer_data` / `icu_properties` / `icu_properties_data` / `icu_provider` 1.5.x → 2.2.0, plus `yoke` / `yoke-derive` 0.7.5 → 0.8.x and `zerovec-derive` 0.10.3 → 0.11.3 — a coordinated major-version upgrade of the ICU4X Unicode stack, reached transitively through `idna` → `url` (domain-name normalization). The graph reshuffle also drops `icu_locid` / `icu_locid_transform*` / direct `tinystr` / `utf16_iter` / `write16` / `zerovec 0.10` and adds `icu_locale_core` / `zerotrie` / `itertools 0.15`. Needs a coordinated, single-PR upgrade with full test coverage on URL/domain-parsing paths, not a piecemeal bump.
- `netlink-packet-route` 0.28.0 → 0.31.0 — three effective major versions for a pre-1.0 crate. Used for Linux routing-table manipulation on the VPN routing path. Breaking API changes are likely; needs its own review.
- `aws-lc-sys` 0.41.0 → 0.43.0 — two effective major versions for a pre-1.0 crate; native FFI bindings to the vendored AWS-LC C library underpinning the TLS crypto backend. High-caution item.
- `boring` / `tokio-boring` — intentionally exact-pinned (`=5.1.0` / `=5.0.0`) because `ripdpi-vless`'s Reality TLS path hand-declares BoringSSL symbols against this exact revision (see `docs/design/reality-boringssl-patch.md`). Any bump must go through that symbol-verification process rather than a routine dependency update; not evaluated against a specific target version here.
- `bincode` 2.0.1 → 3.0.0 available — major bump; low priority given the current 2.0.1 is dev-only/unreachable in the shipped build (see Security section).

### Notes on this run

- `cargo-audit`, `cargo-outdated`, and `cargo-deny` were not pre-installed in this environment; all three were built from source (`cargo install --locked`) before running.
- `cargo outdated --workspace` could not complete: it fails to resolve the repo's `[patch.crates-io] boring-sys = { path = "vendor/boring-sys" }` override while staging its scratch workspace copy (`failed to read .../vendor/boring-sys/Cargo.toml`) — a known `cargo-outdated` limitation with local path patches, not a project misconfiguration. Substituted `cargo update --dry-run --locked` (semver-compatible Cargo.lock bumps) plus direct `crates.io` / Google Maven / Maven Central index queries against every `[workspace.dependencies]` and `gradle/libs.versions.toml` entry to reach equivalent coverage.
- Gradle cross-module dependency-conflict detection could not be run live: this sandbox has no `ANDROID_HOME`/Android SDK, so `./gradlew` tasks that need Android project configuration (even `help`) don't complete. A static sweep of every `build.gradle.kts` for inline/hardcoded dependency versions found none outside the version catalog (the two hardcoded `version = "..."` hits are a CMake toolchain pin and this module's own artifact version, not dependency pins) — no cross-module version conflicts detected by that method. Recommend a follow-up run of `./gradlew :app:dependencies` (or an equivalent insight report) on a runner with the Android SDK installed for full confidence.

## Test plan

- `cargo check -p ripdpi-bench -p ripdpi-io-uring -p ripdpi-tor --locked` (the full reverse-dependency chain of the four bumped crates) — passes
- `cargo check --workspace --locked --all-targets` (host target; no Android SDK/NDK available in this environment) — passes, `Finished` in 2m55s
- `cargo deny --locked check` — `advisories ok, bans ok, licenses ok, sources ok`
- `python3 scripts/ci/check_rust_advisory_waivers.py` — passes (all ignores have current owner/reason/expiry metadata; RSA waiver still valid, expires in 10 days)
- Gradle version catalog cross-checked against Maven Central / Google Maven / Gradle Plugin Portal / services.gradle.org for every pinned version — no live `./gradlew` build was possible (no Android SDK in this sandbox)

## Checklist

- [x] No baseline files extended (detekt, lint, LoC)
- [ ] `timeout-minutes` added to any new CI job — N/A, no new CI job
- [ ] Native ABI matrix not broken (if touching native builds) — only verified on host target (`cargo check`); no Android NDK available in this sandbox to cross-compile the 4 ABIs, recommend CI confirms
- [ ] Non-rooted device path still works (if touching VPN/root features) — N/A, no VPN/root code touched

---
_Generated by [Claude Code](https://claude.ai/code/session_019ceu1Mq7zJuT2myDGDiqzd)_