### PR TITLE
chore(deps): nightly audit 2026-08-21

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -389,9 +389,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3176,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
 dependencies = [
  "bitflags 2.13.1",
  "inotify-sys",
@@ -3269,9 +3269,9 @@ checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 dependencies = [
  "serde",
 ]
@@ -3378,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3418,9 +3418,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -3479,9 +3479,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -5117,18 +5117,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9909,9 +9909,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9922,9 +9922,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9932,9 +9932,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9942,9 +9942,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9955,9 +9955,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -9970,9 +9970,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",


### PR DESCRIPTION
## Task contract

- Task ID: N/A — routine scheduled dependency/security audit, not tracked on the task board
- Task record: N/A
- OpenSpec change: N/A
- Spec-not-required reason: mechanical dependency-version maintenance with no design or behavior change (only patch-level, non-crypto/network/async/FFI crates were bumped)

## Summary

Nightly dependency and security audit across the Rust Cargo workspace (`native/rust`, ~50 crates / 915 locked dependencies) and the Kotlin/Gradle frontend (13 modules, single version catalog). Only SAFE-bucket changes are applied here; everything else is reported below for a human decision.

## Evidence

Commands run from `native/rust/`:
- `cargo audit --json` — 915 dependencies scanned, 0 new/unwaived advisories, 0 yanked crates (see Security)
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- `cargo update --dry-run --workspace --verbose` — enumerated 74 crates with newer versions on crates.io, classified below
- Targeted `cargo update -p <crate>` for the 15 SAFE crates listed under Applied (no blanket `cargo update`)
- `cargo check --workspace --locked` — clean, 0 errors/warnings, all ~50 member crates
- `cargo test --workspace --locked --no-fail-fast` — kicked off for full confidence but did not finish compiling before this draft PR was opened (large workspace, cold build); CI on this PR is the authoritative result, and this session is watching the PR and will follow up on any failure

Gradle catalog (`gradle/libs.versions.toml`) was checked against Maven Central / Google Maven metadata for every versioned entry; no inline/per-module version overrides or `resolutionStrategy`/`force()`/`constraints{}` blocks exist outside the catalog, so there were no cross-module conflicts to resolve. A full Gradle build could not be run in this sandbox (no Android SDK/`local.properties` configured here — `./gradlew help` fails at project configuration with "SDK location not found"); since no Gradle files were changed in this PR, that gap doesn't affect what's being merged, but a Gradle-side SAFE change in a future run should be verified against CI before merging.

## Applied

Rust (`native/rust/Cargo.lock`, targeted `cargo update -p <crate>`, no blanket `cargo update`):

| Crate | Old → New | Notes |
|---|---|---|
| async-compression | 0.4.42 → 0.4.43 | patch |
| async-trait | 0.1.91 → 0.1.92 | patch, proc-macro only |
| inotify | 0.11.4 → 0.11.5 | patch |
| ipnet | 2.12.0 → 2.12.1 | patch |
| js-sys | 0.3.103 → 0.3.104 | patch; wasm32-only, not built for Android |
| kqueue | 1.2.0 → 1.2.1 | patch; BSD/macOS-only, inert on Android/Linux host |
| libredox | 0.1.19 → 0.1.20 | patch; Redox-only, inert on Android/Linux host |
| ref-cast | 1.0.26 → 1.0.27 | patch |
| ref-cast-impl | 1.0.26 → 1.0.27 | patch, paired with ref-cast |
| wasm-bindgen | 0.2.126 → 0.2.127 | patch; wasm32-only, not built for Android |
| wasm-bindgen-futures | 0.4.76 → 0.4.77 | patch; wasm32-only |
| wasm-bindgen-macro | 0.2.126 → 0.2.127 | patch; wasm32-only |
| wasm-bindgen-macro-support | 0.2.126 → 0.2.127 | patch; wasm32-only |
| wasm-bindgen-shared | 0.2.126 → 0.2.127 | patch; wasm32-only |
| web-sys | 0.3.103 → 0.3.104 | patch; wasm32-only |

Verification: `cargo check --workspace --locked` is clean (all ~50 member crates, 0 errors/warnings). `cargo test --workspace --locked` was started but had not finished a cold-compile of the full workspace before this draft PR was opened; see Evidence.

Gradle: no changes applied. Every catalog candidate with an available update crossed into the NEEDS REVIEW or MAJOR bucket (see below) — nothing qualified as a pure patch-level or conflict-only SAFE change this run.

## Security

- **RUSTSEC-2023-0071** (`rsa`, "Marvin Attack" timing side-channel, CVSS 3.1 AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N) — affects `rsa` 0.9.10 (via `arti-client`) and `rsa` 0.10.0-rc.18 (via `russh`). Already tracked and waived in `native/rust/deny.toml` with documented rationale (no constant-time fix published upstream on either path; RIPDPI exposes no RSA private-key service). **Not resolved** by this run — no upgrade path exists in either dependency chain yet.
- **RUSTSEC-2024-0436** (`paste` 1.0.15, unmaintained) — waived in `deny.toml`, no maintained replacement published. No action.
- **RUSTSEC-2025-0069** (`daemonize` 0.5.0, unmaintained) — waived in `deny.toml` (isolated behind `ripdpi-cli`'s optional daemonize feature). No action.
- **RUSTSEC-2025-0141** (`bincode` 2.0.1, unmaintained) — waived in `deny.toml`, but `cargo deny check` reported this waiver as `advisory-not-detected` ("no crate matched advisory criteria") against the current lockfile, while `cargo audit`'s rustsec DB still flags `bincode` 2.0.1 as unmaintained. Worth a human check on whether the `deny.toml` waiver is now stale/mismatched — not changed here since it's a waiver-metadata question, not a dependency bump.
- `cargo audit`: 915 locked dependencies scanned against the 2026-08-20 RustSec DB — 0 new/unwaived vulnerabilities, 0 yanked crate versions in the lockfile.
- `cargo deny check`: `advisories ok, bans ok, licenses ok, sources ok`.

## Needs review

Rust — minor-version bumps, or touching crypto/networking/async-runtime/JNI-FFI regardless of semver level (never auto-applied per policy):

| Crate | Old → New | Why withheld |
|---|---|---|
| idna_adapter | 1.2.0 → 1.2.2 | Looks like a patch bump but transitively forces an ICU4X 1.x→2.x rewrite (icu_normalizer/icu_properties/icu_provider/icu_collections/litemap/writeable/yoke/zerovec-derive all jump major; icu_locid, icu_provider_macros, tinystr 0.7, utf16_iter, write16 are removed, icu_locale_core/zerotrie/potential_utf are added). Confirmed in isolation with `cargo update -p idna_adapter --dry-run`. Reachable through domain-name parsing used across the networking stack. |
| tinystr, zerovec, zerovec-derive | 0.8.3→0.8.4, 0.11.6→0.11.8, 0.10.3→0.11.6 | Entangled with the idna_adapter/ICU4X bump above; withheld together so the diff stays reviewable as one unit. |
| aws-lc-rs | 1.17.0 → 1.18.0 | crypto + FFI (aws-lc-sys C bindings) |
| blake3 | 1.8.5 → 1.8.7 | crypto hash (patch-level, but crypto is never auto-applied) |
| boring, tokio-boring | 5.1.0 → 5.2.0 | BoringSSL bindings, crypto+FFI, vendored under `native/rust/vendor/boring-sys`; Renovate already excludes this from auto-bump |
| bstr | 1.12.3 → 1.13.1 | minor bump |
| cc | 1.2.67 → 1.4.3 | drives native builds (boring-sys, zstd-sys) via the C compiler; FFI-adjacent |
| chacha20 | 0.10.0 → 0.10.1 | crypto cipher |
| clang-sys | 1.8.1 → 1.9.1 | FFI/bindgen backend |
| der | 0.8.0 → 0.8.1 | crypto (ASN.1/DER for keys & certs) |
| either | 1.16.0 → 1.18.0 | minor bump |
| fastrand | 2.4.1 → 2.5.0 | minor bump |
| foreign-types-macros | 0.2.3 → 0.2.4 | FFI type wrapping used by boring/openssl bindings |
| fs-mistrust, fslock-guard, safelog, oneshot-fused-workaround | patch-level | all are Arti/Tor-stack dependencies; grouped for review alongside the `arti-client` major bump (see Major) instead of bumped standalone |
| generic-array | 0.14.7→0.14.9, 1.4.4→1.4.5 | RustCrypto primitive building block |
| h2 | 0.4.17 → 0.4.18 | HTTP/2, networking |
| http-body | 1.0.1 → 1.1.0 | HTTP, networking, minor bump |
| hybrid-array | 0.4.13 → 0.4.14 | RustCrypto primitive building block |
| keccak | 0.2.0 → 0.2.1 | crypto hash primitive |
| netlink-packet-core | 0.8.1 → 0.8.2 | Linux netlink protocol, networking |
| num-bigint, num-integer | 0.4.6→0.4.8, 0.1.46→0.1.47 | bignum arithmetic on RSA/DH crypto paths |
| pageant | 0.2.1 → 0.2.2 | SSH-agent protocol client, networking |
| pkcs5, poly1305, polyval | patch-level | crypto primitives |
| portable-atomic | 1.13.1 → 1.15.0 | minor bump |
| quinn-proto, quinn-udp | 0.11.15→0.11.17, 0.5.14→0.5.15 | QUIC protocol, networking |
| rand (0.8 line) | 0.8.6 → 0.8.7 | RNG, crypto-adjacent key/nonce generation; Renovate-excluded from auto-bump |
| rapidhash | 4.4.2 → 4.5.1 | minor bump |
| regex | 1.12.4 → 1.13.1 | minor bump |
| reseeding_rng | 0.10.6 → 0.10.7 | crypto-adjacent RNG |
| route_manager | 0.2.11 → 0.2.13 | VPN routing-table management, core networking behavior |
| russh | 0.62.6 → 0.62.7 | SSH protocol + crypto; Renovate-excluded from auto-bump. Also: `deny.toml`'s comment block documents `russh =0.62.5` as the pinned release, but the resolved lockfile is already at 0.62.6 — that comment looks stale, worth a doc fix independent of this bump. |
| rustls-pki-types, rustls-webpki, webpki-root-certs | patch/minor | TLS/PKI crypto and root trust data |
| serde_with, serde_with_macros | 3.21.0 → 3.22.0 | minor bump |
| sha1 | 0.10.6 → 0.10.7 | crypto hash |
| simd_cesu8 | 1.1.1 → 1.2.0 | CESU-8 (JVM/JNI modified-UTF-8) string encoding — JNI/FFI-adjacent |
| similar, tinyvec | minor | minor bump |
| tokio-macros | 2.7.0 → 2.7.2 | tokio async-runtime family |
| zerocopy, zerocopy-derive | 0.8.55 → 0.8.56 | unsafe zero-copy memory layout, used on packet-parsing paths |

Gradle:

| Dependency | Old → New | Why withheld |
|---|---|---|
| okhttp | 5.4.0 → 5.5.0 | minor bump + networking (HTTP client backing relay/DoH transports) |
| protobuf-javalite | 4.35.1 → 4.36.0 | minor bump; wire-schema-sensitive (settings/diagnostics contracts) |
| zstd-jni | 1.5.7-13 → 1.5.7-15 | packaging-only revision of the same 1.5.7 release, but it's a native JNI wrapper around libzstd — withheld under the JNI/FFI carve-out rather than auto-applied as a plain patch |
| Gradle wrapper | 9.6.1 → 9.7.1 | minor build-tool bump |
| compose-preview-plugin (`ee.schimke.composeai.preview`) | 1.4.0 → 1.27.0 | technically a minor-version bump under strict semver, but the size of the jump (23 minor releases) is unusual enough to want a changelog read before taking it; affects Compose preview rendering used by golden baselines |

## Major

- **smoltcp**: 0.13.1 → 0.14.0 — breaking 0.x bump on the user-space TCP/IP stack RIPDPI uses for TUN packet processing. Likely the highest-impact update in this scan; deserves its own PR with the upstream changelog read end-to-end.
- **arti-client**: 0.44.0 → 0.45.0 — breaking 0.x bump on the Tor client; also networking+crypto.
- **tor-rtcompat**: 0.44.0 → 0.45.0 — companion crate to arti-client, must move together with it.
- **constant_time_eq**: 0.4.2 → 0.5.0 — breaking 0.x bump; crypto (constant-time comparison primitive).
- **rand** (0.9 line): 0.9.5 → 0.10.2 — breaking 0.x bump on the second `rand` major present in the graph; RNG/crypto-adjacent; Renovate-excluded from auto-bump.
- The idna_adapter/ICU4X cascade under Needs review is a de facto major bump too (it started from a nominal patch-version headline); flagged there since it's entangled with a patch-labeled crate.

## Checklist

- [ ] `just task-check` — not run; this PR has no task-board entry (routine dependency audit, see Task contract)
- [x] No work is marked complete without its required evidence — see Evidence section for exact commands and results
- [x] No baseline files extended (detekt, lint, LoC) — only `native/rust/Cargo.lock` changed
- [x] `timeout-minutes` added to any new CI job — N/A, no CI job added
- [x] Native ABI matrix not broken (if touching native builds) — `cargo check --workspace --locked` passed for every crate including the `*-android` adapter crates; note this is a host-target check, not a cross-compiled Android NDK build, which wasn't run in this sandbox
- [x] Non-rooted device path still works (if touching VPN/root features) — N/A, no VPN/root feature touched
- [x] mdtask PolyForm Shield internal-tool use is owner/legal-approved (if `tools/tasking` changes) — N/A, no `tools/tasking` changes

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01ALtn2nTuhnw123bLG1HVA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALtn2nTuhnw123bLG1HVA4)_