### PR TITLE
chore(deps): nightly audit 2026-08-15

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -276,7 +276,7 @@ dependencies = [
  "safelog",
  "serde",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tor-async-utils",
  "tor-basic-utils",
@@ -324,7 +324,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -496,9 +496,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -1543,7 +1543,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2139,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -2236,7 +2236,7 @@ dependencies = [
  "libc",
  "pwd-grp",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "void",
  "walkdir",
 ]
@@ -2264,7 +2264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63307a37c3d90d55a90eefa5441ec12cbd291ff456b6bf1126656c5bc43b058"
 dependencies = [
  "libc",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -2728,7 +2728,7 @@ dependencies = [
  "ipnet",
  "rand 0.10.2",
  "rustls",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -2749,7 +2749,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.2",
  "ring",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "url",
@@ -2771,7 +2771,7 @@ dependencies = [
  "rand 0.10.2",
  "rustls",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -3329,7 +3329,7 @@ dependencies = [
  "libloading 0.8.9",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -3533,7 +3533,7 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 name = "local-network-fixture"
 version = "0.1.0"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "boring",
  "bytes",
  "crypto_box",
@@ -3652,7 +3652,7 @@ dependencies = [
  "ipnetwork",
  "memchr",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3791,9 +3791,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -3831,7 +3831,7 @@ dependencies = [
  "nix 0.30.1",
  "scopeguard",
  "system-configuration-sys",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "widestring",
  "windows 0.61.3",
 ]
@@ -4302,7 +4302,7 @@ dependencies = [
  "log",
  "rand 0.10.2",
  "sha2 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "windows 0.62.2",
  "windows-strings 0.5.1",
@@ -4591,9 +4591,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plotters"
@@ -4859,7 +4859,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -4881,7 +4881,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5112,7 +5112,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5149,9 +5149,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5213,9 +5213,9 @@ dependencies = [
 
 [[package]]
 name = "retry-error"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c0e06f9b501df8600ad8bd073f4990f703f36e0f48e574b431f4a15d69b449"
+checksum = "d350ad359aca3414f7261cdcc763e37ccc9fa56fe40ca30a9758c28a295bcad0"
 dependencies = [
  "humantime",
  "web-time",
@@ -5297,7 +5297,7 @@ dependencies = [
  "ripdpi-strategy-config",
  "ripdpi-strategy-lua",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5309,7 +5309,7 @@ dependencies = [
  "jni",
  "log",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5331,7 +5331,7 @@ name = "ripdpi-android-fetch-adapter"
 version = "0.1.0"
 dependencies = [
  "android-support",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "golden-test-support",
  "http",
@@ -5360,7 +5360,7 @@ dependencies = [
 name = "ripdpi-android-platform-adapter"
 version = "0.1.0"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "jni",
  "ripdpi-diagnostics-dns",
  "ripdpi-dns-resolver",
@@ -5434,7 +5434,7 @@ dependencies = [
  "ripdpi-native-protect",
  "ripdpi-tls-profiles",
  "sha2 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-boring",
 ]
@@ -5443,7 +5443,7 @@ dependencies = [
 name = "ripdpi-apps-script-core"
 version = "0.1.0"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "flate2",
  "rcgen",
  "ripdpi-packets",
@@ -5451,7 +5451,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tokio-rustls",
@@ -5657,7 +5657,7 @@ dependencies = [
  "hickory-proto",
  "ripdpi-failure-classifier",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5782,7 +5782,7 @@ dependencies = [
  "ripdpi-socks5-core",
  "ripdpi-tls-profiles",
  "rustls",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-boring",
  "tokio-rustls",
@@ -5827,7 +5827,7 @@ dependencies = [
  "arc-swap",
  "libc",
  "maxminddb",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5848,7 +5848,7 @@ dependencies = [
  "ripdpi-protocol-loopback",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -5873,7 +5873,7 @@ name = "ripdpi-ipfrag"
 version = "0.1.0"
 dependencies = [
  "etherparse",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5900,7 +5900,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-boring",
  "tokio-rustls",
@@ -5916,7 +5916,7 @@ dependencies = [
  "chacha20poly1305 0.11.0",
  "ring",
  "ripdpi-network-time",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -5954,7 +5954,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -5987,7 +5987,7 @@ dependencies = [
 name = "ripdpi-naiveproxy"
 version = "0.1.0"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "golden-test-support",
  "http",
@@ -6070,7 +6070,7 @@ dependencies = [
  "quinn",
  "rcgen",
  "rustls",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -6085,7 +6085,7 @@ dependencies = [
  "ripdpi-packets",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6093,7 +6093,7 @@ name = "ripdpi-proxy-runtime"
 version = "0.1.0"
 dependencies = [
  "aes 0.9.2",
- "base64 0.23.0",
+ "base64 0.23.1",
  "ctr 0.10.1",
  "libc",
  "local-network-fixture",
@@ -6120,7 +6120,7 @@ dependencies = [
 name = "ripdpi-proxy-runtime-adapter"
 version = "0.1.0"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "daemonize",
  "libc",
  "metrics",
@@ -6225,7 +6225,7 @@ version = "0.1.0"
 dependencies = [
  "golden-test-support",
  "rand 0.10.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -6413,7 +6413,7 @@ version = "0.1.0"
 dependencies = [
  "aes 0.9.2",
  "aes-gcm 0.11.0",
- "base64 0.23.0",
+ "base64 0.23.1",
  "blake3",
  "bytes",
  "chacha20poly1305 0.11.0",
@@ -6422,7 +6422,7 @@ dependencies = [
  "md5",
  "rand 0.10.2",
  "sha1 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -6445,7 +6445,7 @@ dependencies = [
 name = "ripdpi-shared-priors"
 version = "0.1.0"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "rand 0.10.2",
  "ring",
  "serde",
@@ -6459,7 +6459,7 @@ dependencies = [
  "anyhow",
  "log",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -6469,10 +6469,10 @@ dependencies = [
 name = "ripdpi-ssh"
 version = "0.1.0"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "ripdpi-native-protect",
  "russh",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -6482,7 +6482,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_yaml_ng",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
 ]
 
@@ -6520,7 +6520,7 @@ dependencies = [
  "mlua",
  "ripdpi-strategy-trait",
  "static_assertions",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6537,7 +6537,7 @@ dependencies = [
  "ripdpi-strategy-udp",
  "ripdpi-strategy-window",
  "static_assertions",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6594,7 +6594,7 @@ dependencies = [
  "rustls",
  "serde_json",
  "sha2 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-boring",
  "tracing",
@@ -6611,7 +6611,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -6621,7 +6621,7 @@ version = "0.1.0"
 dependencies = [
  "arti-client",
  "rustls",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
  "tor-rtcompat",
@@ -6637,7 +6637,7 @@ dependencies = [
  "ripdpi-native-protect",
  "ripdpi-tls-profiles",
  "sha2 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-boring",
  "tracing",
@@ -6667,7 +6667,7 @@ dependencies = [
 name = "ripdpi-tun-driver"
 version = "0.1.0"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tun-rs",
 ]
 
@@ -6712,7 +6712,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_yaml_ng",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6746,7 +6746,7 @@ dependencies = [
  "rustls",
  "smoltcp",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-test",
  "tokio-util",
@@ -6777,7 +6777,7 @@ version = "0.1.0"
 dependencies = [
  "aes 0.9.2",
  "android-support",
- "base64 0.23.0",
+ "base64 0.23.1",
  "boring",
  "foreign-types-shared",
  "futures",
@@ -6790,7 +6790,7 @@ dependencies = [
  "ripdpi-relay-mux",
  "ripdpi-tls-profiles",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-boring",
  "tokio-util",
@@ -6832,7 +6832,7 @@ name = "ripdpi-warp-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.23.0",
+ "base64 0.23.1",
  "blake2 0.10.6",
  "boringtun",
  "bytes",
@@ -6861,7 +6861,7 @@ dependencies = [
  "ripdpi-tls-profiles",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-boring",
  "url",
@@ -6874,7 +6874,7 @@ dependencies = [
  "futures",
  "getrandom 0.4.3",
  "rustls",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
@@ -6914,7 +6914,7 @@ dependencies = [
  "ripdpi-native-protect",
  "ripdpi-tls-profiles",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -6936,7 +6936,7 @@ dependencies = [
  "ripdpi-tls-profiles",
  "ripdpi-vless",
  "sha2 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-boring",
  "tracing",
@@ -7003,7 +7003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7087,7 +7087,7 @@ dependencies = [
  "ssh-encoding",
  "ssh-key",
  "subtle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "typenum",
  "universal-hash 0.6.1",
@@ -7266,7 +7266,7 @@ dependencies = [
  "educe",
  "either",
  "fluid-let",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7761,7 +7761,7 @@ dependencies = [
  "paste",
  "serde",
  "slotmap",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "void",
 ]
 
@@ -8107,11 +8107,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -8127,9 +8127,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8440,7 +8440,7 @@ dependencies = [
  "pin-project",
  "postage",
  "sync_wrapper",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tor-basic-utils",
@@ -8468,7 +8468,7 @@ dependencies = [
  "serde",
  "slab",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "weak-table",
  "web-time-compat",
@@ -8486,7 +8486,7 @@ dependencies = [
  "educe",
  "getrandom 0.4.3",
  "safelog",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-error",
  "tor-llcrypto",
  "zeroize",
@@ -8509,7 +8509,7 @@ dependencies = [
  "paste",
  "rand 0.10.2",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-basic-utils",
  "tor-bytes",
  "tor-cert",
@@ -8534,7 +8534,7 @@ dependencies = [
  "derive_more",
  "digest 0.10.7",
  "saturating-time",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-bytes",
  "tor-checkable",
  "tor-error",
@@ -8564,7 +8564,7 @@ dependencies = [
  "safelog",
  "serde",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-cell",
@@ -8593,7 +8593,7 @@ checksum = "ef81835cb0b2db460c694678eae8c4cbad5f31847e473aac42605f9b945fb31a"
 dependencies = [
  "humantime",
  "signature 2.2.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-llcrypto",
  "web-time-compat",
 ]
@@ -8623,7 +8623,7 @@ dependencies = [
  "retry-error",
  "safelog",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-cell",
@@ -8673,7 +8673,7 @@ dependencies = [
  "serde-value",
  "serde_ignored",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
  "tor-basic-utils",
  "tor-error",
@@ -8691,7 +8691,7 @@ dependencies = [
  "directories",
  "serde",
  "shellexpand",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-error",
  "tor-general-addr",
 ]
@@ -8707,7 +8707,7 @@ dependencies = [
  "hex",
  "imara-diff",
  "static_assertions",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-error",
  "tor-llcrypto",
  "tor-netdoc",
@@ -8729,7 +8729,7 @@ dependencies = [
  "httpdate",
  "itertools 0.14.0",
  "memchr",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-circmgr",
  "tor-error",
  "tor-hscrypto",
@@ -8796,7 +8796,7 @@ dependencies = [
  "signature 2.2.0",
  "static_assertions",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tor-async-utils",
  "tor-basic-utils",
@@ -8832,7 +8832,7 @@ dependencies = [
  "retry-error",
  "static_assertions",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
  "void",
  "web-time-compat",
@@ -8845,7 +8845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfee544a33dd3e67e0311cc46ef8f667cbf9c02c7c00ef4f25098a25b2b6e1cf"
 dependencies = [
  "derive_more",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "void",
 ]
 
@@ -8874,7 +8874,7 @@ dependencies = [
  "safelog",
  "serde",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-config",
@@ -8914,7 +8914,7 @@ dependencies = [
  "safelog",
  "slotmap-careful",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-bytes",
@@ -8958,7 +8958,7 @@ dependencies = [
  "serde",
  "signature 2.2.0",
  "subtle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-basic-utils",
  "tor-bytes",
  "tor-error",
@@ -8984,7 +8984,7 @@ dependencies = [
  "rsa 0.9.10",
  "signature 2.2.0",
  "ssh-key-fork-arti",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-bytes",
  "tor-cert",
  "tor-checkable",
@@ -9016,7 +9016,7 @@ dependencies = [
  "serde",
  "signature 2.2.0",
  "ssh-key-fork-arti",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-basic-utils",
  "tor-bytes",
  "tor-config",
@@ -9051,7 +9051,7 @@ dependencies = [
  "serde",
  "serde_with",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-basic-utils",
  "tor-bytes",
  "tor-config",
@@ -9095,7 +9095,7 @@ dependencies = [
  "sha3 0.10.9",
  "signature 2.2.0",
  "subtle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-error",
  "tor-memquota-cost",
  "visibility",
@@ -9111,7 +9111,7 @@ checksum = "37d0f759a875b6f9b6f3657a2626a70e2474e698a4404501033babe63ad888a6"
 dependencies = [
  "futures",
  "humantime",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-error",
  "tor-rtcompat",
  "tracing",
@@ -9138,7 +9138,7 @@ dependencies = [
  "slotmap-careful",
  "static_assertions",
  "sysinfo",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-config",
@@ -9180,7 +9180,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tor-basic-utils",
  "tor-error",
@@ -9226,7 +9226,7 @@ dependencies = [
  "smallvec",
  "strum",
  "subtle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tinystr 0.8.3",
  "tor-basic-utils",
@@ -9263,7 +9263,7 @@ dependencies = [
  "sanitize-filename",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tor-async-utils",
  "tor-basic-utils",
@@ -9311,7 +9311,7 @@ dependencies = [
  "static_assertions",
  "strum",
  "subtle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tor-async-utils",
@@ -9348,7 +9348,7 @@ dependencies = [
  "caret",
  "paste",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-basic-utils",
  "tor-bytes",
 ]
@@ -9368,7 +9368,7 @@ dependencies = [
  "itertools 0.14.0",
  "oneshot-fused-workaround",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-async-utils",
  "tor-basic-utils",
  "tor-chanmgr",
@@ -9423,7 +9423,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-webpki",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tor-error",
@@ -9454,7 +9454,7 @@ dependencies = [
  "priority-queue",
  "slotmap-careful",
  "strum",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-error",
  "tor-general-addr",
  "tor-rtcompat",
@@ -9476,7 +9476,7 @@ dependencies = [
  "educe",
  "safelog",
  "subtle",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-bytes",
  "tor-error",
 ]
@@ -9490,7 +9490,7 @@ dependencies = [
  "derive-deftly",
  "derive_more",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tor-memquota",
 ]
 
@@ -9665,7 +9665,7 @@ dependencies = [
  "log",
  "rand 0.10.2",
  "sha1 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -9802,9 +9802,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -9987,9 +9987,9 @@ dependencies = [
 
 [[package]]
 name = "web-time-compat"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af46dad42aa37be3b4a116fe613365f991b8bdae6cd6ce82d84fa9f9e8f70ae4"
+checksum = "b6ab47578e1cd38415489592da29326341e272bd281f4ddbc0c10b654a425ad7"
 dependencies = [
  "web-time",
 ]
@@ -10526,7 +10526,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
 ]
 


### PR DESCRIPTION
## Task contract

- Task ID: N/A — automated nightly dependency/security audit, not a portfolio task
- Task record: N/A
- OpenSpec change: N/A
- Spec-not-required reason: routine dependency maintenance, no behavior/spec change

## Summary

Nightly dependency and security audit across the Rust Cargo workspace (`native/rust/`, ~90 crates) and the Kotlin/Gradle frontend (~18 modules). Applies only patch-level, non-behavior-sensitive Rust dependency bumps; everything else is reported below for human review. No Gradle catalog changes are included in this PR — see the **Needs review** section for why.

## Applied

### Rust (`native/rust/Cargo.lock`, via targeted `cargo update -p`)

| Crate | Old | New |
|---|---|---|
| android_system_properties | 0.1.5 | 0.1.6 |
| base64 | 0.23.0 | 0.23.1 |
| find-msvc-tools | 0.1.10 | 0.1.11 |
| moka | 0.12.15 | 0.12.16 |
| pkg-config | 0.3.33 | 0.3.34 |
| regex-automata | 0.4.16 | 0.4.18 |
| retry-error | 0.13.0 | 0.13.1 |
| thiserror / thiserror-impl | 2.0.19 | 2.0.20 |
| uuid | 1.24.0 | 1.24.1 |
| web-time-compat | 0.2.0 | 0.2.1 |

All 11 are patch-level only and outside the crypto/networking/async-runtime/JNI-FFI surfaces called out below. Verified with:
- `cargo check --workspace --locked --all-targets` — passes (finished clean, `Finished dev profile`)
- `cargo deny --locked --manifest-path native/rust/Cargo.toml check` — `advisories ok, bans ok, licenses ok, sources ok`

### Gradle

None applied. See **Needs review** for the one genuinely-safe candidate found, and why it wasn't applied.

## Security

`cargo audit --file native/rust/Cargo.lock` reports 2 vulnerabilities + 3 unmaintained-crate warnings — **all four are pre-existing and already tracked** in `native/rust/deny.toml` / `native/rust/advisory-waivers.toml` with active (non-expired) waivers. Nothing new surfaced this run:

| ID | Severity | Crate | Resolved by this PR? |
|---|---|---|---|
| RUSTSEC-2023-0071 | Medium (5.9) — Marvin timing attack | rsa 0.9.10 / 0.10.0-rc.18 (via arti-client, russh) | No — no fixed upstream release exists on either path; waiver expires 2026-11-02 |
| RUSTSEC-2025-0141 | Unmaintained | bincode 2.0.1 (transitive via arti's typed-index-collections) | No — no maintained replacement published; waiver expires 2026-11-02. Note: `cargo deny check` reported a non-blocking `advisory-not-detected` warning for this ignore entry (cargo-deny's advisory scan didn't independently flag it this run, unlike cargo-audit) — worth a follow-up to reconcile the two tools' advisory configs, not a new security issue |
| RUSTSEC-2025-0069 | Unmaintained | daemonize 0.5.0 (direct dep of ripdpi-proxy-runtime-adapter) | No — no maintained replacement published; waiver expires 2026-10-11 |
| RUSTSEC-2024-0436 | Unmaintained | paste 1.0.15 (via netlink-packet-core) | No — compile-time-only proc-macro, no maintained replacement; waiver expires 2026-10-11 |

`cargo audit -D yanked` found **no yanked crate versions** in the current lockfile. `cargo deny check` (advisories/bans/licenses/sources) passes cleanly with only the informational warning above.

## Needs review

**Rust — sensitive-surface patch/minor bumps (crypto/networking/async, withheld regardless of semver level per policy):**

| Crate | Old → New | Level | Why withheld |
|---|---|---|---|
| arti-client, tor-rtcompat | 0.44.0 → 0.45.0 | minor | Tor client / networking stack; requires a `native/rust/Cargo.toml` version-requirement edit |
| futures (+ futures-channel/-core/-executor/-io/-macro/-sink/-task/-util) | 0.3.33 → 0.3.34 | patch | async-runtime-adjacent (core futures abstraction) |
| tokio-macros | 2.7.0 → 2.7.2 | patch | tokio ecosystem |
| async-trait | 0.1.91 → 0.1.92 | patch | async-trait tooling |
| oneshot-fused-workaround | 0.7.0 → 0.7.1 | patch | async channel primitive |
| quinn-proto, quinn-udp | 0.11.15/0.5.14 → 0.11.16/0.5.15 | patch | QUIC networking |
| netlink-packet-core, netlink-packet-route, route_manager | 0.8.1→0.8.2, 0.28.0→0.31.0, 0.2.11→0.2.13 | patch/minor | OS netlink/routing (FFI + networking) |
| http-body-util, async-compression, ipnet, idna_adapter | patch | networking/HTTP surface |
| rcgen | 0.14.8 → 0.14.9 | patch | TLS certificate generation |
| der, chacha20, poly1305, polyval, pkcs5, sha1, keccak, generic-array, hybrid-array, rustls-webpki, webpki-root-certs, blake3, rand, num-bigint, num-integer, fs-mistrust | various | patch | crypto / PKI / RNG / Tor key-storage trust primitives |
| inotify, kqueue, libredox, zerocopy, zerocopy-derive, wasm-bindgen family, foreign-types-macros | various | patch | FFI-adjacent |
| safelog, fslock-guard | patch | Tor privacy-logging / key-storage locking utilities |
| serde_with, serde_with_macros, bstr, cc, clang-sys, either, fastrand, http-body, litemap, rapidhash, regex, tinyvec, writeable, yoke/yoke-derive, zerovec-derive | 3.21.0→3.22.0 etc. | minor | minor-version bumps auto-withheld regardless of category |

**Rust — intentionally exact-pinned crates with newer versions available (never auto-bump per `renovate.json` and `native/rust/Cargo.toml` pin comments):**

| Crate | Pinned | Available | Note |
|---|---|---|---|
| boring | =5.1.0 | 5.2.0 | Pinned for the hand-declared BoringSSL Reality-TLS symbol ABI (`docs/design/reality-boringssl-patch.md`) — bump only via that documented process |
| tokio-boring | =5.0.0 | 5.2.0 | Paired with `boring`, same process |
| io-uring | =0.7.13 | 0.7.14 | Renovate-excluded exact pin |
| russh | =0.62.5 | 0.62.6 | Renovate-excluded exact pin; also gates the tracked RC-crypto exposure (`docs/tasks/issues/unpin-russh-after-rsa-advisory-fix.md`) — worth checking whether 0.62.6 moves any of the RC primitives (rsa/ed25519-dalek/curve25519-dalek/p256-384-521/pkcs1/ssh-key) toward stable |

**Gradle — withheld because this run's environment has no Android SDK:**

This session's container has no `ANDROID_HOME`/`local.properties`, so any Gradle configuration that applies the Android plugin fails at `SDK location not found`, and no `./gradlew` dependency resolution or build could be run this cycle (confirmed via `./gradlew projects`). The version catalog (`gradle/libs.versions.toml`) is otherwise unusually current: AGP (9.3.1), Kotlin/Compose-compiler (2.4.10), KSP (2.3.11), Hilt (2.60.1), coroutines (1.11.0), OkHttp (5.4.0), Retrofit (3.0.0), detekt (1.23.8), Robolectric (4.16.1), protobuf (4.35.1), gRPC (1.83.1), Room (2.8.4), and navigation-compose (2.9.8) are all already at latest stable.

| Dependency | Old → New | Level | Why withheld |
|---|---|---|---|
| zstd-jni | 1.5.7-12 → 1.5.7-13 | patch | Content-wise this is the one SAFE-shaped Gradle candidate found, but it was **not applied**: this environment cannot run `./gradlew` dependency resolution to verify it (no Android SDK), and step 4 of this audit requires build verification before anything lands in Applied. Safe to apply once verified in an SDK-equipped run. |
| androidx.compose:compose-bom | 2026.06.01 → 2026.08.00 | minor | Broad Compose surface bump; touches Roborazzi golden screenshot baselines (`golden-bless-discipline.md`) |
| roborazzi / roborazzi-compose | 1.70.0 → 1.72.0 | minor | Golden-fixture tooling itself |
| Gradle wrapper | 9.6.1 → 9.7.0 | minor | Build-tooling-wide change |

No stable major-version upgrade is available for any directly declared Rust workspace dependency, and no stable major-version upgrade is available for any of the sampled Gradle catalog entries (several AndroidX libraries have alpha/beta/rc next-majors in flight — e.g. compose-ui 1.13.0-alpha01, navigation-compose 2.10.0-rc01, work 2.12.0-rc01, datastore/biometric/glance/camera next-majors — none are actionable yet).

## Conflicts

Static analysis of all 18 module `build.gradle.kts` files plus `build.gradle.kts`/`settings.gradle.kts` found **no cross-module version divergence**: every dependency coordinate in the project is declared exclusively through `gradle/libs.versions.toml` (no inline/hardcoded coordinate versions in any module build file, one unrelated `version = "1.0"` on the `quality:detekt-rules` project itself), and no `resolutionStrategy`/`force(...)`/`constraints {}` overrides exist anywhere that could mask a transitive constraint diverging from a declared one. Structurally, the single-catalog setup makes this class of conflict currently not reproducible without an SDK-equipped Gradle dependency-resolution run, which this environment could not perform — flagged above under Needs review.

## Evidence

```
cd native/rust
cargo audit --file Cargo.lock                       # 2 vulnerabilities, 3 warnings — all pre-existing/waived
cargo audit --file Cargo.lock -D yanked --no-fetch   # no yanked crates
cargo update --dry-run                               # 105 semver-compatible packages available
cargo update -p android_system_properties -p base64@0.23.0 -p find-msvc-tools -p moka \
  -p pkg-config -p regex-automata -p retry-error -p thiserror@2.0.19 \
  -p thiserror-impl@2.0.19 -p uuid -p web-time-compat
cargo check --workspace --locked --all-targets       # Finished `dev` profile, exit 0
cargo deny --locked --manifest-path Cargo.toml check # advisories ok, bans ok, licenses ok, sources ok

cd /home/user/RIPDPI
./gradlew projects                                    # FAILED: SDK location not found (no Android SDK in this environment)
grep -rn "version = \"[0-9]" --include="build.gradle.kts" .   # only quality/detekt-rules self-version
grep -rn "resolutionStrategy|force(|constraints {" --include="*.gradle.kts" .  # no matches
```

## Checklist

- [x] No baseline files extended (detekt, lint, LoC)
- [x] Native ABI matrix not broken — no native code, feature flags, or build profile changed; `Cargo.lock`-only diff
- [x] Diff is minimal and reviewable (single file, 11 targeted `cargo update -p` bumps, no incidental reformatting)
- [ ] `just task-check` — not applicable, no portfolio task backs this automated PR
- [ ] Gradle-side verification — blocked this run by missing Android SDK in the execution environment; see Needs review


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyX7kNgjC44g2SNEhhnvFd)_