### PR TITLE
chore(deps): nightly audit 2026-08-30

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -48,7 +48,7 @@ checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "zeroize",
 ]
 
@@ -230,7 +230,7 @@ checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
 dependencies = [
  "base64ct",
  "blake2 0.11.0-rc.6",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "password-hash",
 ]
 
@@ -615,7 +615,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq 0.4.2",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -851,7 +851,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cipher 0.5.2",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
  "zeroize",
 ]
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1366,7 +1366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto 0.3.0",
@@ -3384,7 +3384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -4627,7 +4627,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
 dependencies = [
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "universal-hash 0.6.1",
  "zeroize",
 ]
@@ -4651,7 +4651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "universal-hash 0.6.1",
 ]
 
@@ -7544,7 +7544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -7566,7 +7566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 


### PR DESCRIPTION
## Task contract

- Task ID: N/A — automated nightly dependency/security audit, not a portfolio task
- Task record: N/A
- OpenSpec change: N/A
- Spec-not-required reason: routine dependency-version maintenance with no behavior change

## Summary

Nightly dependency and security audit across the Rust Cargo workspace (`native/rust/`, 84 direct `[workspace.dependencies]` entries / ~90 member crates) and the Gradle version catalog (`gradle/libs.versions.toml`, ~40 checked entries). One safe, isolated patch bump is applied; everything else is reported below for human review.

## Applied

**Rust**
- `cpufeatures`: `0.3.0` → `0.3.1` (patch). Pure CPU-feature-detection utility (no crypto/network/async/FFI operations of its own — it only reads CPUID/`getauxval`). `cargo update -p cpufeatures@0.3.0 --precise 0.3.1` produced a clean, isolated `Cargo.lock` diff (only `cpufeatures` version/checksum lines changed across its dependents — no cascading bumps).

**Gradle**
- None. Every catalog entry checked against its upstream registry (Maven Central / Google Maven / Gradle Plugin Portal) is either already on the latest stable release or only has a minor/major bump available (see Needs review / Major below).

## Security

- **RUSTSEC-2023-0071** (`rsa`, "Marvin Attack" timing side-channel, severity 5.9/medium) — hits both `rsa 0.9.10` (via `arti-client` → `ssh-key-fork-arti`) and `rsa 0.10.0-rc.18` (via `russh`). Already tracked: ignored in `native/rust/deny.toml` with a waiver in `advisory-waivers.toml` (owner: Native security maintainer, expires 2026-11-02, tracking `docs/tasks/issues/unpin-russh-after-rsa-advisory-fix.md`). `cargo audit` confirms **no fixed upgrade is available upstream** on either path. Not resolved by this PR — no action possible yet.
- **RUSTSEC-2024-0436** (`paste 1.0.15`, unmaintained) — already waived (expires **2026-10-11**, the soonest of the three waivers — about 6 weeks out from this run). No maintained replacement exists yet. Flagging early so the waiver renewal isn't a surprise; no fixed upgrade available today.
- **RUSTSEC-2025-0141** (`bincode 2.0.1`, unmaintained) — `cargo audit` still flags this against the current lockfile, but `cargo deny check advisories` reports its `deny.toml` ignore rule as `advisory-not-detected` ("no crate matched advisory criteria"), i.e. cargo-deny's advisory-db snapshot no longer matches `bincode 2.0.1` the way the ignore entry expects. Waiver expires 2026-11-02. Worth a human check on whether the `deny.toml`/`advisory-waivers.toml` entry is now stale (crate resolved away under different criteria) or this is just a transient db-sync difference between the two tools — not urgent either way since it's an unmaintained-only warning, not a vulnerability.
- **Yanked crate:** `chacha20 0.10.0` (and `0.10.1`) are yanked from crates.io; `0.10.2` is available and un-yanked. Pulled in transitively via `chacha20poly1305` (`ripdpi-mieru`, `ripdpi-shadowsocks`). This is a crypto-primitive crate, so per this project's own policy (crypto changes are never auto-applied, "regardless of semver level") it is **withheld** here despite being a trivial, low-risk lockfile-only patch — see Needs review. Recommend prioritizing this one since it clears a yanked-crate warning, not just a version bump.

## Needs review

Withheld because they touch crypto, networking, async runtime, or JNI/FFI-adjacent surfaces (regardless of semver level), or because they are minor-version bumps, or because attempting them produced an unexpectedly wide diff:

