### PR TITLE
chore(deps): nightly audit 2026-08-20

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -2546,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Task contract

- Task ID: N/A — automated nightly dependency/security audit, not a task-board item
- Task record: N/A
- OpenSpec change: N/A
- Spec-not-required reason: mechanical dependency-lockfile bump with no behavior/API surface change

## Summary

Nightly audit of the Rust Cargo workspace (`native/rust`, ~20 crates) and the
Kotlin/Gradle frontend (`gradle/libs.versions.toml`, ~13 modules). Exactly one
change qualified as SAFE — a patch-level security fix with no major/minor
bump — and is applied here. Everything else surfaced is withheld for human
review per policy; see the sections below.

**Note for reviewers:** #423 (still open, from the 2026-08-19 run) proposes
the same `h2` bump. This PR reflects tonight's independent re-scan (now on
the newly published `h2` 0.4.17, one patch ahead of what #423 applied) —
merge whichever lands first and close the other to avoid a duplicate
`Cargo.lock` churn.

## Applied

### Rust

- `h2`: `0.4.15` → `0.4.17` — patch bump (0.4.16 fixed the advisory; 0.4.17
  published 2026-08-19 is the current 0.4.x tip, so this applies the latest
  patch rather than the minimum fix). Resolves `RUSTSEC-2026-0258`.
  Transitive only (via `hickory-net`/`hyper`/`reqwest`), so only the
  `Cargo.lock` entry (version + checksum) changed; no `Cargo.toml` edit
  needed.

### Gradle

- None. Every catalog-declared direct dependency and plugin in
  `gradle/libs.versions.toml` is already at its latest **stable** release,
  the only newer release available is a pre-release (alpha/beta/RC), or the
  version is withheld under policy — see Needs review / Major below. No
  cross-module version-alignment fixes were needed (see Conflicts). The
  Gradle wrapper (9.6.1) is one minor behind current (9.7.1) — withheld as a
  minor bump, see Needs review.

## Security

