### PR TITLE
fix(ci): restore native and DNS baseline checks

### DIFF
--- a/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/ConnectivityDnsTargetPlannerTest.kt
+++ b/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/ConnectivityDnsTargetPlannerTest.kt
@@ -3,6 +3,7 @@ package com.poyka.ripdpi.diagnostics
 import com.poyka.ripdpi.data.ActiveDnsSettings
 import com.poyka.ripdpi.data.DnsModePlainUdp
 import com.poyka.ripdpi.data.DnsProviderCloudflare
+import com.poyka.ripdpi.data.DnsProviderCloudflareIp
 import com.poyka.ripdpi.data.DnsProviderCustom
 import com.poyka.ripdpi.data.EncryptedDnsPathCandidate
 import com.poyka.ripdpi.data.EncryptedDnsProtocolDoh
@@ -10,6 +11,7 @@ import com.poyka.ripdpi.data.EncryptedDnsProtocolDot
 import com.poyka.ripdpi.data.NativeNetworkSnapshot
 import com.poyka.ripdpi.data.activeDnsSettings
 import com.poyka.ripdpi.data.builtInEncryptedDnsPathCandidates
+import com.poyka.ripdpi.data.isAutomaticEncryptedDnsProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -103,8 +105,7 @@ class ConnectivityDnsTargetPlannerTest {
                 activeDns = plainUdpDns(),
                 preferredPath = null,
             )
-        val expectedCount = builtInEncryptedDnsPathCandidates().size
-        assertEquals(expectedCount, result.size)
+        assertAutomaticResolverMatrix(result)
         assertTrue(result.all { it.domain == "example.com" })
         assertTrue(result.all { !it.encryptedResolverId.isNullOrBlank() })
         assertTrue(result.any { it.encryptedProtocol == EncryptedDnsProtocolDoh })
@@ -188,7 +189,7 @@ class ConnectivityDnsTargetPlannerTest {
     }
 
     @Test
-    fun `resolver audit keeps full resolver matrix`() {
+    fun `resolver audit keeps full automatic resolver matrix`() {
         val target = DnsTarget(domain = "example.com")
         val result =
             ConnectivityDnsTargetPlanner.expandTargets(
@@ -198,7 +199,20 @@ class ConnectivityDnsTargetPlannerTest {
                 resolverCandidateLimit = defaultDiagnosticsResolverCandidateLimit("resolver-audit"),
             )
 
-        assertEquals(builtInEncryptedDnsPathCandidates().size, result.size)
+        assertAutomaticResolverMatrix(result)
+    }
+
+    private fun assertAutomaticResolverMatrix(targets: List<DnsTarget>) {
+        val expected =
+            builtInEncryptedDnsPathCandidates()
+                .filter { isAutomaticEncryptedDnsProvider(it.resolverId) }
+        assertEquals(expected.size, targets.size)
+        assertEquals(
+            expected.map { it.resolverId to it.protocol }.toSet(),
+            targets.map { it.encryptedResolverId to it.encryptedProtocol }.toSet(),
+        )
+        val explicitOnlyProviders = setOf(DnsProviderCloudflare, DnsProviderCloudflareIp, "cloudflare-malware")
+        assertTrue(targets.none { it.encryptedResolverId in explicitOnlyProviders })
     }
 
     @Test

--- a/core/service/src/main/kotlin/com/poyka/ripdpi/services/FlowAppAttributionStore.kt
+++ b/core/service/src/main/kotlin/com/poyka/ripdpi/services/FlowAppAttributionStore.kt
@@ -159,7 +159,7 @@ class DefaultFlowAppAttributionStore
         ): Int {
             val digest = flowAttributionDigest(remoteIp)
             // Overwrite rather than putIfAbsent: the native queue already dedupes
-            // noteFlow calls per destination (one per dest until evict_flow on
+            // noteFlow calls per destination (one per dest until evict_flow_if_current on
             // close), so a fresh call here means the destination was re-seen and
             // must be re-resolved -- e.g. after a different app reuses the IP.
             val (uid, attribution) = resolveAttribution(protocol, localIp, localPort, remoteIp, remotePort)

--- a/native/rust/crates/ripdpi-flow-app-attribution/src/lib.rs
+++ b/native/rust/crates/ripdpi-flow-app-attribution/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! Like `ripdpi-native-protect`, each `.so` links its own copy, so the cache is
 //! per-`.so`. State is bounded (LRU) and additionally evicted on flow close
-//! ([`evict_flow`]) and cleared on session teardown ([`end_attribution_session_if`]).
+//! ([`evict_flow_if_current`]) and cleared on session teardown ([`end_attribution_session_if`]).
 //!
 //! ## Conservative by default
 //!
@@ -51,7 +51,7 @@ use std::time::{Duration, Instant};
 use lru::LruCache;
 
 /// Max distinct destination IPs tracked before LRU eviction kicks in. A backstop
-/// for flows whose explicit [`evict_flow`] was missed; sized for many concurrent
+/// for flows whose explicit [`evict_flow_if_current`] was missed; sized for many concurrent
 /// destinations without unbounded growth under churn.
 const CACHE_CAPACITY: usize = 4096;
 
@@ -154,31 +154,35 @@ impl FlowResolveRequest {
     }
 }
 
-/// Opaque identity of one exact flow registration.
+/// Copyable identity of one exact flow registration, not its lifetime owner.
 ///
 /// The generation prevents a delayed cleanup from removing a later flow that reused the same protocol/local/remote tuple.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct FlowAttributionToken {
+/// Copying or discarding the ID does not retain or unregister the flow. The
+/// cache may invalidate it through eviction, admission expiry, or session end.
+/// TCP session and UDP association containers perform explicit cleanup using
+/// [`evict_flow_if_current`] when their flow lifetime ends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FlowRegistrationId {
     request: FlowResolveRequest,
     generation: u64,
 }
 
-impl FlowAttributionToken {
-    /// Exact tuple owned by this registration.
+impl FlowRegistrationId {
+    /// Exact tuple identified by this registration.
     #[must_use]
     pub const fn request(&self) -> FlowResolveRequest {
         self.request
     }
 }
 
-/// Result of recording a flow, including the token its owner must release.
-#[must_use = "the flow token must be retained and released with evict_flow"]
+/// Cached attribution and the identity shared by observations of the same flow.
+#[must_use = "flow lifetime containers use the registration ID for explicit generation-checked cleanup"]
 #[derive(Debug, PartialEq, Eq)]
 pub struct FlowObservation {
     /// Destination-level app context already cached when the flow was noted.
     pub context: Option<FlowAppContext>,
-    /// Exact registration identity that must be released with [`evict_flow`].
-    pub token: FlowAttributionToken,
+    /// Non-owning identity; dropping this observation does not unregister it.
+    pub registration_id: FlowRegistrationId,
 }
 
 /// Generation-stamped unit of work drained by the asynchronous UID resolver.
@@ -275,7 +279,7 @@ fn lock() -> std::sync::MutexGuard<'static, State> {
     state().lock().expect("flow-app-attribution state poisoned")
 }
 
-/// Record a flow and return its cached attribution plus the exact generation token its owner must release.
+/// Record a flow and return cached attribution plus its non-owning registration ID.
 ///
 /// Non-blocking and hot-path safe: on a cache miss this marks the destination IP `Pending`, enqueues a [`FlowResolveRequest`] for the worker, and returns no context. A later flow to the same destination picks up the resolved answer.
 pub fn note_flow(protocol: u8, local: SocketAddr, remote: SocketAddr) -> FlowObservation {
@@ -290,10 +294,13 @@ pub fn note_flow(protocol: u8, local: SocketAddr, remote: SocketAddr) -> FlowObs
         guard.cache.put(key, Resolution::Pending);
     }
     if let Some(resolution) = guard.uid_cache.get(&request).copied() {
-        return FlowObservation { context, token: FlowAttributionToken { request, generation: resolution.generation } };
+        return FlowObservation {
+            context,
+            registration_id: FlowRegistrationId { request, generation: resolution.generation },
+        };
     }
     let generation = NEXT_FLOW_GENERATION.fetch_add(1, Ordering::Relaxed);
