### PR TITLE
fix(ci): unblock mux streams and bound emulator cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,10 @@ jobs:
             scripts.tests.test_run_android_e2e_emulator \
             scripts.tests.test_start_local_network_fixture
 
+      - name: Test bounded Android emulator diagnostics and teardown
+        timeout-minutes: 2
+        run: timeout --kill-after=2 30 bash scripts/ci/test-android-emulator-helpers.sh
+
   design-md-lint:
     needs: change-routing
     if: github.event_name != 'schedule' && (needs.change-routing.outputs.run_full_ci == 'true' || needs.change-routing.outputs.run_android_ci == 'true' || needs.change-routing.outputs.run_rust_native_ci == 'true')
@@ -2319,6 +2323,7 @@ jobs:
           cp -R app/build/outputs/androidTest-results/connected/debug/flavors/githubFull/. "$evidence_dir/"
 
       - name: Capture Android instrumented-test emulator diagnostics
+        timeout-minutes: 3
         if: always()
         run: |
           bash scripts/ci/capture-android-emulator-diagnostics.sh \
@@ -2331,6 +2336,7 @@ jobs:
           artifact-name: build-observability-android-instrumented-${{ matrix.device }}
 
       - name: Stop ${{ matrix.device }} emulator
+        timeout-minutes: 1
         if: always()
         run: bash scripts/ci/stop-android-emulator.sh --avd "${{ matrix.device }}"
 
@@ -2755,6 +2761,7 @@ jobs:
         run: bash scripts/ci/run-android-journeys-emulator.sh
 
       - name: Capture journeys emulator diagnostics
+        timeout-minutes: 3
         if: always()
         run: |
           bash scripts/ci/capture-android-emulator-diagnostics.sh \
@@ -2768,6 +2775,7 @@ jobs:
           artifact-name: build-observability-android-journeys
 
       - name: Stop emulator
+        timeout-minutes: 1
         if: always()
         run: bash scripts/ci/stop-android-emulator.sh --avd journeys
 
@@ -2840,6 +2848,7 @@ jobs:
         run: bash scripts/ci/run-android-relay-emulator-smoke.sh
 
       - name: Capture relay smoke emulator diagnostics
+        timeout-minutes: 3
         if: always()
         run: |
           bash scripts/ci/capture-android-emulator-diagnostics.sh \
@@ -2853,6 +2862,7 @@ jobs:
           artifact-name: build-observability-android-relay-smoke
 
       - name: Stop emulator
+        timeout-minutes: 1
         if: always()
         run: bash scripts/ci/stop-android-emulator.sh --avd relay-smoke
 

--- a/app/src/androidTest/kotlin/com/poyka/ripdpi/integration/ServiceLifecycleIntegrationTest.kt
+++ b/app/src/androidTest/kotlin/com/poyka/ripdpi/integration/ServiceLifecycleIntegrationTest.kt
@@ -589,6 +589,8 @@ class ServiceLifecycleIntegrationTest {
             awaitFailure(Sender.VPN)
             awaitStatus(AppStatus.Halted, Mode.VPN)
             awaitVpnSessionClosed()
+            // TUN closes before the composed runtime finishes stopping its upstream proxy.
+            awaitProxyStopCount(1)
 
             assertEquals(1, IntegrationTestOverrides.tun2SocksBridgeFactory.bridge.stopCount)
             assertEquals(1, IntegrationTestOverrides.proxyFactory.lastRuntime.stopCount)

--- a/native/rust/crates/local-network-fixture/src/lib.rs
+++ b/native/rust/crates/local-network-fixture/src/lib.rs
@@ -619,7 +619,8 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(udp_reply[4], udp_reply[5], udp_reply[6], udp_reply[7])),
             u16::from_be_bytes([udp_reply[8], udp_reply[9]]),
         );