| Advisory | Severity | Crate | Resolved? |
|---|---|---|---|
| [RUSTSEC-2026-0258](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h) | Low (DoS — unbounded empty DATA frames) | `h2` 0.4.15 | **Yes**, by the applied bump to 0.4.17 |
| [RUSTSEC-2023-0071](https://rustsec.org/advisories/RUSTSEC-2023-0071) (Marvin Attack) | Medium | `rsa` 0.9.10 / 0.10.0-rc.18 (via `arti-client`/`russh`) | No — already waived in `advisory-waivers.toml` (expires 2026-11-02, tracked by `docs/tasks/issues/unpin-russh-after-rsa-advisory-fix.md`). No safe upgrade exists on either path; unaffected by this PR. |
| [RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141) (unmaintained) | Informational | `bincode` 2.0.1 (via Arti) | No — already waived, expires 2026-11-02, tracked. |
| [RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436) (unmaintained) | Informational | `paste` 1.0.15 (via `netlink-packet-core`) | No — already waived, expires 2026-10-11, tracked. |
| [RUSTSEC-2025-0069](https://rustsec.org/advisories/RUSTSEC-2025-0069) (unmaintained) | Informational | `daemonize` 0.5.0 (CLI-only) | No — already waived, expires 2026-10-11, tracked. |

No yanked crate versions were found in `native/rust/Cargo.lock`. `cargo deny check bans licenses sources` passes clean — only the pre-existing, already-tolerated coexistence of multiple resolved majors for a handful of transitive crates (`aes`, `base64`, `nix`, `rand`, `sha2`, `thiserror`, `x25519-dalek`, `windows-sys`, …), none newly introduced by this PR.

## Needs review

Per policy, minor-version bumps and any crypto/networking/async-runtime/JNI-FFI-adjacent change are withheld regardless of semver level.

### Rust

| Crate | Locked | Latest | Why withheld |
|---|---|---|---|
| `russh` | 0.62.5 | 0.62.7 | Patch-level, but exact-pinned (`=0.62.5`) on purpose — pins the SSH relay's RustCrypto RC-crypto graph tied to the open `RUSTSEC-2023-0071` tracking issue. Crypto-adjacent. |
| `boring` | 5.1.0 | 5.2.0 | Minor bump; exact-pinned (`=5.1.0`) because BoringSSL has no stable ABI and the Reality TLS path hand-declares BoringSSL symbols (`docs/design/reality-boringssl-patch.md`). Crypto-adjacent. |
| `tokio-boring` | 5.0.0 | 5.2.0 | Same BoringSSL ABI-pin rationale as `boring`; must move in lockstep with it. Crypto-adjacent. |
| `io-uring` | 0.7.13 | 0.7.14 | Patch-level, but exact-pinned (`=0.7.13`); async-IO/FFI-adjacent (kernel io_uring syscalls). |
| `futures` | 0.3.33 | 0.3.34 | Patch-level, but async-runtime-adjacent. |
| `http-body-util` | 0.1.4 | 0.1.5 | Patch-level, but networking-adjacent (hyper ecosystem). |
| `similar` | 3.1.2 | 3.2.0 | Minor bump (dev/diff-testing crate; low risk, but policy withholds all minor bumps). |

### Gradle

| Dependency | Current | Latest stable | Why withheld |
|---|---|---|---|
| Gradle wrapper | 9.6.1 | 9.7.1 | Minor bump. |
| `androidx.compose:compose-bom` | 2026.06.01 | 2026.08.00 | BOM bump — moves the whole Compose artifact set at once; UI-framework-wide surface. |
| `androidx.appcompat:appcompat` | 1.7.1 | 1.8.0 | Minor bump. |
| `com.squareup.okhttp3:okhttp` | 5.4.0 | 5.5.0 | Minor bump and networking crate. |
| `io.github.takahirom.roborazzi:roborazzi` | 1.70.0 | 1.72.0 | Minor bump; also golden-screenshot tooling (`golden-bless-discipline.md`) — a version bump can shift pixel output and needs a bless pass. |
| `com.github.luben:zstd-jni` | 1.5.7-13 | 1.5.7-15 | JNI-adjacent by name/nature; withheld regardless of the build-number-only bump. |

## Major

| Dependency | Current | Latest | Note |
|---|---|---|---|
| `arti-client` (Rust) | 0.44.0 | 0.45.0 | Tor client — breaking 0.x minor. Paired with `tor-rtcompat` below; bump together if pursued. |
| `tor-rtcompat` (Rust) | 0.44.0 | 0.45.0 | Must track `arti-client`'s version. |
| `smoltcp` (Rust) | 0.13.1 | 0.14.0 | Breaking 0.x minor in the TUN/IP data-plane stack — highest-risk major bump in this scan; needs its own review pass. |
| `ee.schimke.composeai.preview` (Gradle plugin) | 0.19.56 | 1.21.0 | Compose-preview-rendering dev-tool plugin, 0.x → 1.x plus 20 further 1.x releases since. Renovate has an open PR (#413) proposing an intermediate 1.4.0 step; the plugin ships weekly, so pin whichever version is chosen deliberately rather than chasing the tip. |

Everything else with a newer version on the Gradle side (AGP 9.5.0-alpha01, Kotlin 2.4.20-RC, `androidx.lifecycle` 2.12.0-alpha01, `androidx.navigation` 2.10.0-rc01, `androidx.datastore` 1.3.0-alpha10, `protobuf-javalite` 4.36.0-RC2, `androidx.biometric` 1.4.0-alpha07, `androidx.work` 2.12.0-rc01, `androidx.camera` 1.7.0-alpha03, `androidx.glance` 1.3.0-alpha02, `androidx.benchmark` 1.5.0-rc01, `robolectric` 4.17-beta-2, `leakcanary` 3.0-alpha-9) is pre-release only — no stable major/minor release is currently available, so there is nothing actionable to list here for those. `ksp` (2.3.11) is already at KSP's latest published build; it has not yet shipped a build tracking Kotlin 2.4.x, so the apparent gap versus `kotlin-compose` (2.4.10) is not a fixable lag on our side.

## Conflicts

No cross-module Gradle version-pinning conflicts were found: every dependency version in this repo is centralized in `gradle/libs.versions.toml` (re-verified — no module hardcodes a version outside the catalog via `.gradle.kts` scan), so there is no per-module divergence to reconcile. `ksp` intentionally trails `kotlin-compose` by one Kotlin minor because KSP has not yet published a 2.4.x-tracking build (see Major note above) — not a conflict, just an upstream lag.

## Evidence

- `cargo deny --locked check advisories` (native/rust, cargo-deny 0.19.8, matching the pinned CI version) — advisory data above; passes clean after the applied bump (only the pre-existing stale-waiver informational warning for `RUSTSEC-2025-0141`/`bincode`, unrelated to this change and unchanged from before).
- `cargo deny --locked check bans licenses sources` (native/rust) — `bans ok, licenses ok, sources ok`.
- `cargo check --workspace --locked --lib --bins` (native/rust, toolchain 1.96.0 pinned) — builds clean after the `h2` bump.
- Version-currency data for direct Rust deps was queried live against the crates.io sparse index (`index.crates.io`) for every `[workspace.dependencies]` entry with a registry source; git-pinned deps (`hickory-proto`/`hickory-resolver`, pinned to an upstream commit) were excluded from the comparison as intentionally pre-release.
- Version-currency data for the Gradle catalog was queried live against Maven Central, Google's Maven repository, and the Gradle Plugin Portal metadata for every `[versions]` entry, plus the Gradle Services API for the wrapper version.
- `./gradlew help` failed in this sandbox with `SDK location not found` (no Android SDK/NDK installed here — matches the note in #423); since no Gradle catalog entries qualified as SAFE this run, no Gradle build verification was required. `cargo-outdated` could not run cleanly against this workspace (it fails to resolve the vendored `boring-sys` path patch when copying the tree to a scratch directory), so Rust version currency was instead checked directly against the crates.io sparse index as described above.

## Checklist

- [x] No baseline files extended (detekt, lint, LoC, architecture-health)
- [x] Native ABI matrix not touched
- [x] Diff kept minimal and reviewable — lockfile version+checksum only, no incidental reformatting
- [ ] `just task-check` — not run (no task-board entry backs this automated audit; see Task contract)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gd2aJRid1zytnu8HMaANZN)_