### PR TITLE
chore(deps): nightly audit 2026-08-19

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -2546,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Task contract

- Task ID: N/A — automated nightly dependency/security audit, not a task-board item
- Task record: N/A
- OpenSpec change: N/A
- Spec-not-required reason: mechanical dependency-lockfile bump with no behavior/API surface change

## Summary

Nightly audit of the Rust Cargo workspace (`native/rust`) and the Kotlin/Gradle
frontend. Only one change qualified as SAFE (patch-level security fix, no
major/minor bump) and is applied here. Everything else surfaced is either
already tracked, pre-release-only, or withheld for human review per policy —
see the sections below.

## Applied

### Rust

- `h2`: `0.4.15` → `0.4.16` — patch bump, resolves `RUSTSEC-2026-0258`. Transitive
  (via `hyper`/`reqwest`/`hickory-net`), so only the `Cargo.lock` entry
  (version + checksum) changed; no `Cargo.toml` edit needed.

### Gradle

- None. Every catalog-declared direct dependency and plugin in
  `gradle/libs.versions.toml` is already at its latest **stable** release, or
  the only newer release available is a pre-release (alpha/beta/RC) — see
  Major/Needs review below. No cross-module version-alignment fixes were
  needed (see Conflicts).

## Security

| Advisory | Severity | Crate | Resolved? |
|---|---|---|---|
| [RUSTSEC-2026-0258](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h) | Low (DoS — unbounded empty DATA frames) | `h2` 0.4.15 | **Yes**, by the applied bump to 0.4.16 |
| [RUSTSEC-2023-0071](https://rustsec.org/advisories/RUSTSEC-2023-0071) (Marvin Attack) | Medium | `rsa` 0.9.10 / 0.10.0-rc.18 (via `arti-client`/`russh`) | No — already waived in `advisory-waivers.toml` (expires 2026-11-02, tracked by `docs/tasks/issues/unpin-russh-after-rsa-advisory-fix.md`). No safe upgrade exists on either path; unaffected by this PR. |
| [RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141) (unmaintained) | Informational | `bincode` 2.0.1 (via Arti) | No — already waived, expires 2026-11-02, tracked. |
| [RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436) (unmaintained) | Informational | `paste` 1.0.15 (via `netlink-packet-core`) | No — already waived, expires 2026-10-11, tracked. |
| [RUSTSEC-2025-0069](https://rustsec.org/advisories/RUSTSEC-2025-0069) (unmaintained) | Informational | `daemonize` 0.5.0 (CLI-only) | No — already waived, expires 2026-10-11, tracked. |

No yanked crate versions were found in `native/rust/Cargo.lock`. `cargo deny check bans licenses sources` passes clean (only the pre-existing, already-tolerated transitive duplicate-version warnings, e.g. `aead`, `base64`, `rand`, `sha2`, `x25519-dalek` pulled at two versions by different branches of the graph — none newly introduced by this PR).

## Needs review

Per policy, minor-version bumps and any crypto/networking/async-runtime/JNI-FFI-adjacent change are withheld regardless of semver level.

### Rust

| Crate | Locked | Latest | Why withheld |
|---|---|---|---|
| `russh` | 0.62.5 | 0.62.7 | Patch-level, but exact-pinned (`=0.62.5`) on purpose — pins the SSH relay's RustCrypto RC-crypto graph tied to the open `RUSTSEC-2023-0071` tracking issue. Crypto-adjacent. |
| `boring` | 5.1.0 | 5.2.0 | Minor bump; exact-pinned (`=5.1.0`) because BoringSSL has no stable ABI and the Reality TLS path hand-declares BoringSSL symbols (`docs/design/reality-boringssl-patch.md`). Crypto-adjacent. |
| `tokio-boring` | 5.0.0 | 5.2.0 | Same BoringSSL ABI-pin rationale as `boring`; must move in lockstep with it. Crypto-adjacent. |
| `io-uring` | 0.7.13 | 0.7.14 | Patch-level, but exact-pinned (`=0.7.13`); async-IO/FFI-adjacent (kernel io_uring syscalls). |
| `futures` | 0.3.33 | 0.3.34 | Patch-level, but async-runtime-adjacent. |
| `http-body-util` | 0.1.4 | 0.1.5 | Patch-level, but networking-adjacent (hyper ecosystem). |
| `similar` | 3.1.2 | 3.2.0 | Minor bump (dev/diff-testing crate; low risk, but policy withholds all minor bumps). |

### Gradle

| Dependency | Current | Latest stable | Why withheld |
|---|---|---|---|
| `androidx.compose:compose-bom` | 2026.06.01 | 2026.08.00 | BOM bump — moves the whole Compose artifact set at once; UI-framework-wide surface. |
| `androidx.appcompat:appcompat` | 1.7.1 | 1.8.0 | Minor bump. |
| `com.squareup.okhttp3:okhttp` | 5.4.0 | 5.5.0 | Minor bump and networking crate. |
| `io.github.takahirom.roborazzi:roborazzi` | 1.70.0 | 1.72.0 | Minor bump; also golden-screenshot tooling (`golden-bless-discipline.md`) — a version bump can shift pixel output and needs a bless pass. |
| `com.github.luben:zstd-jni` | 1.5.7-13 | 1.5.7-15 | JNI-adjacent by name/nature; withheld regardless of the build-number-only bump. |

## Major

| Dependency | Current | Latest | Note |
|---|---|---|---|
| `arti-client` (Rust) | 0.44.0 | 0.45.0 | Tor client — breaking 0.x minor. Paired with `tor-rtcompat` below; bump together if pursued. |
| `tor-rtcompat` (Rust) | 0.44.0 | 0.45.0 | Must track `arti-client`'s version. |
| `smoltcp` (Rust) | 0.13.1 | 0.14.0 | Breaking 0.x minor in the TUN/IP data-plane stack — highest-risk major bump in this scan; needs its own review pass. |

Everything else with a newer version on the Gradle side (AGP 9.5.0-alpha01, Kotlin 2.4.20-RC, KSP/Kotlin-compose companions, `androidx.lifecycle` 2.12.0-alpha01, `androidx.navigation` 2.10.0-rc01, `androidx.datastore` 1.3.0-alpha10, `protobuf-javalite` 4.36.0-RC2, `androidx.biometric` 1.4.0-alpha07, `androidx.work` 2.12.0-rc01, `androidx.camera` 1.7.0-alpha03, `androidx.glance` 1.3.0-alpha02, `robolectric` 4.17-beta-2, `leakcanary` 3.0-alpha-9) is pre-release only — no stable major/minor release is currently available, so there is nothing actionable to list here for those.

## Conflicts

No cross-module Gradle version-pinning conflicts were found: every dependency version in this repo is centralized in `gradle/libs.versions.toml` (verified — no module hardcodes a version outside the catalog), so there is no per-module divergence to reconcile. Resolving `:app`'s `githubFullDebugRuntimeClasspath` (~600 transitive edges) completes successfully with Gradle's normal highest-version conflict resolution and no forced/strict-conflict failures.

One unrelated observation surfaced while resolving that classpath: the `:app` → `:xray-protos` project-dependency edge renders as `FAILED` in the `dependencies` report, even though `:xray-protos:dependencies` resolves cleanly in isolation and the overall Gradle invocation still succeeds. This reproduced before any change in this PR and is unaffected by it; it looks like a variant-matching artifact of this audit's minimal SDK sandbox (no NDK/full toolchain installed) rather than a real dependency conflict, but is worth a human re-check against the full CI environment.

## Evidence

- `cargo audit --json` / `cargo deny check advisories` (native/rust) — advisory data above; both pass clean after the applied bump.
- `cargo deny check bans licenses sources` (native/rust) — `bans ok, licenses ok, sources ok`.
- `cargo check --workspace --locked --lib --bins` (native/rust, toolchain 1.96.0 pinned) — builds clean after the `h2` bump.
- `cargo metadata --locked` (native/rust) — resolves clean against the hand-edited lockfile.
- `./gradlew help` and `./gradlew :app:dependencies --configuration githubFullDebugRuntimeClasspath` — both `BUILD SUCCESSFUL`.
- Version-currency data for direct Rust deps and the Gradle catalog was queried live against the crates.io sparse index and Maven Central / Google Maven metadata.

## Checklist

- [x] No baseline files extended (detekt, lint, LoC, architecture-health)
- [x] Native ABI matrix not touched
- [x] Diff kept minimal and reviewable — lockfile version+checksum only, no incidental reformatting
- [ ] `just task-check` — not run (no task-board entry backs this automated audit; see Task contract)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ADLjFpegW8B3xRbXDxGew)_