-        assert_eq!(relay_addr.port(), stack.manifest().socks5_port);
+        assert_eq!(relay_addr.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert_ne!(relay_addr.port(), 0);
 
         let udp_client = UdpSocket::bind((DEFAULT_BIND_HOST, 0)).expect("bind udp client");
         udp_client.set_read_timeout(Some(Duration::from_secs(1))).expect("set udp timeout");

--- a/native/rust/crates/local-network-fixture/src/socks.rs
+++ b/native/rust/crates/local-network-fixture/src/socks.rs
@@ -18,9 +18,9 @@ pub(crate) fn start_socks5_server(
     faults: FaultController,
 ) -> io::Result<(JoinHandle<()>, u16)> {
     let listener = TcpListener::bind((config.bind_host.as_str(), config.socks5_port))?;
+    let (listener, udp_socket) = bind_udp_relay_socket(&config, listener)?;
     listener.set_nonblocking(true)?;
     let local_port = listener.local_addr()?.port();
-    let udp_socket = UdpSocket::bind((config.bind_host.as_str(), local_port))?;
     udp_socket.set_read_timeout(Some(IO_TIMEOUT))?;
     let udp_local = udp_socket.local_addr()?;
     let advertised_udp_relay = advertised_udp_relay_addr(udp_local, &config.android_host)?;
@@ -221,6 +221,13 @@ pub(crate) fn start_socks5_server(
     ))
 }
 