**Rust — crypto**
- `chacha20`: `0.10.0` → `0.10.2` (patch; fixes the yanked-crate warning above)
- `aes`: `0.9.2` → `0.9.3` (patch)
- `rcgen`: `0.14.9` → `0.14.10` (patch; certificate generation)
- `blake2` (transitive RC instance): `0.11.0-rc.6` → `0.11.0` (RC→stable; part of the already-documented "Known RC-crypto exposure" cluster pinned by `russh`'s graph — bundle with the `russh` review below rather than bumping alone)

**Rust — networking**
- `hyper`: `1.11.0` → `1.11.1` (patch)

**Rust — FFI-adjacent**
- `mlua`: `0.12.0` → `0.12.1` (patch; embeds the Lua VM for `ripdpi-strategy-lua`)

**Rust — exact-pinned by repo policy (Renovate `enabled: false`, never auto-bump)**
- `russh`: `0.62.7` → `0.63.1` (minor). Exact-pinned for the documented RC-crypto exposure; do not bump without following `docs/tasks/issues/unpin-russh-after-rsa-advisory-fix.md`.
- `boring` / `tokio-boring`: `5.1.0` → `5.2.0` (minor, both). Exact-pinned because `reality_hook.rs` hand-declares 6 BoringSSL symbols against this exact build — see `docs/design/reality-boringssl-patch.md`. A transitive bump here is exactly what the pin guards against.

**Rust — attempted, withheld (unexpectedly wide cascade)**
- `flate2`: `1.1.9` → `1.1.10` (patch on its face). Resolving it also bumps `miniz_oxide` `0.8.9` → `0.9.1` (minor) and **adds a brand-new transitive crate, `zlib-rs 0.6.7`**, to the dependency graph. That's a bigger shape-of-the-tree change than "patch bump" implies, so it's held for a human to confirm the new backend is acceptable.
- `fs-mistrust`: `0.15.0` → `0.15.1` (patch on its face; Arti/Tor filesystem-permission checker, not itself crypto/net/async/FFI). Resolving it cascades much further than expected via Cargo's cross-graph version unification: it **shifts the resolved `getrandom` line from `0.4.3` to `0.3.4`** for the affected subtree (a crypto/RNG-adjacent crate), bumps `thiserror` `1.0.69` → `2.0.20` for `pwd-grp`, and moves `windows-sys` `0.52.0`/`0.59.0` → `0.60.2` across roughly a dozen unrelated crates. Withheld given the `getrandom` line change.

**Rust — minor, Tor stack (bump together)**
- `arti-client`: `0.44.0` → `0.45.0`
- `tor-rtcompat`: `0.44.0` → `0.45.0`

**Gradle — minor**
- `androidx-navigation-compose`: `2.9.8` → `2.10.0`
- `androidx-glance` (`glance-appwidget`/`glance-material3`): `1.1.1` → `1.2.0`
- `roborazzi`/`roborazzi-compose`: `1.72.0` → `1.73.0` (test tooling only)

**Gradle — JNI-adjacent (withheld regardless of semver level)**
- `zstd-jni`: `1.5.7-15` → `1.5.7-16`. Ships native per-ABI compression bindings, so it falls under the JNI/FFI-adjacent sensitive category even though the delta looks like a patch/build bump.

## Major

None found. Every one of the 84 directly-declared `native/rust/Cargo.toml` `[workspace.dependencies]` entries and every checked `gradle/libs.versions.toml` entry (AGP 9.3.2, Kotlin 2.4.10, Gradle wrapper 9.7.1, Compose BOM 2026.08.00, Room 2.8.4, Hilt 2.60.1, KSP 2.3.11, detekt 1.23.8, ktlint-gradle 14.2.0, coroutines 1.11.0, protobuf 4.36.0, grpc 1.83.1, and ~25 other AndroidX/test/tooling entries) already sits on its latest stable release, or the only newer release available is minor (listed above).

One transitive-only note for awareness, not actionable directly: a broad `cargo update` shows the `idna`/`url` dependency chain is able to move the whole `icu4x` crate family (`icu_collections`, `icu_normalizer`, `icu_properties`, `icu_provider`, `litemap`, `yoke`, `zerovec`, …) from its 1.x line to 2.x, restructuring several sub-crates in the process. None of these are direct workspace dependencies, so there's no single targeted edit to make here; flagging only so a future `cargo update` isn't a surprise.

## Conflicts

- No static cross-module version conflicts found on the Gradle side: every dependency and plugin version in this repo is declared exactly once in `gradle/libs.versions.toml` via `version.ref`, and a repo-wide search for inline Maven coordinate versions in `build.gradle.kts` files outside the catalog found none (the one `version = "1.0"` hit, in `quality/detekt-rules/build.gradle.kts`, is that module's own artifact version, not a dependency pin).
- Full transitive-vs-declared conflict detection (`./gradlew :module:dependencies` / `dependencyInsight`) could **not** be run in this sandbox: no Android SDK is installed (`ANDROID_HOME` unset, no `local.properties`, no `/opt/android-sdk`). `./gradlew help` gets past buildscript/plugin resolution cleanly and fails specifically at `SdkLocator` for the Android modules, confirming the SDK is the only blocker. Recommend this check run in CI or a dev box with the SDK — this PR cannot rule out transitive-vs-declared divergences beyond the static catalog check above.
- Rust: `cargo deny check bans` (`multiple-versions = "warn"`) reports **bans ok** — the `cpufeatures` bump applied here introduces no new duplicate-version violations.

## Evidence

```
cd native/rust
cargo deny --locked check advisories   # advisories ok (+ yanked/waiver warnings, see Security)
cargo audit --file Cargo.lock          # 2 vulnerabilities (waived), 3 warnings (waived + yanked)
cargo update --dry-run                 # full compatible-update survey (not applied wholesale)
cargo update -p cpufeatures@0.3.0 --precise 0.3.1
cargo check --workspace --locked       # Finished, no errors
cargo deny --locked check              # advisories ok, bans ok, licenses ok, sources ok
```

Direct-dependency version comparison for all 84 `[workspace.dependencies]` entries was done against crates.io's published version list (max stable semver, not "most recently published"). Gradle catalog entries were checked against Google Maven / Maven Central / Gradle Plugin Portal `maven-metadata.xml`.

## Checklist

- [ ] `just task-check` — N/A, no portfolio task for this automated run
- [x] No work is marked complete without its required evidence (see Evidence above)
- [x] No baseline files extended (detekt, lint, LoC)
- [ ] `timeout-minutes` added to any new CI job — N/A, no CI changes
- [x] Native ABI matrix not broken — no cross-compilation-affecting change; `cpufeatures` is a pure-Rust crate with no ABI/symbol surface, verified via `cargo check --workspace` on host
- [x] Non-rooted device path still works — N/A, no runtime behavior change
- [ ] mdtask PolyForm Shield internal-tool use is owner/legal-approved — N/A, `tools/tasking` untouched


---
_Generated by [Claude Code](https://claude.ai/code/session_01T4DrMc8p87HcPvt2d2yegu)_