-    let token = FlowAttributionToken { request, generation };
+    let registration_id = FlowRegistrationId { request, generation };
     guard.uid_cache.put(
         request,
         UidResolution {
@@ -312,7 +319,7 @@ pub fn note_flow(protocol: u8, local: SocketAddr, remote: SocketAddr) -> FlowObs
     guard.pending.push_back(FlowResolutionJob { request, generation, kind: FlowResolutionKind::Attribution });
     drop(guard);
     pending_signal().notify_one();
-    FlowObservation { context, token }
+    FlowObservation { context, registration_id }
 }
 
 /// Ensure an exact tuple has an asynchronous UID resolution request without
@@ -323,16 +330,16 @@ pub fn note_flow(protocol: u8, local: SocketAddr, remote: SocketAddr) -> FlowObs
 /// never renew that security bound: the exact tuple is forcibly re-resolved
 /// after five seconds in case the kernel assigned it to a different socket
 /// owner. The cache is also bounded by LRU and cleared at session shutdown.
-pub fn request_uid_admission(protocol: u8, local: SocketAddr, remote: SocketAddr) -> FlowAttributionToken {
+pub fn request_uid_admission(protocol: u8, local: SocketAddr, remote: SocketAddr) -> FlowRegistrationId {
     let request = FlowResolveRequest { protocol, local, remote };
     request_uid_admission_at(request, Instant::now())
 }
 
-fn request_uid_admission_at(request: FlowResolveRequest, now: Instant) -> FlowAttributionToken {
+fn request_uid_admission_at(request: FlowResolveRequest, now: Instant) -> FlowRegistrationId {
     let mut guard = lock();
     remove_expired_admission(&mut guard, request, now);
     if let Some(entry) = guard.uid_cache.get(&request) {
-        return FlowAttributionToken { request, generation: entry.generation };
+        return FlowRegistrationId { request, generation: entry.generation };
     }
     let generation = NEXT_FLOW_GENERATION.fetch_add(1, Ordering::Relaxed);
     guard.uid_cache.put(
@@ -353,16 +360,16 @@ fn request_uid_admission_at(request: FlowResolveRequest, now: Instant) -> FlowAt
     guard.pending.push_back(FlowResolutionJob { request, generation, kind: FlowResolutionKind::AdmissionOnly });
     drop(guard);
     pending_signal().notify_one();
-    FlowAttributionToken { request, generation }
+    FlowRegistrationId { request, generation }
 }
 
 /// Read only this registration's UID; a reused tuple never supplies its successor's verdict.
 #[must_use]
-pub fn lookup_registered_flow_uid(token: &FlowAttributionToken) -> FlowUidLookup {
+pub fn lookup_registered_flow_uid(registration_id: &FlowRegistrationId) -> FlowUidLookup {
     let mut guard = lock();
-    remove_expired_admission(&mut guard, token.request, Instant::now());
-    match guard.uid_cache.get(&token.request) {
-        Some(entry) if entry.generation == token.generation => match entry.state {
+    remove_expired_admission(&mut guard, registration_id.request, Instant::now());
+    match guard.uid_cache.get(&registration_id.request) {
+        Some(entry) if entry.generation == registration_id.generation => match entry.state {
             UidResolutionState::Pending => FlowUidLookup::Pending,
             UidResolutionState::Resolved(uid) => FlowUidLookup::Resolved(uid),
         },
@@ -454,17 +461,20 @@ fn store_resolution(dest_ip: IpAddr, context: Option<FlowAppContext>) {
     lock().cache.put(dest_ip, Resolution::Resolved(context));
 }
 
-/// Release one exact flow registration if its generation is still current.
+/// Unregister one exact flow if the ID's generation is still current.
 ///
 /// The destination-level attribution remains cached while any other exact flow to that IP is registered.
-pub fn evict_flow(token: FlowAttributionToken) -> bool {
+/// A duplicate or stale ID returns `false`. Consuming this copyable ID does not
+/// imply ownership: the caller must be responsible for the flow's lifetime.
+pub fn evict_flow_if_current(registration_id: FlowRegistrationId) -> bool {
     let mut guard = lock();
-    if guard.uid_cache.peek(&token.request).is_none_or(|entry| entry.generation != token.generation) {
+    if guard.uid_cache.peek(&registration_id.request).is_none_or(|entry| entry.generation != registration_id.generation)
+    {
         return false;
     }
-    guard.uid_cache.pop(&token.request);
-    guard.pending.retain(|job| job.request != token.request || job.generation != token.generation);
-    let dest_ip = token.request.key();
+    guard.uid_cache.pop(&registration_id.request);
+    guard.pending.retain(|job| job.request != registration_id.request || job.generation != registration_id.generation);
+    let dest_ip = registration_id.request.key();
     if !guard.uid_cache.iter().any(|(request, _)| request.key() == dest_ip) {
         guard.cache.pop(&dest_ip);
     }
@@ -559,6 +569,35 @@ mod tests {
 
     fn sock(a: u8, b: u8, c: u8, d: u8, port: u16) -> SocketAddr {
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(a, b, c, d), port))
+    }
+
+    #[test]
+    fn registration_id_is_shared_identity_not_a_lifetime_owner() {
+        fn copied(id: FlowRegistrationId) -> FlowRegistrationId {
+            let copy = id;
+            assert_eq!(copy, id);
+            copy
+        }
+
+        let _g = TEST_GUARD.lock().expect("test guard");
+        clear();
+        let local = sock(10, 0, 0, 2, 50000);
+        let remote = sock(203, 0, 113, 7, 443);
+        let first = note_flow(6, local, remote);
+        let id = copied(first.registration_id);
+        let repeated = note_flow(6, local, remote);
+        assert_eq!(id, repeated.registration_id);
+        drop(first);
+        drop(repeated);
+
+        assert_eq!(lookup_registered_flow_uid(&id), FlowUidLookup::Pending);
+        assert!(evict_flow_if_current(id));
+        assert!(!evict_flow_if_current(id));
+        let replacement = note_flow(6, local, remote).registration_id;
+        assert_ne!(replacement, id);
+        assert!(!evict_flow_if_current(id));
+        assert_eq!(lookup_registered_flow_uid(&replacement), FlowUidLookup::Pending);
+        assert!(evict_flow_if_current(replacement));
     }
 
     #[test]
@@ -658,14 +697,14 @@ mod tests {
         let remote = sock(93, 184, 216, 34, 443);
         let observation = note_flow(6, local, remote);
         let job = pop_pending_request(Duration::from_millis(10)).expect("pending job");
-        assert!(evict_flow(observation.token));
+        assert!(evict_flow_if_current(observation.registration_id));
         let current = note_flow(6, local, remote);
         store_uid_resolution(&job, Some(10_123));
         store_flow_resolution(&job, Some(FlowAppContext::new("com.stale", 1)));
 
         assert_eq!(lookup_flow_uid(6, local, remote), FlowUidLookup::Pending);
         assert!(lookup_flow(remote.ip()).is_none());
-        assert!(evict_flow(current.token));
+        assert!(evict_flow_if_current(current.registration_id));
     }
 
     #[test]
@@ -677,9 +716,9 @@ mod tests {
         let second = note_flow(6, sock(10, 0, 0, 3, 50000), remote);
         store_resolution(remote.ip(), Some(FlowAppContext::new("com.example", 1)));
 
-        assert!(evict_flow(first.token));
+        assert!(evict_flow_if_current(first.registration_id));
         assert!(lookup_flow(remote.ip()).is_some(), "the other exact flow still owns the destination entry");
-        assert_eq!(lookup_flow_uid(6, second.token.request().local, remote), FlowUidLookup::Pending);
+        assert_eq!(lookup_flow_uid(6, second.registration_id.request().local, remote), FlowUidLookup::Pending);
     }
 
     #[test]
@@ -688,16 +727,16 @@ mod tests {
         clear();
         let local = sock(10, 0, 0, 2, 50000);
         let remote = sock(203, 0, 113, 7, 443);
-        let stale = note_flow(6, local, remote).token;
+        let stale = note_flow(6, local, remote).registration_id;
         let stale_request = stale.request;
         let stale_generation = stale.generation;
-        assert!(evict_flow(stale));
-        let current = note_flow(6, local, remote).token;
+        assert!(evict_flow_if_current(stale));
+        let current = note_flow(6, local, remote).registration_id;
 
-        let replayed_stale = FlowAttributionToken { request: stale_request, generation: stale_generation };
-        assert!(!evict_flow(replayed_stale));
+        let replayed_stale = FlowRegistrationId { request: stale_request, generation: stale_generation };
+        assert!(!evict_flow_if_current(replayed_stale));
         assert_eq!(lookup_flow_uid(6, local, remote), FlowUidLookup::Pending);
-        assert!(evict_flow(current));
+        assert!(evict_flow_if_current(current));
     }
 
     #[test]
@@ -747,8 +786,8 @@ mod tests {
         let remote = sock(198, 51, 100, 7, 443);
         store_resolution(remote.ip(), Some(FlowAppContext::new("com.example.c", 1)));
         assert!(lookup_flow(remote.ip()).is_some());
-        let token = note_flow(6, sock(10, 0, 0, 2, 40000), remote).token;
-        evict_flow(token);
+        let registration_id = note_flow(6, sock(10, 0, 0, 2, 40000), remote).registration_id;
+        evict_flow_if_current(registration_id);
         assert!(lookup_flow(remote.ip()).is_none());
     }
 

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/bridge/session_cleanup.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/bridge/session_cleanup.rs
@@ -32,8 +32,8 @@ pub(super) fn take_session_task(
     if let (Some(cache), Some(ip)) = (dns_cache.as_mut(), entry.pinned_synthetic_ip) {
         cache.unpin(ip);
     }
-    if let Some(token) = entry.attribution_token {
-        ripdpi_flow_app_attribution::evict_flow(token);
+    if let Some(registration_id) = entry.attribution_id {
+        ripdpi_flow_app_attribution::evict_flow_if_current(registration_id);
     }
     entry.cancel.cancel();
     drop(entry.smoltcp_side);

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/bridge/tests/session_flow.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/bridge/tests/session_flow.rs
@@ -27,7 +27,7 @@ async fn u22_pump_forwards_smoltcp_to_session() {
         pending_to_smoltcp: Vec::new(),
         upstream_closed: false,
         pinned_synthetic_ip: None,
-        attribution_token: None,
+        attribution_id: None,
     };
     let mut sessions = ActiveSessions::new(8);
     sessions.insert(handle, entry);
@@ -96,7 +96,7 @@ async fn u23_pump_forwards_session_to_smoltcp() {
         pending_to_smoltcp: Vec::new(),
         upstream_closed: false,
         pinned_synthetic_ip: None,
-        attribution_token: None,
+        attribution_id: None,
     };
     let mut sessions = ActiveSessions::new(8);
     sessions.insert(handle, entry);
@@ -143,7 +143,7 @@ async fn u25_pump_handles_partial_writes() {
         pending_to_smoltcp: Vec::new(),
         upstream_closed: false,
         pinned_synthetic_ip: None,
-        attribution_token: None,
+        attribution_id: None,
     };
     let mut sessions = ActiveSessions::new(8);
     sessions.insert(handle, entry);

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/bridge/tests/session_lifecycle.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/bridge/tests/session_lifecycle.rs
@@ -25,7 +25,7 @@ async fn u24_pump_removes_closed_session() {
         pending_to_smoltcp: Vec::new(),
         upstream_closed: false,
         pinned_synthetic_ip: None,
-        attribution_token: None,
+        attribution_id: None,
     };
     let mut sessions = ActiveSessions::new(8);
     sessions.insert(handle, entry);
@@ -62,7 +62,7 @@ async fn u26_pump_upstream_closed_closes_tcp() {
         pending_to_smoltcp: Vec::new(),
         upstream_closed: true, // Simulate upstream already closed
         pinned_synthetic_ip: None,
-        attribution_token: None,
+        attribution_id: None,
     };
     let mut sessions = ActiveSessions::new(8);
     sessions.insert(handle, entry);
@@ -113,7 +113,7 @@ async fn u28_pump_removal_cancels_session_task_token() {
         pending_to_smoltcp: Vec::new(),
         upstream_closed: false,
         pinned_synthetic_ip: None,
-        attribution_token: None,
+        attribution_id: None,
     };
     let mut sessions = ActiveSessions::new(8);
     sessions.insert(handle, entry);

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/bridge/tests/shutdown.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/bridge/tests/shutdown.rs
@@ -47,7 +47,7 @@ fn insert_stalled_session(
         pending_to_smoltcp: Vec::new(),
         upstream_closed: false,
         pinned_synthetic_ip: None,
-        attribution_token: None,
+        attribution_id: None,
     };
     assert!(sessions.insert(socket_handle, entry).is_none());
     (cancel, alive, started_rx)
@@ -74,7 +74,7 @@ async fn u27_shutdown_cancels_all() {
         pending_to_smoltcp: Vec::new(),
         upstream_closed: false,
         pinned_synthetic_ip: None,
-        attribution_token: None,
+        attribution_id: None,
     };
     let mut sessions = ActiveSessions::new(8);
     sessions.insert(handle, entry);

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/phases.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/phases.rs
@@ -370,7 +370,7 @@ mod tests {
         assert_eq!(
             ripdpi_flow_app_attribution::lookup_flow_uid(request.protocol, request.local, request.remote,),
             ripdpi_flow_app_attribution::FlowUidLookup::Missing,
-            "denied UDP admission must evict its exact-tuple UID cache token",
+            "denied UDP admission must evict its exact-tuple UID cache registration",
         );
 
         let allowed_packet = ipv4_udp_packet(55_124, 443, b"uid-allowed");
@@ -854,16 +854,16 @@ mod tests {
     fn pending_uid_udp_storage_is_bounded_and_reuses_preallocated_buffers() {
         let mut packets = PendingUidPackets::new(64);
         assert_eq!(packets.free_len(), PENDING_UID_POOL_CAPACITY);
-        let token = ripdpi_flow_app_attribution::note_flow(
+        let registration_id = ripdpi_flow_app_attribution::note_flow(
             17,
             "10.0.0.2:55800".parse().unwrap(),
             "203.0.113.1:443".parse().unwrap(),
         )
-        .token;
+        .registration_id;
         let captured_at = std::time::Instant::now();
 
         for byte in 0..=PENDING_UID_CAPACITY {
-            assert!(packets.retain(&[byte as u8; 32], token.clone(), captured_at).is_stored());
+            assert!(packets.retain(&[byte as u8; 32], registration_id, captured_at).is_stored());
         }
         assert_eq!(packets.len(), PENDING_UID_CAPACITY);
         assert_eq!(packets.free_len(), 1);
@@ -872,9 +872,16 @@ mod tests {
         let allocation = packet.bytes.as_ptr();
         packets.recycle(packet);
         assert_eq!(packets.free_len(), 2);
-        assert!(packets.retain(&[7; 32], token, captured_at).is_stored());
+        assert!(packets.retain(&[7; 32], registration_id, captured_at).is_stored());
         assert_eq!(packets.back_ptr(), Some(allocation), "retention must reuse a preallocated buffer");
         assert_eq!(packets.free_len() + packets.len(), PENDING_UID_POOL_CAPACITY);
+        drop(packets);
+        assert_eq!(
+            ripdpi_flow_app_attribution::lookup_registered_flow_uid(&registration_id),
+            ripdpi_flow_app_attribution::FlowUidLookup::Pending,
+            "discarding packet references must not unregister their live flow"
+        );
+        assert!(ripdpi_flow_app_attribution::evict_flow_if_current(registration_id));
     }
 
     #[test]

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/phases/tests/uid_admission.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/phases/tests/uid_admission.rs
@@ -38,14 +38,14 @@ async fn queued_packet_cannot_borrow_reused_tuple_uid_generation() {
     };
     route_tun_packet(&packet, &mut state);
     let original = ripdpi_flow_app_attribution::note_flow(request.protocol, request.local, request.remote);
-    ripdpi_flow_app_attribution::evict_flow(original.token);
+    ripdpi_flow_app_attribution::evict_flow_if_current(original.registration_id);
     let replacement = ripdpi_flow_app_attribution::note_flow(request.protocol, request.local, request.remote);
     let job = ripdpi_flow_app_attribution::take_pending_request(request).expect("replacement job");
     ripdpi_flow_app_attribution::store_uid_resolution(&job, Some(10_123));
     retry_pending_uid_packets(&mut state);
     assert!(seen.lock().expect("seen packets").is_empty(), "old packet must not inherit a new owner's UID");
     assert!(state.pending_uid_packets.is_empty());
-    ripdpi_flow_app_attribution::evict_flow(replacement.token);
+    ripdpi_flow_app_attribution::evict_flow_if_current(replacement.registration_id);
     state.shutdown().await;
 }
 
@@ -139,19 +139,19 @@ fn expired_pending_packet_cannot_reach_raw_egress() {
     let mut state = test_loop_state(Box::new(RecordingEgressHandler::new(true, Arc::clone(&seen))));
     state.runtime.uid_policy = crate::uid_policy::UidFlowPolicy::enforcing(HashSet::from([10_123]));
     let packet = ipv4_udp_packet(55_627, 443, b"expired-uid-packet");
-    let token = ripdpi_flow_app_attribution::note_flow(
+    let registration_id = ripdpi_flow_app_attribution::note_flow(
         crate::uid_policy::PROTO_UDP,
         "10.0.0.2:55627".parse().expect("local"),
         "93.184.216.34:443".parse().expect("remote"),
     )
-    .token;
-    let job = ripdpi_flow_app_attribution::take_pending_request(token.request()).expect("UID job");
+    .registration_id;
+    let job = ripdpi_flow_app_attribution::take_pending_request(registration_id.request()).expect("UID job");
     ripdpi_flow_app_attribution::store_uid_resolution(&job, Some(10_123));
-    state.pending_uid_packets.retain(&packet, token.clone(), std::time::Instant::now() - Duration::from_secs(6));
+    state.pending_uid_packets.retain(&packet, registration_id, std::time::Instant::now() - Duration::from_secs(6));
     retry_pending_uid_packets(&mut state);
     assert!(seen.lock().expect("seen packets").is_empty());
     assert!(state.pending_uid_packets.is_empty());
-    ripdpi_flow_app_attribution::evict_flow(token);
+    ripdpi_flow_app_attribution::evict_flow_if_current(registration_id);
 }
 
 /// # Cancel safety:
@@ -167,8 +167,16 @@ async fn pending_source_cannot_steal_an_allowed_syn_to_the_same_destination() {
         1,
         "allowed source must own the accepted socket, even when a prior UID is pending"
     );
-    let request =
-        state.sessions.iter_mut().next().expect("session").1.attribution_token.as_ref().expect("token").request();
+    let request = state
+        .sessions
+        .iter_mut()
+        .next()
+        .expect("session")
+        .1
+        .attribution_id
+        .as_ref()
+        .expect("registration_id")
+        .request();
     assert_eq!(request.local.port(), 55_641);
     assert_eq!(state.pending_listens.len(), 1, "the unresolved source still owns its lookup");
     state.shutdown().await;
@@ -219,14 +227,14 @@ fn establish_allowed_tcp(state: &mut LoopState, port: u16) {
 async fn consumed_repeated_syn_cannot_acquire_active_session_attribution() {
     let mut state = tcp_test_loop();
     establish_allowed_tcp(&mut state, 55_642);
-    let token = state.sessions.iter_mut().next().expect("session").1.attribution_token.clone().expect("token");
+    let registration_id = state.sessions.iter_mut().next().expect("session").1.attribution_id.expect("registration_id");
     state.runtime.tun_egress_interceptor =
         Box::new(RecordingEgressHandler::new(true, Arc::new(Mutex::new(Vec::new()))));
     let syn = build_ipv4_tcp_syn_packet(Ipv4Addr::new(10, 0, 0, 2), Ipv4Addr::new(93, 184, 216, 34), 55_642, 443);
     route_tun_packet(&syn, &mut state);
     gc_stale_pending_listens(&mut state.pending_listens, &mut state.socket_set, Duration::ZERO);
     assert_eq!(
-        ripdpi_flow_app_attribution::lookup_registered_flow_uid(&token),
+        ripdpi_flow_app_attribution::lookup_registered_flow_uid(&registration_id),
         ripdpi_flow_app_attribution::FlowUidLookup::Resolved(Some(10_123)),
         "an intercepted retransmission must not evict the active session's UID owner"
     );
@@ -253,7 +261,7 @@ fn pending_three_cycle_reconciles_before_gc() {
     for (key, listener) in &state.pending_listens {
         let tcp = state.socket_set.get::<TcpSocket>(listener.handle);
         assert_eq!(tcp.remote_endpoint().map(endpoint_to_socketaddr), Some(key.src));
-        assert_eq!(listener.attribution_token().request().local, key.src);
+        assert_eq!(listener.attribution_id().request().local, key.src);
     }
     let oldest =
         TcpFlowKey { src: SocketAddr::new(source.into(), 55_643), dst: SocketAddr::new(destination.into(), 443) };

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/routing.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/routing.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use ripdpi_flow_app_attribution::FlowAttributionToken;
+use ripdpi_flow_app_attribution::FlowRegistrationId;
 
 use crate::IpClass;
 use crate::classify::classify_ip_packet_with_parse_status;
@@ -22,7 +22,7 @@ pub(in crate::io_loop) fn route_tun_packet(packet: &[u8], state: &mut LoopState)
     route_tun_packet_inner(packet, state, None);
 }
 
-fn route_tun_packet_inner(packet: &[u8], state: &mut LoopState, pending: Option<(&FlowAttributionToken, Instant)>) {
+fn route_tun_packet_inner(packet: &[u8], state: &mut LoopState, pending: Option<(&FlowRegistrationId, Instant)>) {
     let (ip_class, parsed_ip) = classify_ip_packet_with_parse_status(packet, state.runtime.mapdns_classify);
     if !parsed_ip {
         state.stats.record_tun_parse_failure();
@@ -47,23 +47,23 @@ fn route_tun_packet_inner(packet: &[u8], state: &mut LoopState, pending: Option<
                 // Allocate a parked listener before queuing UID work. It owns
                 // the generation, but no unadmitted bytes reach smoltcp.
                 ensure_pending_listen_for_syn(packet, &mut state.pending_listens, &mut state.socket_set);
-                let token = pending.map_or_else(
+                let registration_id = pending.map_or_else(
                     || {
                         state.pending_listens.get(&key).map_or_else(
-                            || ripdpi_flow_app_attribution::note_flow(PROTO_TCP, src, dst).token,
-                            |listener| listener.attribution_token().clone(),
+                            || ripdpi_flow_app_attribution::note_flow(PROTO_TCP, src, dst).registration_id,
+                            |listener| *listener.attribution_id(),
                         )
                     },
-                    |(token, _)| token.clone(),
+                    |(registration_id, _)| *registration_id,
                 );
-                match state.runtime.uid_policy.admit_token(&token) {
+                match state.runtime.uid_policy.admit_registration(&registration_id) {
                     Verdict::Pending => {
-                        retain_pending_uid_packet(packet, state, token, pending.map(|(_, time)| time));
+                        retain_pending_uid_packet(packet, state, registration_id, pending.map(|(_, time)| time));
                         return;
                     }
                     Verdict::ResetTcp | Verdict::DropUdp => {
                         retire_denied_tcp_flow(state, key);
-                        ripdpi_flow_app_attribution::evict_flow(token);
+                        ripdpi_flow_app_attribution::evict_flow_if_current(registration_id);
                         state.stats.record_tun_policy_drop();
                         if let Some(reset) = build_tcp_reset(packet) {
                             state.device.tx_queue.push_back(reset);
@@ -73,10 +73,16 @@ fn route_tun_packet_inner(packet: &[u8], state: &mut LoopState, pending: Option<
                     Verdict::Allow => {}
                 }
                 if intercept_packet(packet, state) {
-                    if !state.pending_listens.get(&key).is_some_and(|listener| listener.attribution_token() == &token)
-                        && !state.sessions.iter_mut().any(|(_, entry)| entry.attribution_token.as_ref() == Some(&token))
+                    if !state
+                        .pending_listens
+                        .get(&key)
+                        .is_some_and(|listener| listener.attribution_id() == &registration_id)
+                        && !state
+                            .sessions
+                            .iter_mut()
+                            .any(|(_, entry)| entry.attribution_id.as_ref() == Some(&registration_id))
                     {
-                        ripdpi_flow_app_attribution::evict_flow(token);
+                        ripdpi_flow_app_attribution::evict_flow_if_current(registration_id);
                     }
                     return;
                 }
@@ -92,13 +98,13 @@ fn route_tun_packet_inner(packet: &[u8], state: &mut LoopState, pending: Option<
         }
         IpClass::UdpDns { src, dst, payload } => {
             if state.runtime.uid_policy.is_enforcing() {
-                let token = pending.map_or_else(
+                let registration_id = pending.map_or_else(
                     || ripdpi_flow_app_attribution::request_uid_admission(PROTO_UDP, src, dst),
-                    |(token, _)| token.clone(),
+                    |(registration_id, _)| *registration_id,
                 );
-                match state.runtime.uid_policy.admit_token(&token) {
+                match state.runtime.uid_policy.admit_registration(&registration_id) {
                     Verdict::Pending => {
-                        retain_pending_uid_packet(packet, state, token, pending.map(|(_, time)| time));
+                        retain_pending_uid_packet(packet, state, registration_id, pending.map(|(_, time)| time));
                         return;
                     }
                     Verdict::DropUdp | Verdict::ResetTcp => {
@@ -134,17 +140,17 @@ fn route_tun_packet_inner(packet: &[u8], state: &mut LoopState, pending: Option<
             if !state.runtime.uid_policy.is_enforcing() && intercept_packet(packet, state) {
                 return;
             }
-            let token = pending.map_or_else(
-                || ripdpi_flow_app_attribution::note_flow(PROTO_UDP, src, dst).token,
-                |(token, _)| token.clone(),
+            let registration_id = pending.map_or_else(
+                || ripdpi_flow_app_attribution::note_flow(PROTO_UDP, src, dst).registration_id,
+                |(registration_id, _)| *registration_id,
             );
-            match state.runtime.uid_policy.admit_token(&token) {
+            match state.runtime.uid_policy.admit_registration(&registration_id) {
                 Verdict::Pending => {
-                    retain_pending_uid_packet(packet, state, token, pending.map(|(_, time)| time));
+                    retain_pending_uid_packet(packet, state, registration_id, pending.map(|(_, time)| time));
                     return;
                 }
                 Verdict::DropUdp | Verdict::ResetTcp => {
-                    ripdpi_flow_app_attribution::evict_flow(token);
+                    ripdpi_flow_app_attribution::evict_flow_if_current(registration_id);
                     state.stats.record_tun_policy_drop();
                     return;
                 }
@@ -152,7 +158,7 @@ fn route_tun_packet_inner(packet: &[u8], state: &mut LoopState, pending: Option<
             }
             // A raw hook can send even when it does not consume the packet.
             if state.runtime.uid_policy.is_enforcing() && intercept_packet(packet, state) {
-                release_unowned_udp_attribution(&state.udp_associations, src, token);
+                release_unowned_udp_attribution(&state.udp_associations, src, registration_id);
                 return;
             }
             state.stats.record_dht_trigger_destination(dst);
@@ -189,7 +195,7 @@ fn route_tun_packet_inner(packet: &[u8], state: &mut LoopState, pending: Option<
                     &state.cancel,
                     &state.udp_tx,
                     &state.stats,
-                    token,
+                    registration_id,
                 );
             }
         }
@@ -201,8 +207,8 @@ fn retire_denied_tcp_flow(state: &mut LoopState, key: TcpFlowKey) {
         state.socket_set.remove(listener.handle);
     }
     let handle = state.sessions.iter_mut().find_map(|(handle, entry)| {
-        entry.attribution_token.as_ref().and_then(|token| {
-            let request = token.request();
+        entry.attribution_id.as_ref().and_then(|registration_id| {
+            let request = registration_id.request();
             (request.local == key.src && request.remote == key.dst).then_some(handle)
         })
     });
@@ -222,10 +228,10 @@ fn intercept_packet(packet: &[u8], state: &mut LoopState) -> bool {
 fn retain_pending_uid_packet(
     packet: &[u8],
     state: &mut LoopState,
-    token: FlowAttributionToken,
+    registration_id: FlowRegistrationId,
     captured_at: Option<Instant>,
 ) {
-    match state.pending_uid_packets.retain(packet, token, captured_at.unwrap_or_else(Instant::now)) {
+    match state.pending_uid_packets.retain(packet, registration_id, captured_at.unwrap_or_else(Instant::now)) {
         PendingUidRetainOutcome::Stored => {}
         PendingUidRetainOutcome::EvictedOldest | PendingUidRetainOutcome::Rejected => {
             state.stats.record_tun_queue_drop();
@@ -250,13 +256,13 @@ pub(in crate::io_loop) fn retry_pending_uid_packets(state: &mut LoopState) {
         };
         if packet.expired()
             || matches!(
-                ripdpi_flow_app_attribution::lookup_registered_flow_uid(&packet.token),
+                ripdpi_flow_app_attribution::lookup_registered_flow_uid(&packet.registration_id),
                 ripdpi_flow_app_attribution::FlowUidLookup::Missing
             )
         {
             state.stats.record_tun_policy_drop();
         } else {
-            route_tun_packet_inner(&packet.bytes, state, Some((&packet.token, packet.captured_at)));
+            route_tun_packet_inner(&packet.bytes, state, Some((&packet.registration_id, packet.captured_at)));
         }
         state.pending_uid_packets.recycle(packet);
     }

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/state/pending_uid.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/state/pending_uid.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
-use ripdpi_flow_app_attribution::FlowAttributionToken;
+use ripdpi_flow_app_attribution::FlowRegistrationId;
 
 pub(in crate::io_loop) const PENDING_UID_CAPACITY: usize = 256;
 pub(in crate::io_loop) const PENDING_UID_POOL_CAPACITY: usize = PENDING_UID_CAPACITY + 1;
@@ -9,7 +9,8 @@ const PENDING_UID_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(crate) struct PendingUidPacket {
     pub(crate) bytes: Vec<u8>,
-    pub(crate) token: FlowAttributionToken,
+    // The TCP listener/session or UID cache owns the lifetime, not this queued packet.
+    pub(crate) registration_id: FlowRegistrationId,
     pub(crate) captured_at: Instant,
 }
 
@@ -48,7 +49,7 @@ impl PendingUidPackets {
     pub(in crate::io_loop) fn retain(
         &mut self,
         packet: &[u8],
-        token: FlowAttributionToken,
+        registration_id: FlowRegistrationId,
         captured_at: Instant,
     ) -> PendingUidRetainOutcome {
         if packet.len() > self.packet_capacity {
@@ -61,7 +62,7 @@ impl PendingUidPackets {
         };
         buffer.clear();
         buffer.extend_from_slice(packet);
-        self.queued.push_back(PendingUidPacket { bytes: buffer, token, captured_at });
+        self.queued.push_back(PendingUidPacket { bytes: buffer, registration_id, captured_at });
         if evicted_oldest { PendingUidRetainOutcome::EvictedOldest } else { PendingUidRetainOutcome::Stored }
     }
 

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/tcp_accept/admission/collect.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/tcp_accept/admission/collect.rs
@@ -50,7 +50,7 @@ pub(super) fn collect_admissible_sessions(
     let listeners = pending_listener_batch(pending_listens, admission_cursor, TCP_ADMISSION_WORK_BUDGET);
     for listener in listeners {
         let handle = listener.handle;
-        let token = listener.attribution_token();
+        let registration_id = listener.attribution_id();
         let tcp = socket_set.get_mut::<TcpSocket>(handle);
         if !tcp.may_send() || sessions.contains(handle) {
             continue;
@@ -69,7 +69,7 @@ pub(super) fn collect_admissible_sessions(
                 handle,
                 tcp,
                 AdmissionTarget { resolved: target, synthetic_ip: None, dns_intercept: true },
-                token,
+                registration_id,
                 inputs.uid_policy,
                 &mut new_sessions,
                 &mut unresolvable,
@@ -82,7 +82,7 @@ pub(super) fn collect_admissible_sessions(
                     handle,
                     tcp,
                     AdmissionTarget { resolved: target, synthetic_ip, dns_intercept: false },
-                    token,
+                    registration_id,
                     inputs.uid_policy,
                     &mut new_sessions,
                     &mut unresolvable,
@@ -101,7 +101,7 @@ fn collect_resolved_session(
     handle: SocketHandle,
     tcp: &mut TcpSocket<'_>,
     target: AdmissionTarget,
-    token: &ripdpi_flow_app_attribution::FlowAttributionToken,
+    registration_id: &ripdpi_flow_app_attribution::FlowRegistrationId,
     uid_policy: &UidFlowPolicy,
     new_sessions: &mut Vec<PendingTcpSession>,
     unresolvable: &mut Vec<SocketHandle>,
@@ -110,7 +110,7 @@ fn collect_resolved_session(
     let ResolvedMappedTarget { addr: target_addr, host: target_host } = resolved;
     // The registration belongs to this exact pre-handshake listener. Never
     // create a fresh generation at admission after its original lookup expired.
-    let request = token.request();
+    let request = registration_id.request();
     if tcp.remote_endpoint().map(endpoint_to_socketaddr) != Some(request.local)
         || tcp_target_endpoint(tcp) != Some(request.remote)
     {
@@ -118,7 +118,7 @@ fn collect_resolved_session(
         unresolvable.push(handle);
         return;
     }
-    match uid_policy.admit_token(token) {
+    match uid_policy.admit_registration(registration_id) {
         Verdict::Allow => {
             new_sessions.push(PendingTcpSession { handle, target_addr, target_host, synthetic_ip, dns_intercept });
         }

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/tcp_accept/admission/session.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/tcp_accept/admission/session.rs
@@ -41,7 +41,7 @@ pub(super) fn admit_session(
     let Some(mut listener) = remove_pending_listen(pending_listens, pending.handle) else {
         return;
     };
-    let attribution_token = listener.take_attribution();
+    let attribution_id = listener.take_attribution();
     pin_synthetic_ip(dns_cache, pending.synthetic_ip);
 
     let target = pending.target_host.as_ref().map_or(TargetAddr::Ip(pending.target_addr), |host| {
@@ -69,7 +69,7 @@ pub(super) fn admit_session(
         pending_to_smoltcp: Vec::new(),
         upstream_closed: false,
         pinned_synthetic_ip: pending.synthetic_ip,
-        attribution_token: Some(attribution_token),
+        attribution_id: Some(attribution_id),
     };
     let evicted = sessions.insert(pending.handle, entry);
     if let Some((_, Some(ip))) = evicted

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/tcp_accept/listener.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/tcp_accept/listener.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
-use std::time::Instant as StdInstant;
 
-use ripdpi_flow_app_attribution::FlowAttributionToken;
-use smoltcp::iface::{SocketHandle, SocketSet};
+use smoltcp::iface::SocketSet;
 use smoltcp::socket::AnySocket;
 use smoltcp::socket::tcp::{self, Socket as TcpSocket};
 use tracing::{debug, warn};
@@ -14,45 +12,13 @@ use super::eviction::evict_oldest_pending_listen;
 use super::socketaddr_to_listen_endpoint;
 
 mod maintenance;
+mod pending;
 
 pub(crate) use maintenance::{gc_stale_pending_listens, reconcile_pending_listeners};
+pub(crate) use pending::PendingListener;
 
 /// Each pending TCP socket owns two `TCP_SOCKET_BUF` allocations. Keep the half-open handshake budget at roughly 16 MiB on Android.
 const MAX_PENDING_LISTENS: usize = 128;
-
-pub(crate) struct PendingListener {
-    pub(crate) handle: SocketHandle,
-    pub(crate) created_at: StdInstant,
-    attribution: PendingAttribution,
-}
-
-/// The listener owns the registration until admission transfers it to a session.
-struct PendingAttribution(Option<FlowAttributionToken>);
-
-impl Drop for PendingAttribution {
-    fn drop(&mut self) {
-        if let Some(token) = self.0.take() {
-            ripdpi_flow_app_attribution::evict_flow(token);
-        }
-    }
-}
-
-impl PendingListener {
-    pub(crate) fn new(handle: SocketHandle, key: TcpFlowKey) -> Self {
-        let token = ripdpi_flow_app_attribution::note_flow(crate::uid_policy::PROTO_TCP, key.src, key.dst).token;
-        Self { handle, created_at: StdInstant::now(), attribution: PendingAttribution(Some(token)) }
-    }
-
-    pub(crate) fn attribution_token(&self) -> &FlowAttributionToken {
-        // Infallible: only admission takes the token, after removing this listener from the pending map.
-        self.attribution.0.as_ref().expect("pending listener owns its attribution")
-    }
-
-    pub(crate) fn take_attribution(&mut self) -> FlowAttributionToken {
-        // Infallible: admission removes the unique listener and calls this exactly once before dropping it.
-        self.attribution.0.take().expect("attribution transfers once at admission")
-    }
-}
 
 pub(crate) fn ensure_pending_listen_for_syn(
     pkt: &[u8],

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/tcp_accept/listener/pending.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/tcp_accept/listener/pending.rs
@@ -2,7 +2,7 @@
 
 use std::time::Instant as StdInstant;
 
-use ripdpi_flow_app_attribution::FlowAttributionToken;
+use ripdpi_flow_app_attribution::FlowRegistrationId;
 use smoltcp::iface::SocketHandle;
 
 use crate::io_loop::packet::TcpFlowKey;
@@ -14,28 +14,29 @@ pub(crate) struct PendingListener {
 }
 
 /// The listener owns the registration until admission transfers it to a session.
-struct PendingAttribution(Option<FlowAttributionToken>);
+struct PendingAttribution(Option<FlowRegistrationId>);
 
 impl Drop for PendingAttribution {
     fn drop(&mut self) {
-        if let Some(token) = self.0.take() {
-            ripdpi_flow_app_attribution::evict_flow(token);
+        if let Some(registration_id) = self.0.take() {
+            ripdpi_flow_app_attribution::evict_flow_if_current(registration_id);
         }
     }
 }
 
 impl PendingListener {
     pub(crate) fn new(handle: SocketHandle, key: TcpFlowKey) -> Self {
-        let token = ripdpi_flow_app_attribution::note_flow(crate::uid_policy::PROTO_TCP, key.src, key.dst).token;
-        Self { handle, created_at: StdInstant::now(), attribution: PendingAttribution(Some(token)) }
+        let registration_id =
+            ripdpi_flow_app_attribution::note_flow(crate::uid_policy::PROTO_TCP, key.src, key.dst).registration_id;
+        Self { handle, created_at: StdInstant::now(), attribution: PendingAttribution(Some(registration_id)) }
     }
 
-    pub(crate) fn attribution_token(&self) -> &FlowAttributionToken {
-        // Infallible: only admission takes the token, after removing this listener from the pending map.
+    pub(crate) fn attribution_id(&self) -> &FlowRegistrationId {
+        // Infallible: only admission takes the registration ID, after removing this listener from the pending map.
         self.attribution.0.as_ref().expect("pending listener owns its attribution")
     }
 
-    pub(crate) fn take_attribution(&mut self) -> FlowAttributionToken {
+    pub(crate) fn take_attribution(&mut self) -> FlowRegistrationId {
         // Infallible: admission removes the unique listener and calls this exactly once before dropping it.
         self.attribution.0.take().expect("attribution transfers once at admission")
     }

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/tcp_accept/listener/pending.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/tcp_accept/listener/pending.rs
@@ -1,0 +1,42 @@
+//! Ownership of a pending listener and its flow-attribution generation.
+
+use std::time::Instant as StdInstant;
+
+use ripdpi_flow_app_attribution::FlowAttributionToken;
+use smoltcp::iface::SocketHandle;
+
+use crate::io_loop::packet::TcpFlowKey;
+
+pub(crate) struct PendingListener {
+    pub(crate) handle: SocketHandle,
+    pub(crate) created_at: StdInstant,
+    attribution: PendingAttribution,
+}
+
+/// The listener owns the registration until admission transfers it to a session.
+struct PendingAttribution(Option<FlowAttributionToken>);
+
+impl Drop for PendingAttribution {
+    fn drop(&mut self) {
+        if let Some(token) = self.0.take() {
+            ripdpi_flow_app_attribution::evict_flow(token);
+        }
+    }
+}
+
+impl PendingListener {
+    pub(crate) fn new(handle: SocketHandle, key: TcpFlowKey) -> Self {
+        let token = ripdpi_flow_app_attribution::note_flow(crate::uid_policy::PROTO_TCP, key.src, key.dst).token;
+        Self { handle, created_at: StdInstant::now(), attribution: PendingAttribution(Some(token)) }
+    }
+
+    pub(crate) fn attribution_token(&self) -> &FlowAttributionToken {
+        // Infallible: only admission takes the token, after removing this listener from the pending map.
+        self.attribution.0.as_ref().expect("pending listener owns its attribution")
+    }
+
+    pub(crate) fn take_attribution(&mut self) -> FlowAttributionToken {
+        // Infallible: admission removes the unique listener and calls this exactly once before dropping it.
+        self.attribution.0.take().expect("attribution transfers once at admission")
+    }
+}

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc.rs
@@ -19,12 +19,11 @@ mod tests;
 pub(crate) fn release_unowned_udp_attribution(
     associations: &std::collections::HashMap<std::net::SocketAddr, UdpAssociation>,
     src: std::net::SocketAddr,
-    token: ripdpi_flow_app_attribution::FlowAttributionToken,
+    registration_id: ripdpi_flow_app_attribution::FlowRegistrationId,
 ) {
-    if !associations
-        .get(&src)
-        .is_some_and(|association| association.attribution_tokens.peek(&token.request()) == Some(&token))
-    {
-        ripdpi_flow_app_attribution::evict_flow(token);
+    if !associations.get(&src).is_some_and(|association| {
+        association.attribution_ids.peek(&registration_id.request()) == Some(&registration_id)
+    }) {
+        ripdpi_flow_app_attribution::evict_flow_if_current(registration_id);
     }
 }

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/association_removal.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/association_removal.rs
@@ -17,8 +17,8 @@ pub(super) fn remove_association(
                 cache.unpin(ip);
             }
         }
-        for (_request, token) in association.attribution_tokens {
-            ripdpi_flow_app_attribution::evict_flow(token);
+        for (_request, registration_id) in association.attribution_ids {
+            ripdpi_flow_app_attribution::evict_flow_if_current(registration_id);
         }
     }
 }

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/association_state.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/association_state.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::AtomicU64;
 use lru::LruCache;
 use tokio_util::sync::CancellationToken;
 
-use ripdpi_flow_app_attribution::{FlowAttributionToken, FlowResolveRequest};
+use ripdpi_flow_app_attribution::{FlowRegistrationId, FlowResolveRequest};
 
 mod activity;
 mod datagram;
@@ -18,7 +18,7 @@ pub(super) const UDP_OUTBOUND_QUEUE_CAPACITY: usize = 16;
 
 // At most 512 associations retain 32,768 tuple leases in total. Removing a lease
 // only forces a fresh UID lookup; it never grants admission to an unknown flow.
-pub(crate) const UDP_ATTRIBUTION_TOKEN_CAPACITY: NonZeroUsize = match NonZeroUsize::new(64) {
+pub(crate) const UDP_ATTRIBUTION_ID_CAPACITY: NonZeroUsize = match NonZeroUsize::new(64) {
     Some(capacity) => capacity,
     // Infallible: the literal capacity 64 is non-zero.
     None => panic!("UDP attribution capacity must be non-zero"),
@@ -35,5 +35,5 @@ pub(in crate::io_loop) struct UdpAssociation {
     /// one cache lease until association removal or shutdown.
     pub(super) leased_synthetic_ips: HashSet<u32>,
     /// One current generation per exact tuple, bounded independently of association lifetime.
-    pub(super) attribution_tokens: LruCache<FlowResolveRequest, FlowAttributionToken>,
+    pub(super) attribution_ids: LruCache<FlowResolveRequest, FlowRegistrationId>,
 }

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/forwarding/delivery.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/forwarding/delivery.rs
@@ -81,7 +81,7 @@ pub(super) fn deliver_udp_datagram(
                 udp_tx,
                 stats,
             );
-            lease_udp_attribution(associations, src, replacement.token);
+            lease_udp_attribution(associations, src, replacement.registration_id);
             lease_udp_mapping(associations, dns_cache, src, synthetic_ip);
             if let Some(association) = associations.get(&src) {
                 if association.outbound.try_send(datagram).is_err() {

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/forwarding/dispatch.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/forwarding/dispatch.rs
@@ -38,7 +38,7 @@ pub(in crate::io_loop) fn forward_udp_payload(
     cancel: &CancellationToken,
     udp_tx: &tokio::sync::mpsc::Sender<UdpEvent>,
     stats: &Arc<Stats>,
-    admitted_token: ripdpi_flow_app_attribution::FlowAttributionToken,
+    admitted_id: ripdpi_flow_app_attribution::FlowRegistrationId,
 ) {
     // The routing boundary admitted this exact packet before invoking raw hooks.
     // Do not resolve again: cache churn must not replay an already-admitted packet.
@@ -60,7 +60,7 @@ pub(in crate::io_loop) fn forward_udp_payload(
         stats,
     );
 
-    lease_udp_attribution(associations, src, admitted_token);
+    lease_udp_attribution(associations, src, admitted_id);
     lease_udp_mapping(associations, dns_cache, src, synthetic_ip);
 
     deliver_udp_datagram(

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/forwarding/leases.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/forwarding/leases.rs
@@ -8,17 +8,17 @@ use super::super::association_state::UdpAssociation;
 pub(super) fn lease_udp_attribution(
     associations: &mut HashMap<SocketAddr, UdpAssociation>,
     src: SocketAddr,
-    token: ripdpi_flow_app_attribution::FlowAttributionToken,
+    registration_id: ripdpi_flow_app_attribution::FlowRegistrationId,
 ) {
     if let Some(association) = associations.get_mut(&src) {
-        let request = token.request();
+        let request = registration_id.request();
         // Repeated packets may carry the same identity. Refresh its LRU position
         // without evicting the registration still owned by this association.
-        if association.attribution_tokens.get(&request) == Some(&token) {
+        if association.attribution_ids.get(&request) == Some(&registration_id) {
             return;
         }
-        if let Some((_request, removed)) = association.attribution_tokens.push(request, token) {
-            let _ = ripdpi_flow_app_attribution::evict_flow(removed);
+        if let Some((_request, removed)) = association.attribution_ids.push(request, registration_id) {
+            let _ = ripdpi_flow_app_attribution::evict_flow_if_current(removed);
         }
     }
 }
@@ -52,10 +52,10 @@ mod tests {
             let dst = SocketAddr::new("198.51.100.221".parse().expect("destination"), port);
             for _ in 0..2 {
                 let observation = ripdpi_flow_app_attribution::note_flow(17, src, dst);
-                lease_udp_attribution(&mut associations, src, observation.token);
+                lease_udp_attribution(&mut associations, src, observation.registration_id);
                 // Simulate expiry/LRU removal while the multiplexed association remains live.
                 let cleanup = ripdpi_flow_app_attribution::note_flow(17, src, dst);
-                assert!(ripdpi_flow_app_attribution::evict_flow(cleanup.token));
+                assert!(ripdpi_flow_app_attribution::evict_flow_if_current(cleanup.registration_id));
             }
         }
         let retained = finish_association(&mut associations, src).await;
@@ -68,10 +68,24 @@ mod tests {
         let src: SocketAddr = "192.0.2.222:53192".parse().expect("source");
         let dst: SocketAddr = "198.51.100.222:40000".parse().expect("destination");
         let mut associations = HashMap::from([(src, test_association())]);
-        lease_udp_attribution(&mut associations, src, ripdpi_flow_app_attribution::note_flow(17, src, dst).token);
-        assert!(ripdpi_flow_app_attribution::evict_flow(ripdpi_flow_app_attribution::note_flow(17, src, dst).token));
-        lease_udp_attribution(&mut associations, src, ripdpi_flow_app_attribution::note_flow(17, src, dst).token);
-        lease_udp_attribution(&mut associations, src, ripdpi_flow_app_attribution::note_flow(17, src, dst).token);
+        lease_udp_attribution(
+            &mut associations,
+            src,
+            ripdpi_flow_app_attribution::note_flow(17, src, dst).registration_id,
+        );
+        assert!(ripdpi_flow_app_attribution::evict_flow_if_current(
+            ripdpi_flow_app_attribution::note_flow(17, src, dst).registration_id
+        ));
+        lease_udp_attribution(
+            &mut associations,
+            src,
+            ripdpi_flow_app_attribution::note_flow(17, src, dst).registration_id,
+        );
+        lease_udp_attribution(
+            &mut associations,
+            src,
+            ripdpi_flow_app_attribution::note_flow(17, src, dst).registration_id,
+        );
         let current = ripdpi_flow_app_attribution::lookup_flow_uid(17, src, dst);
         let retained = finish_association(&mut associations, src).await;
         assert_eq!(retained, 1, "one tuple owns only its latest generation");
@@ -92,18 +106,18 @@ mod tests {
             lease_udp_attribution(
                 &mut associations,
                 src,
-                ripdpi_flow_app_attribution::note_flow(17, src, destination(port)).token,
+                ripdpi_flow_app_attribution::note_flow(17, src, destination(port)).registration_id,
             );
         }
         lease_udp_attribution(
             &mut associations,
             src,
-            ripdpi_flow_app_attribution::note_flow(17, src, destination(40_000)).token,
+            ripdpi_flow_app_attribution::note_flow(17, src, destination(40_000)).registration_id,
         );
         lease_udp_attribution(
             &mut associations,
             src,
-            ripdpi_flow_app_attribution::note_flow(17, src, destination(40_064)).token,
+            ripdpi_flow_app_attribution::note_flow(17, src, destination(40_064)).registration_id,
         );
         let oldest = ripdpi_flow_app_attribution::lookup_flow_uid(17, src, destination(40_001));
         let refreshed = ripdpi_flow_app_attribution::lookup_flow_uid(17, src, destination(40_000));
@@ -125,8 +139,8 @@ mod tests {
             last_activity: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
             worker: tokio::spawn(std::future::pending()),
             leased_synthetic_ips: std::collections::HashSet::new(),
-            attribution_tokens: lru::LruCache::new(
-                crate::io_loop::udp_assoc::association_state::UDP_ATTRIBUTION_TOKEN_CAPACITY,
+            attribution_ids: lru::LruCache::new(
+                crate::io_loop::udp_assoc::association_state::UDP_ATTRIBUTION_ID_CAPACITY,
             ),
         }
     }
@@ -135,9 +149,9 @@ mod tests {
     /// The worker is aborted before awaiting its join; tokens are synchronously released first.
     async fn finish_association(associations: &mut HashMap<SocketAddr, UdpAssociation>, src: SocketAddr) -> usize {
         let association = associations.remove(&src).expect("association remains live");
-        let retained = association.attribution_tokens.len();
-        for (_, token) in association.attribution_tokens {
-            let _ = ripdpi_flow_app_attribution::evict_flow(token);
+        let retained = association.attribution_ids.len();
+        for (_, registration_id) in association.attribution_ids {
+            let _ = ripdpi_flow_app_attribution::evict_flow_if_current(registration_id);
         }
         association.worker.abort();
         assert!(association.worker.await.expect_err("worker aborted").is_cancelled());

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/shutdown.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/shutdown.rs
@@ -17,8 +17,8 @@ pub(in crate::io_loop) fn take_udp_association_tasks(
                 cache.unpin(ip);
             }
         }
-        for (_request, token) in association.attribution_tokens {
-            ripdpi_flow_app_attribution::evict_flow(token);
+        for (_request, registration_id) in association.attribution_ids {
+            ripdpi_flow_app_attribution::evict_flow_if_current(registration_id);
         }
         tasks.push(association.worker);
     }

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/tests.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/tests.rs
@@ -54,7 +54,7 @@ fn stalled_udp_association(
         last_activity: Arc::new(AtomicU64::new(now_millis())),
         worker,
         leased_synthetic_ips: std::collections::HashSet::new(),
-        attribution_tokens: lru::LruCache::new(super::association_state::UDP_ATTRIBUTION_TOKEN_CAPACITY),
+        attribution_ids: lru::LruCache::new(super::association_state::UDP_ATTRIBUTION_ID_CAPACITY),
     };
     (association, alive, started_rx)
 }
@@ -395,7 +395,7 @@ async fn udp_forwarding_budget_rejection_records_queue_drop_evidence() {
         last_activity: Arc::new(AtomicU64::new(now_millis())),
         worker: tokio::spawn(std::future::pending()),
         leased_synthetic_ips: std::collections::HashSet::new(),
-        attribution_tokens: lru::LruCache::new(super::association_state::UDP_ATTRIBUTION_TOKEN_CAPACITY),
+        attribution_ids: lru::LruCache::new(super::association_state::UDP_ATTRIBUTION_ID_CAPACITY),
     };
     let mut associations = HashMap::from([(src, association)]);
     let mut eviction_heap = BoundedHeap::new(4);
@@ -424,7 +424,7 @@ async fn udp_forwarding_budget_rejection_records_queue_drop_evidence() {
         &CancellationToken::new(),
         &udp_tx,
         &stats,
-        ripdpi_flow_app_attribution::note_flow(crate::uid_policy::PROTO_UDP, src, dst).token,
+        ripdpi_flow_app_attribution::note_flow(crate::uid_policy::PROTO_UDP, src, dst).registration_id,
     );
 
     assert_eq!(stats.tun_forwarding_evidence_snapshot().tun_queue_drops, 1);
@@ -451,7 +451,7 @@ async fn udp_forwarding_full_association_channel_records_queue_drop_evidence() {
         last_activity: Arc::new(AtomicU64::new(now_millis())),
         worker: tokio::spawn(std::future::pending()),
         leased_synthetic_ips: std::collections::HashSet::new(),
-        attribution_tokens: lru::LruCache::new(super::association_state::UDP_ATTRIBUTION_TOKEN_CAPACITY),
+        attribution_ids: lru::LruCache::new(super::association_state::UDP_ATTRIBUTION_ID_CAPACITY),
     };
     let mut associations = HashMap::from([(src, association)]);
     let mut eviction_heap = BoundedHeap::new(4);
@@ -478,7 +478,7 @@ async fn udp_forwarding_full_association_channel_records_queue_drop_evidence() {
         &CancellationToken::new(),
         &udp_tx,
         &stats,
-        ripdpi_flow_app_attribution::note_flow(crate::uid_policy::PROTO_UDP, src, dst).token,
+        ripdpi_flow_app_attribution::note_flow(crate::uid_policy::PROTO_UDP, src, dst).registration_id,
     );
 
     assert_eq!(stats.tun_forwarding_evidence_snapshot().tun_queue_drops, 1);

--- a/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/worker.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/io_loop/udp_assoc/worker.rs
@@ -12,7 +12,7 @@ use crate::session::udp::UdpMemoryBudget;
 mod spawn;
 
 use super::association_state::{
-    OutboundDatagram, UDP_ATTRIBUTION_TOKEN_CAPACITY, UDP_OUTBOUND_QUEUE_CAPACITY, UdpAssociation, now_millis,
+    OutboundDatagram, UDP_ATTRIBUTION_ID_CAPACITY, UDP_OUTBOUND_QUEUE_CAPACITY, UdpAssociation, now_millis,
 };
 use super::event_handling::UdpEvent;
 use spawn::{UdpWorkerConfig, spawn_udp_worker};
@@ -65,6 +65,6 @@ pub(super) fn spawn_udp_association(
         last_activity,
         worker,
         leased_synthetic_ips: HashSet::new(),
-        attribution_tokens: LruCache::new(UDP_ATTRIBUTION_TOKEN_CAPACITY),
+        attribution_ids: LruCache::new(UDP_ATTRIBUTION_ID_CAPACITY),
     }
 }

--- a/native/rust/crates/ripdpi-tunnel-core/src/sessions.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/sessions.rs
@@ -27,7 +27,7 @@ pub struct SessionEntry {
     /// for the duration of this session, if any. Unpinned when the session ends.
     pub pinned_synthetic_ip: Option<u32>,
     /// Exact generation-stamped attribution registration released on close.
-    pub attribution_token: Option<ripdpi_flow_app_attribution::FlowAttributionToken>,
+    pub attribution_id: Option<ripdpi_flow_app_attribution::FlowRegistrationId>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -83,8 +83,8 @@ impl ActiveSessions {
                 self.sequences.remove(&evicted.handle);
                 self.entries.remove(&evicted.handle).map(|oldest| {
                     oldest.cancel.cancel();
-                    if let Some(token) = oldest.attribution_token {
-                        ripdpi_flow_app_attribution::evict_flow(token);
+                    if let Some(registration_id) = oldest.attribution_id {
+                        ripdpi_flow_app_attribution::evict_flow_if_current(registration_id);
                     }
                     drop(oldest.smoltcp_side);
                     oldest.handle.abort();
@@ -189,7 +189,7 @@ mod tests {
             pending_to_smoltcp: Vec::new(),
             upstream_closed: false,
             pinned_synthetic_ip: None,
-            attribution_token: None,
+            attribution_id: None,
         };
         (entry, child)
     }

--- a/native/rust/crates/ripdpi-tunnel-core/src/uid_policy.rs
+++ b/native/rust/crates/ripdpi-tunnel-core/src/uid_policy.rs
@@ -178,13 +178,16 @@ impl UidFlowPolicy {
     }
 
     /// Admit a captured packet against its original registration generation.
-    pub(crate) fn admit_token(&self, token: &ripdpi_flow_app_attribution::FlowAttributionToken) -> Verdict {
+    pub(crate) fn admit_registration(
+        &self,
+        registration_id: &ripdpi_flow_app_attribution::FlowRegistrationId,
+    ) -> Verdict {
         if !self.is_enforcing() {
             return Verdict::Allow;
         }
         use ripdpi_flow_app_attribution::FlowUidLookup;
-        let protocol = token.request().protocol;
-        match ripdpi_flow_app_attribution::lookup_registered_flow_uid(token) {
+        let protocol = registration_id.request().protocol;
+        match ripdpi_flow_app_attribution::lookup_registered_flow_uid(registration_id) {
             FlowUidLookup::Missing => Verdict::deny_for(protocol),
             FlowUidLookup::Pending => Verdict::Pending,
             FlowUidLookup::Resolved(Some(uid)) => self.evaluate(uid, protocol),


### PR DESCRIPTION
## Changes

Three separate fixes for reproduced baseline CI failures on main:

- Extract pending TCP listener ownership without changing hotspot budgets.
- Assert the exact automatic DNS candidate matrix, including Cloudflare exclusion; explicit user-selected targets remain supported.
- Represent flow registration identity as a copyable, non-owning `FlowRegistrationId`, with explicit generation-checked cleanup by lifetime containers. Update all callers; leave the separate JNI session-generation API unchanged.

No unsafe allowlist, quality baseline, runtime wire version, or contract mirror changes. This prerequisite is separate from the remaining June audit work and unblocks the schema-only #451 integration sequence.

## Observed local validation on this branch

- Attribution and tunnel-core: 339 passed, 1 existing skip; all-target Clippy with warnings denied passed.
- Full diagnostics unit suite: 1408 passed, no failures or skips; ktlint passed.
- Unsafe boundary guard and native hotspot budgets passed unchanged.
- Architecture: 23 existing indicators, 0 new, 0 worsened; locked Cargo metadata: 114 members.
- Task contracts: 46 tasks / 221 steps valid.
- Regression evidence: original DNS tests failed 2/11 before the test correction; new registration API test failed to compile before implementation.

Hosted CI remains required. The separate baseline Robolectric artifact-fetch failure did not reproduce locally; this PR does not claim that external fetch failure is fixed. No device, deployment, or release acceptance is claimed.