+fn bind_udp_relay_socket(config: &FixtureConfig, listener: TcpListener) -> io::Result<(TcpListener, UdpSocket)> {
+    // A dynamic TCP port does not reserve the same number for UDP.
+    // Keep explicit ports strict; advertise the separately bound UDP endpoint.
+    let udp_socket = UdpSocket::bind((config.bind_host.as_str(), config.socks5_port))?;
+    Ok((listener, udp_socket))
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum SocksTarget {
     Socket(SocketAddr),
@@ -415,5 +422,49 @@ pub(crate) fn decode_socks5_udp_frame(frame: &[u8]) -> Result<(SocketAddr, Vec<u
             Ok((SocketAddr::new(IpAddr::from(raw), u16::from_be_bytes([frame[20], frame[21]])), frame[22..].to_vec()))
         }
         atyp => Err(io::Error::new(ErrorKind::InvalidData, format!("SOCKS5 UDP atyp unsupported: {atyp}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reserve_tcp_and_udp_port() -> (TcpListener, UdpSocket) {
+        for _ in 0..32 {
+            let tcp = TcpListener::bind((crate::types::DEFAULT_BIND_HOST, 0)).expect("bind TCP candidate");
+            let address = tcp.local_addr().expect("TCP candidate address");
+            match UdpSocket::bind(address) {
+                Ok(udp) => return (tcp, udp),
+                Err(error) if error.kind() == ErrorKind::AddrInUse => continue,
+                Err(error) => panic!("reserve UDP candidate: {error}"),
+            }
+        }
+        panic!("could not reserve a TCP/UDP port pair after 32 candidates");
+    }
+
+    #[test]
+    fn dynamic_udp_relay_does_not_reuse_occupied_tcp_listener_port() {
+        let (listener, occupied_udp) = reserve_tcp_and_udp_port();
+        let tcp_address = listener.local_addr().expect("TCP listener address");
+        let config = FixtureConfig { socks5_port: 0, ..FixtureConfig::default() };
+
+        let (listener, relay) = bind_udp_relay_socket(&config, listener).expect("independent ephemeral UDP relay");
+
+        assert_eq!(listener.local_addr().unwrap(), tcp_address);
+        assert_ne!(relay.local_addr().unwrap().port(), occupied_udp.local_addr().unwrap().port());
+        assert_ne!(relay.local_addr().unwrap().port(), 0);
+    }
+
+    #[test]
+    fn fixed_udp_relay_port_remains_strict_when_occupied() {
+        let (listener, _occupied_udp) = reserve_tcp_and_udp_port();
+        let config = FixtureConfig {
+            socks5_port: listener.local_addr().expect("TCP listener address").port(),
+            ..FixtureConfig::default()
+        };
+
+        let result = bind_udp_relay_socket(&config, listener);
+
+        assert!(matches!(result, Err(error) if error.kind() == ErrorKind::AddrInUse));
     }
 }

--- a/native/rust/crates/ripdpi-relay-core/src/tests.rs
+++ b/native/rust/crates/ripdpi-relay-core/src/tests.rs
@@ -393,16 +393,25 @@ async fn vless_reality_mux_interleaves_three_streams_over_one_carrier() {
 
     let backend = build_backend(&config).await.expect("build VLESS Reality mux backend");
     let target = RelayTargetAddr::Ip(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), fixture.target_port()));
-    let (first, second, third) =
-        tokio::join!(backend.connect_tcp(&target), backend.connect_tcp(&target), backend.connect_tcp(&target));
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    // Cancel safety: a timeout fails this test and drops all streams, backend
+    // and fixture; partially exchanged protocol state is never reused.
+    let (first, second, third) = tokio::time::timeout_at(deadline, async {
+        tokio::join!(backend.connect_tcp(&target), backend.connect_tcp(&target), backend.connect_tcp(&target))
+    })
+    .await
+    .expect("three VLESS mux streams did not open before the deadline");
     let (mut first, mut second, mut third) = (
         first.expect("open first mux stream"),
         second.expect("open second mux stream"),
         third.expect("open third mux stream"),
     );
 
-    let (first_write, second_write, third_write) =
-        tokio::join!(first.write_all(b"one"), second.write_all(b"two"), third.write_all(b"tri"),);
+    let (first_write, second_write, third_write) = tokio::time::timeout_at(deadline, async {
+        tokio::join!(first.write_all(b"one"), second.write_all(b"two"), third.write_all(b"tri"))
+    })
+    .await
+    .expect("VLESS mux payload writes stalled");
     first_write.expect("write first");
     second_write.expect("write second");
     third_write.expect("write third");
@@ -410,11 +419,15 @@ async fn vless_reality_mux_interleaves_three_streams_over_one_carrier() {
     let mut first_reply = [0u8; 3];
     let mut second_reply = [0u8; 3];
     let mut third_reply = [0u8; 3];
-    let (first_read, second_read, third_read) = tokio::join!(
-        first.read_exact(&mut first_reply),
-        second.read_exact(&mut second_reply),
-        third.read_exact(&mut third_reply),
-    );
+    let (first_read, second_read, third_read) = tokio::time::timeout_at(deadline, async {
+        tokio::join!(
+            first.read_exact(&mut first_reply),
+            second.read_exact(&mut second_reply),
+            third.read_exact(&mut third_reply),
+        )
+    })
+    .await
+    .expect("VLESS mux replies stalled");
     first_read.expect("read first");
     second_read.expect("read second");
     third_read.expect("read third");

--- a/native/rust/crates/ripdpi-vless/src/yamux_session.rs
+++ b/native/rust/crates/ripdpi-vless/src/yamux_session.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use futures::future::poll_fn;
 use futures::io::AsyncWriteExt as FuturesAsyncWriteExt;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::sync::Notify;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 
 use crate::AsyncIo;
@@ -29,6 +30,7 @@ impl Drop for AbortOnDrop {
 pub struct VlessYamuxSession {
     connection: Arc<Mutex<Connection>>,
     closed: Arc<AtomicBool>,
+    driver_notify: Arc<Notify>,
     _driver_guard: Arc<AbortOnDrop>,
 }
 
@@ -41,11 +43,21 @@ impl VlessYamuxSession {
         carrier.flush().await?;
         let connection = Arc::new(Mutex::new(yamux::Connection::new(carrier, config, yamux::Mode::Client)));
         let closed = Arc::new(AtomicBool::new(false));
+        let driver_notify = Arc::new(Notify::new());
         let driver_connection = Arc::clone(&connection);
         let driver_closed = Arc::clone(&closed);
+        let driver_wake = Arc::clone(&driver_notify);
         let driver = tokio::spawn(async move {
             loop {
-                let next = poll_fn(|cx| lock_connection(&driver_connection).poll_next_inbound(cx)).await;
+                // Cancel safety: `poll_next_inbound` owns protocol state inside
+                // the shared yamux connection. If `notified()` wins this
+                // select, the next loop iteration polls the same connection
+                // again without discarding an external future or stream state.
+                let next = tokio::select! {
+                    biased;
+                    _ = driver_wake.notified() => continue,
+                    next = poll_fn(|cx| lock_connection(&driver_connection).poll_next_inbound(cx)) => next,
+                };
                 match next {
                     Some(Ok(_)) => {
                         // Client VLESS mux sessions do not accept peer-opened
@@ -59,7 +71,7 @@ impl VlessYamuxSession {
                 }
             }
         });
-        Ok(Self { connection, closed, _driver_guard: Arc::new(AbortOnDrop(driver)) })
+        Ok(Self { connection, closed, driver_notify, _driver_guard: Arc::new(AbortOnDrop(driver)) })
     }
 
     /// Opens a TCP stream and completes the sing-mux stream request before
@@ -74,11 +86,17 @@ impl VlessYamuxSession {
         if self.is_closed() {
             return Err(io::Error::new(io::ErrorKind::ConnectionAborted, "VLESS mux carrier closed"));
         }
+        let request = crate::mux::encode_tcp_stream_request(destination)?;
         let stream = poll_fn(|cx| lock_connection(&self.connection).poll_new_outbound(cx)).await.map_err(|error| {
             io::Error::new(io::ErrorKind::ConnectionAborted, format!("VLESS mux carrier closed: {error}"))
         })?;
+        // `yamux::Connection` must be polled after `poll_new_outbound` pushes
+        // the new stream command receiver. The driver can otherwise stay
+        // asleep on the previous receiver set while this stream's first write
+        // waits for connection progress.
+        self.driver_notify.notify_one();
         let mut stream = stream.compat();
-        stream.write_all(&crate::mux::encode_tcp_stream_request(destination)?).await?;
+        stream.write_all(&request).await?;
         stream.flush().await?;
         crate::mux::read_stream_response(&mut stream).await?;
         Ok(stream)
@@ -114,7 +132,7 @@ mod tests {
 
     use super::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::sync::oneshot;
+    use tokio::sync::{oneshot, watch};
     use tokio_util::compat::TokioAsyncReadCompatExt;
 
     struct DropTrackedIo {
@@ -249,6 +267,69 @@ mod tests {
         assert_eq!(first_reply, *b"one");
         assert_eq!(second_reply, *b"two");
         assert_eq!(third_reply, *b"tri");
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn later_stream_open_wakes_driver_after_existing_streams_are_idle() {
+        let (client, mut server) = tokio::io::duplex(64 * 1024);
+        let (release_tx, release_rx) = watch::channel(false);
+        let server_task = tokio::spawn(async move {
+            let mut preamble = [0u8; 2];
+            server.read_exact(&mut preamble).await.unwrap();
+            assert_eq!(preamble, crate::mux::encode_session_request());
+
+            let connection = Arc::new(Mutex::new(yamux::Connection::new(
+                server.compat(),
+                yamux::Config::default(),
+                yamux::Mode::Server,
+            )));
+            let mut workers = Vec::new();
+            for _ in 0..3 {
+                let mut release_rx = release_rx.clone();
+                let stream = poll_fn(|cx| lock_connection(&connection).poll_next_inbound(cx))
+                    .await
+                    .expect("carrier stays open")
+                    .expect("valid inbound yamux stream");
+                workers.push(tokio::spawn(async move {
+                    let mut stream = stream.compat();
+                    read_stream_request(&mut stream).await;
+                    stream.write_all(&[0]).await.unwrap();
+                    stream.flush().await.unwrap();
+                    release_rx.wait_for(|released| *released).await.unwrap();
+                }));
+            }
+            let driver_connection = Arc::clone(&connection);
+            let driver = tokio::spawn(async move {
+                while let Some(result) = poll_fn(|cx| lock_connection(&driver_connection).poll_next_inbound(cx)).await {
+                    if result.is_err() {
+                        break;
+                    }
+                }
+            });
+            for worker in workers {
+                worker.await.unwrap();
+            }
+            driver.abort();
+        });
+
+        let session = VlessYamuxSession::establish(Box::new(client), 3).await.unwrap();
+        let first = tokio::time::timeout(Duration::from_secs(1), session.open_stream("first.test:443"))
+            .await
+            .expect("first stream opens before deadline")
+            .expect("open first stream");
+        let second = tokio::time::timeout(Duration::from_secs(1), session.open_stream("second.test:443"))
+            .await
+            .expect("second stream opens before deadline")
+            .expect("open second stream");
+
+        let third = tokio::time::timeout(Duration::from_secs(1), session.open_stream("third.test:443"))
+            .await
+            .expect("later stream open must wake the yamux driver")
+            .expect("open third stream");
+
+        release_tx.send(true).unwrap();
+        drop((first, second, third));
         server_task.await.unwrap();
     }
 

--- a/scripts/ci/android-emulator-helpers.sh
+++ b/scripts/ci/android-emulator-helpers.sh
@@ -224,15 +224,24 @@ adb_cmd_timeout() {
   local adb_bin
   adb_bin="$(resolve_adb_bin)" || return 127
   if [[ -n "${ANDROID_SERIAL:-}" ]]; then
-    timeout "$timeout_seconds" "$adb_bin" -s "${ANDROID_SERIAL}" "$@"
+    timeout --kill-after=2 "$timeout_seconds" "$adb_bin" -s "${ANDROID_SERIAL}" "$@"
   else
-    timeout "$timeout_seconds" "$adb_bin" "$@"
+    timeout --kill-after=2 "$timeout_seconds" "$adb_bin" "$@"
   fi
+}
+
+adb_raw_timeout() {
+  local timeout_seconds="$1"
+  shift
+
+  local adb_bin
+  adb_bin="$(resolve_adb_bin)" || return 127
+  timeout --kill-after=2 "$timeout_seconds" "$adb_bin" "$@"
 }
 
 has_adb_device() {
   local state
-  state="$(adb_cmd get-state 2>/dev/null | tr -d '\r' || true)"
+  state="$(adb_cmd_timeout 5 get-state 2>/dev/null | tr -d '\r' || true)"
   [[ "$state" == "device" ]]
 }
 
@@ -279,14 +288,7 @@ capture_android_emulator_diagnostics() {
   : > "$output_dir/device-getprop.txt"
   : > "$output_dir/package-manager-health.txt"
 
-  adb_raw devices -l >"$output_dir/adb-devices.txt" 2>&1 || true
-
-  if has_adb_device; then
-    adb_cmd shell getprop >"$output_dir/device-getprop.txt" 2>&1 || true
-    adb_cmd shell pm path android >"$output_dir/package-manager-health.txt" 2>&1 || true
-    adb_cmd logcat -d >"$logcat_file" 2>&1 || true
-  fi
-
+  # Preserve host-side boot evidence before querying a potentially wedged ADB.
   if [[ -n "$avd_name" ]]; then
     if [[ -f "$HOME/.android/$avd_name/emulator.log" ]]; then
       cp "$HOME/.android/$avd_name/emulator.log" "$output_dir/emulator.log"
@@ -310,13 +312,21 @@ capture_android_emulator_diagnostics() {
     : > "$output_dir/avd-config.ini"
     : > "$output_dir/avdmanager-create.log"
   fi
+
+  adb_raw_timeout 10 devices -l >"$output_dir/adb-devices.txt" 2>&1 || true
+
+  if has_adb_device; then
+    adb_cmd_timeout 10 shell getprop >"$output_dir/device-getprop.txt" 2>&1 || true
+    adb_cmd_timeout 5 shell pm path android >"$output_dir/package-manager-health.txt" 2>&1 || true
+    adb_cmd_timeout 15 logcat -d >"$logcat_file" 2>&1 || true
+  fi
 }
 
 stop_android_emulator() {
   local avd_name="$1"
 
   if has_adb_device; then
-    adb_cmd emu kill >/dev/null 2>&1 || true
+    adb_cmd_timeout 5 emu kill >/dev/null 2>&1 || true
   fi
 
   pkill -f "emulator .* -avd ${avd_name}( |$)" >/dev/null 2>&1 || true

--- a/scripts/ci/test-android-emulator-helpers.sh
+++ b/scripts/ci/test-android-emulator-helpers.sh
@@ -82,4 +82,52 @@ actual="$(
 )"
 assert_equals "$mac_sdk/cmdline-tools/latest/bin/avdmanager" "$actual" "avdmanager should resolve from discovered macOS SDK"
 
+(
+  # Use the real timeout process supervisor, with short test deadlines. ADB
+  # deliberately ignores TERM so the escalation path is exercised as well.
+  real_timeout="$(command -v timeout)"
+  fake_adb="$tmpdir/wedged-adb"
+  export EMULATOR_TEST_TIMEOUT_LOG="$tmpdir/timeout-calls"
+  export EMULATOR_TEST_CONNECTED=false
+  : > "$EMULATOR_TEST_TIMEOUT_LOG"
+  cat > "$fake_adb" <<'ADB'
+#!/usr/bin/env bash
+if [[ "$*" == *get-state && "$EMULATOR_TEST_CONNECTED" == true ]]; then
+  echo device
+  exit 0
+fi
+trap '' TERM
+while :; do sleep 1; done
+ADB
+  chmod +x "$fake_adb"
+
+  resolve_adb_bin() { printf '%s\n' "$fake_adb"; }
+  timeout() {
+    [[ "$1" == --kill-after=2 ]] || { echo "ADB timeout lacks kill escalation" >&2; return 97; }
+    shift
+    [[ "$1" -gt 0 && "$1" -le 30 ]] || return 98
+    printf '%s\n' "$1" >> "$EMULATOR_TEST_TIMEOUT_LOG"
+    shift
+    "$real_timeout" --kill-after=0.1 1 "$@"
+  }
+  pkill() { printf '%s\n' "$*" > "$tmpdir/emulator-stop-fallback"; }
+
+  echo "Checking diagnostics with unresponsive ADB"
+  capture_android_emulator_diagnostics "$tmpdir/offline-diagnostics"
+  assert_equals 2 "$(wc -l < "$EMULATOR_TEST_TIMEOUT_LOG" | tr -d ' ')" "Offline ADB commands must be bounded"
+  for artifact in android-logcat.txt adb-devices.txt device-getprop.txt package-manager-health.txt emulator.log avd-config.ini avdmanager-create.log; do
+    [[ -f "$tmpdir/offline-diagnostics/$artifact" ]] || { echo "Missing diagnostic artifact: $artifact" >&2; exit 1; }
+  done
+
+  : > "$EMULATOR_TEST_TIMEOUT_LOG"
+  export EMULATOR_TEST_CONNECTED=true
+  capture_android_emulator_diagnostics "$tmpdir/connected-diagnostics"
+  assert_equals 5 "$(wc -l < "$EMULATOR_TEST_TIMEOUT_LOG" | tr -d ' ')" "Connected device diagnostics must all be bounded"
+
+  : > "$EMULATOR_TEST_TIMEOUT_LOG"
+  stop_android_emulator test-owned-avd
+  assert_equals 2 "$(wc -l < "$EMULATOR_TEST_TIMEOUT_LOG" | tr -d ' ')" "Emulator stop must bound get-state and emu kill"
+  [[ -s "$tmpdir/emulator-stop-fallback" ]] || { echo "Emulator stop did not reach its process fallback" >&2; exit 1; }
+)
+
 echo "Android emulator helper tests passed."


### PR DESCRIPTION
## Changes

- Wake the VLESS yamux connection driver immediately after allocating an outbound stream. The previous receiver set could leave the driver asleep while a later stream waited for its request/response handshake.
- Add a deterministic regression that holds existing streams open, and bound the existing three-stream Reality integration test so a regression reports a failure instead of exhausting the job timeout.
- Bound every emulator diagnostic/teardown ADB call, escalate when ADB ignores TERM, preserve host boot logs before querying ADB, and add step deadlines plus a wedged-ADB regression to CI.

- Allocate a separate ephemeral SOCKS UDP port when configured with port zero, preserving strict nonzero ports and advertising the actual UDP endpoint. This avoids assuming a TCP port allocation reserves that numeric UDP port. Regression setup retains both occupied sockets and tolerates only candidate-allocation contention.

## Verification

- Final full local Rust workspace on `63f8deb2d9b85af4814620edcc0da3210587856d`: **5278 passed, 32 existing skips** (no-fail-fast).

- Deterministic mux regression: observed timeout without the production fix; passes with the fix.
- Full local Rust workspace before rebase: 5276 passed, 32 existing skips. The first combined-tree run had 5275 passed and one fixture-start `AddrInUse` failure before HTTP behavior; the unchanged full retry passed all 5276 tests (32 existing skips). A separate review reproduced a TCP/UDP fixture port-allocation collision hazard; the third commit fixes that independently verified defect.
- Linux ARM64 affected packages: 109 VLESS tests passed; 178 relay-core tests passed, 1 existing ignored; 200/200 repeated three-stream Reality mux tests passed on the final patch.
- Wedged-ADB regression: observed outer timeout before the fix; passes after it, including TERM-resistant ADB.
- 78 combined-tree Python tests and 27 task/harness contract tests passed; actionlint, shell syntax, strict harness links, locked metadata, hotspot and architecture gates passed.
- Final fixture regression: observed `AddrInUse` with the old allocation algorithm, then 627 fixture/proxy-runtime/tunnel-core tests passed (8 existing skips), including the real SOCKS UDP roundtrip. Hotspot budget remains 404/407 production lines.
- Independent read-only review passed. Normal commit hooks used.

## Scope and remaining evidence

This is a narrow CI prerequisite follow-up to externally merged #452. It excludes the broader June audit, root-helper protocol changes, and contract mirrors. The old API 27 provisioning step failed before device tests ran; its precise boot error could not be retrieved. This change fixes the confirmed unbounded diagnostics/teardown path and preserves evidence for a subsequent provisioning failure; it does not claim a proven API 27 boot fix. Exact-head hosted CI must pass before normal protected integration. No gate, assertion, baseline or branch protection is weakened.
