### PR TITLE
chore(deps): nightly audit 2026-08-14

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -2422,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4e5aa225bc56696909483320f0ff9b600f1a971b52e07a17d70f3d9b43254b"
+checksum = "337d46834ee672ab3e48caca2cb0c78cc174fb12b3a68d0d88f99a0519a5e36e"
 dependencies = [
  "generic-array 0.14.7",
  "rustversion",
@@ -2913,9 +2913,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "ctutils",
  "subtle",
@@ -3398,9 +3398,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3438,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -4057,9 +4057,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -7076,7 +7076,7 @@ dependencies = [
  "enum_dispatch",
  "flate2",
  "futures",
- "generic-array 1.4.4",
+ "generic-array 1.4.5",
  "getrandom 0.4.3",
  "ghash 0.6.0",
  "hex-literal",
@@ -9945,9 +9945,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9958,9 +9958,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9968,9 +9968,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9978,9 +9978,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9991,9 +9991,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -10006,9 +10006,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10620,18 +10620,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Task contract

- Task ID: N/A -- scheduled nightly dependency/security audit, not tracked on the portfolio task board
- Task record: N/A
- OpenSpec change: N/A
- Spec-not-required reason: mechanical dependency-lockfile bump only, no behavior or contract change

## Summary

Nightly dependency and security audit across the Rust Cargo workspace (`native/rust/`, ~116 crates) and the Kotlin/Gradle catalog (`gradle/libs.versions.toml`, ~13 modules). Applies only the changes that are semver patch-level *and* outside crypto/networking/async-runtime/JNI-FFI surfaces. Everything else is listed below for human review.

## Evidence

```
cd native/rust
cargo audit --file Cargo.lock
cargo update --dry-run --verbose        # candidate discovery, targeted -p updates applied from this list
cargo update -p generic-array@1.4.4 -p hybrid-array@0.4.13 -p num-integer@0.1.46 \
  -p kqueue@1.2.0 -p js-sys@0.3.103 -p wasm-bindgen@0.2.126 -p wasm-bindgen-futures@0.4.76 \
  -p wasm-bindgen-macro@0.2.126 -p wasm-bindgen-macro-support@0.2.126 -p wasm-bindgen-shared@0.2.126 \
  -p web-sys@0.3.103 -p zerocopy@0.8.55 -p zerocopy-derive@0.8.55
cargo metadata --locked --format-version 1
cargo check --workspace --all-targets --locked      # clean
cargo deny --locked check                            # advisories ok, bans ok, licenses ok, sources ok
python3 scripts/ci/check_architecture_health.py       # 0 new indicators, 0 worsened, 0 stale
```

Gradle side: every `gradle/libs.versions.toml` entry was checked against its upstream Maven/Google-Maven/Gradle-Plugin-Portal metadata feed (including AGP, Gradle wrapper, Kotlin, Compose BOM, KSP). All are already at the latest published stable release except the two minor bumps listed under Needs review. No `implementation("group:artifact:version")` inline-version bypasses, `resolutionStrategy`/`force()` blocks, or `constraints {}` blocks exist in any module -- every dependency routes through the single catalog, so no *declared* cross-module divergence is structurally possible.

**Coverage gap:** this container has no Android SDK installed (`ANDROID_HOME` unset, no `local.properties`), so `./gradlew :app:dependencies` could not run and live transitive-conflict resolution was not verified. Static inspection found nothing; a full dependency-tree pass is still recommended next time an SDK-equipped runner is available.

## Applied

**Rust** (`native/rust/Cargo.lock` only -- no manifest changes, all within existing semver requirements):

| Crate | Old | New |
|---|---|---|
| generic-array | 1.4.4 | 1.4.5 |
| hybrid-array | 0.4.13 | 0.4.14 |
| num-integer | 0.1.46 | 0.1.47 |
| kqueue | 1.2.0 | 1.2.1 |
| js-sys | 0.3.103 | 0.3.104 |
| wasm-bindgen | 0.2.126 | 0.2.127 |
| wasm-bindgen-futures | 0.4.76 | 0.4.77 |
| wasm-bindgen-macro | 0.2.126 | 0.2.127 |
| wasm-bindgen-macro-support | 0.2.126 | 0.2.127 |
| wasm-bindgen-shared | 0.2.126 | 0.2.127 |
| web-sys | 0.3.103 | 0.3.104 |
| zerocopy | 0.8.55 | 0.8.56 |
| zerocopy-derive | 0.8.55 | 0.8.56 |

All patch-level. `kqueue` (BSD/macOS-only) and the `wasm-bindgen`/`js-sys`/`web-sys` family (wasm32-only) are unreachable on any shipped Android target (`cargo tree -i` confirms no edge into the resolved graph). `generic-array`, `hybrid-array`, `num-integer`, `zerocopy(-derive)` are generic data-structure/math utilities, not crypto/network/async/FFI logic themselves.

**Gradle**: none. Every catalog entry already matches upstream latest.

## Security

All four RUSTSEC advisories `cargo audit` reports are pre-existing, already documented in `native/rust/deny.toml` `[advisories].ignore` with matching owner/reason/expiry/tracking-issue entries in `native/rust/advisory-waivers.toml`. None are new; none have passed their SLA expiry (today: 2026-08-14).

| ID | Severity | Crate | Resolved by this PR? |
|---|---|---|---|
| RUSTSEC-2023-0071 | Medium (5.9) -- Marvin Attack timing side-channel | `rsa` 0.9.10 (via Arti) and 0.10.0-rc.18 (via russh) | No -- no fixed upgrade exists on either path. Waiver expires 2026-11-02, tracked in `docs/tasks/issues/unpin-russh-after-rsa-advisory-fix.md`. |
| RUSTSEC-2025-0141 | Informational -- unmaintained | `bincode` 2.0.1 (transitive via Arti's `typed-index-collections`) | No -- no maintained replacement upstream. Waiver expires 2026-11-02. **Housekeeping note:** `cargo deny check` now reports `advisory-not-detected` for this ignore entry; `cargo tree -i bincode@2.0.1` shows it isn't actually reachable in the resolved dependency graph for any checked target, so the waiver may be dead and removable -- worth a follow-up, not urgent. |
| RUSTSEC-2025-0069 | Informational -- unmaintained | `daemonize` 0.5.0 (direct dep of `ripdpi-proxy-runtime-adapter`, CLI-only feature) | No -- confirmed via `cargo update -p daemonize --dry-run` that no newer version is published. Waiver expires 2026-10-11. |
| RUSTSEC-2024-0436 | Informational -- unmaintained | `paste` 1.0.15 (compile-time proc-macro via netlink-packet-core) | No -- no maintained replacement upstream. Waiver expires 2026-10-11. |

## Needs review

Withheld per policy: minor-version bumps, and any crypto/networking/async-runtime/JNI-FFI-adjacent change regardless of semver level.

**Crypto:**
`chacha20` 0.10.0→0.10.1, `der` 0.8.0→0.8.1, `keccak` 0.2.0→0.2.1, `pkcs5` 0.8.0→0.8.1, `poly1305` 0.9.0→0.9.1, `polyval` 0.7.1→0.7.3, `rcgen` 0.14.8→0.14.9, `sha1` 0.10.6→0.10.7, `rand` 0.8.6→0.8.7, `reseeding_rng` 0.10.6→0.10.7 (all patch-level, held for crypto category), `aws-lc-rs` 1.17.0→1.18.0 (minor, TLS crypto backend), `aws-lc-sys` 0.41.0→0.44.0 (0.x jump, crypto FFI/C bindings), `webpki-root-certs` 1.0.8→1.0.9 (patch, CA trust-anchor bundle data).

**Networking:**
`async-compression` 0.4.42→0.4.43, `http-body-util` 0.1.4→0.1.5, `idna_adapter` 1.2.0→1.2.2, `ipnet` 2.12.0→2.12.1, `netlink-packet-core` 0.8.1→0.8.2, `quinn-proto` 0.11.15→0.11.16, `quinn-udp` 0.5.14→0.5.15, `route_manager` 0.2.11→0.2.13, `rustls-webpki` 0.103.13→0.103.14 (all patch-level, held for networking category); `http-body` 1.0.1→1.1.0 (minor), `rustls-pki-types` 1.14.1→1.15.1 (minor), `netlink-packet-route` 0.28.0→0.31.0 (large 0.x jump spanning three releases -- treat with the same caution as a major bump; VPN-relevant routing crate).

**Async runtime:**
`futures`, `futures-channel`, `futures-core`, `futures-executor`, `futures-io`, `futures-macro`, `futures-sink`, `futures-task`, `futures-util` (all 0.3.33→0.3.34, lockstep release), `oneshot-fused-workaround` 0.7.0→0.7.1, `tokio-macros` 2.7.0→2.7.2.

**JNI/FFI-adjacent (native build tooling):**
`cc` 1.2.67→1.4.2 (minor), `clang-sys` 1.8.1→1.9.1 (minor), `foreign-types-macros` 0.2.3→0.2.4 (patch).

**Minor bumps, non-sensitive category:**
`bstr` 1.12.3→1.13.1, `either` 1.16.0→1.17.0, `fastrand` 2.4.1→2.5.0, `litemap` 0.7.5→0.8.3, `portable-atomic` 1.13.1→1.15.0 (also concurrency/atomics-sensitive per this repo's own `memory-model` skill), `rapidhash` 4.4.2→4.5.1, `regex` 1.12.4→1.13.1, `serde_with`/`serde_with_macros` 3.21.0→3.22.0, `simd_cesu8` 1.1.1→1.2.0, `tinyvec` 1.11.0→1.12.0, `zerovec-derive` 0.10.3→0.11.4 (pairs with the ICU major bump below).

**Gradle (golden/baseline-sensitive tooling, held per `.claude/rules/golden-bless-discipline.md` and `.claude/rules/compose-preview.md`):**
`roborazzi` 1.71.0→1.72.0 (minor -- screenshot-golden rendering may shift, needs re-bless pass), `compose-preview-plugin` (`ee.schimke.composeai.preview`) 1.1.0→1.2.0 (minor -- Compose Preview image generation, published 2026-08-13).

## Major

`icu_collections`, `icu_normalizer`, `icu_normalizer_data`, `icu_properties`, `icu_properties_data`, `icu_provider`: all `1.5.x → 2.3.0`. Transitive via the `idna`/URL-parsing stack (ICU4X 2.0 is a breaking rewrite of the Unicode-data crates). Not directly actionable from this workspace's `Cargo.toml` -- the bump is resolver-controlled by whatever range the upstream `idna_adapter`/`idna` crate declares; flagging for awareness only.

## Conflicts

None found via static inspection: no inline `implementation("group:artifact:version")` overrides, no `resolutionStrategy`/`force()` blocks, no `constraints {}` blocks in any of the ~13 Gradle modules -- every dependency resolves through the single `gradle/libs.versions.toml` catalog. Live transitive-dependency-tree verification (`./gradlew :app:dependencies`) could not run this cycle -- see the coverage-gap note under Evidence.

## Checklist

- [ ] `just task-check` passes -- not run; this PR is outside the portfolio task-board workflow (see Task contract)
- [x] No work is marked complete without its required evidence
- [x] No baseline files extended (detekt, lint, LoC, architecture-health)
- [x] `timeout-minutes` added to any new CI job -- N/A, no CI job changes
- [x] Native ABI matrix not broken (if touching native builds) -- `cargo check --workspace --all-targets --locked` clean; no manifest/feature changes
- [x] Non-rooted device path still works (if touching VPN/root features) -- N/A, no runtime code touched
- [x] mdtask PolyForm Shield internal-tool use is owner/legal-approved (if `tools/tasking` changes) -- N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_01RdNHoPWNqBe1yibghgzD68)_