### PR TITLE
fix(contract): sync authenticated liveness schema

### DIFF
--- a/core/data/src/test/resources/contract/protocol-liveness.schema.json
+++ b/core/data/src/test/resources/contract/protocol-liveness.schema.json
@@ -23,10 +23,12 @@
     "otp_ttl_seconds": { "type": "integer", "minimum": 60, "default": 3600 },
     "expected_runtime": {
       "type": "object",
-      "required": ["sing_box", "awg"],
+      "minProperties": 1,
       "properties": {
         "sing_box": { "type": "string", "minLength": 1 },
-        "awg": { "type": "string", "minLength": 1 }
+        "awg": { "type": "string", "minLength": 1 },
+        "xray": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+        "awg_toolchain": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
       },
       "additionalProperties": false
     },
@@ -54,12 +56,23 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["id", "ssh_target", "policy"],
+        "required": ["id", "ssh_target", "policy", "vantage"],
         "properties": {
           "id": { "$ref": "#/$defs/technical_id" },
-          "ssh_target": { "type": "string", "pattern": "^[A-Za-z0-9_.@-]+$" },
-          "ssh_transport_host": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+$" },
-          "ssh_host_key_alias": { "type": "string", "pattern": "^[A-Za-z0-9_.@-]+$" },
+          "ssh_target": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_.@-]*$" },
+          "ssh_transport_host": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]*$" },
+          "ssh_host_key_alias": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_.@-]*$" },
+          "vantage": { "enum": ["external", "filtered"] },
+          "awg_target": {
+            "type": "object",
+            "required": ["provider", "environment", "instance"],
+            "properties": {
+              "provider": { "enum": ["upcloud", "vultr", "hetzner", "scaleway"] },
+              "environment": { "$ref": "#/$defs/technical_id" },
+              "instance": { "type": "string", "pattern": "^[A-Za-z0-9_][A-Za-z0-9_.-]{0,14}$" }
+            },
+            "additionalProperties": false
+          },
           "policy": { "$ref": "#/$defs/technical_id" }
         },
         "dependentRequired": {


### PR DESCRIPTION
## Summary

Synchronize only `core/data/src/test/resources/contract/protocol-liveness.schema.json` byte-for-byte with po4yka/ripdpi-vpn-deploy commit `33fa9c7a2147bfa0464b747ca73a3c2ff24d2d62` (PR po4yka/ripdpi-vpn-deploy#112).

The operator liveness schema adds per-policy runtime pins, Xray/toolchain identity, vantage and explicit AWG target binding, and tightens SSH name validation. Repository search found no Android runtime consumer of this mirrored schema; the Kotlin bundle contract test uses a separate schema. No runtime, device, probe-matrix schema 3, or network-exposure change is included.

## Verification

- Actual byte drift reproduced before copying; exact equality and JSON Schema validity passed after copying.
- All 22 mirrored contract files match the proposed producer tree with zero drift or orphans.
- Deployment evaluator and existing Snell consumer tests: 88 passed against the exact schema bytes.
- Architecture check: no new or worsened findings; locked Cargo metadata and task contracts passed.
- Existing Android owner was consulted; main integration will be serialized with that lane. Hosted CI is pending; no Kotlin/device execution claim is made from these checks.
