### PR TITLE
fix(runtime): preserve terminal event ownership

### DIFF
--- a/app/src/androidTest/kotlin/com/poyka/ripdpi/integration/IntegrationServiceLifecycleSupport.kt
+++ b/app/src/androidTest/kotlin/com/poyka/ripdpi/integration/IntegrationServiceLifecycleSupport.kt
@@ -8,6 +8,7 @@ import com.poyka.ripdpi.core.Tun2SocksBridgeFactory
 import com.poyka.ripdpi.data.AppSettingsRepository
 import com.poyka.ripdpi.data.AppStatus
 import com.poyka.ripdpi.data.Mode
+import com.poyka.ripdpi.data.OrderedServiceStateStore
 import com.poyka.ripdpi.data.ServiceStateStore
 import com.poyka.ripdpi.data.stopAction
 import com.poyka.ripdpi.services.AcceptedUserStopRecorder
@@ -32,7 +33,7 @@ internal data class ServiceLifecycleIntegrationBindings(
     val proxyPreferencesResolver: ProxyPreferencesResolver,
     val proxyFactory: RipDpiProxyFactory,
     val tun2SocksBridgeFactory: Tun2SocksBridgeFactory,
-    val serviceStateStore: ServiceStateStore,
+    val serviceStateStore: OrderedServiceStateStore,
     val vpnTunnelSessionProvider: VpnTunnelSessionProvider,
     val networkHandoverMonitor: RecordingNetworkHandoverMonitor,
     val permissionWatchdog: RecordingPermissionWatchdog,

--- a/app/src/androidTest/kotlin/com/poyka/ripdpi/integration/MainActivityNavigationInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/com/poyka/ripdpi/integration/MainActivityNavigationInstrumentedTest.kt
@@ -26,6 +26,7 @@ import com.poyka.ripdpi.core.Tun2SocksBridgeFactory
 import com.poyka.ripdpi.core.Tun2SocksBridgeFactoryModule
 import com.poyka.ripdpi.data.AppSettingsRepository
 import com.poyka.ripdpi.data.AppSettingsRepositoryModule
+import com.poyka.ripdpi.data.OrderedServiceStateStore
 import com.poyka.ripdpi.data.ServiceStateStore
 import com.poyka.ripdpi.data.ServiceStateStoreModule
 import com.poyka.ripdpi.diagnostics.BypassApproachId
@@ -254,7 +255,11 @@ class MainActivityNavigationInstrumentedTest {
 
     @BindValue
     @JvmField
-    var serviceStateStore: ServiceStateStore = FakeInstrumentedServiceStateStore()
+    var serviceStateStore: OrderedServiceStateStore = FakeInstrumentedServiceStateStore()
+
+    @BindValue
+    @JvmField
+    var serviceStateStoreContract: ServiceStateStore = serviceStateStore
 
     @BindValue
     @JvmField
@@ -595,7 +600,11 @@ class MainActivityOnboardingStartupInstrumentedTest {
 
     @BindValue
     @JvmField
-    var serviceStateStore: ServiceStateStore = FakeInstrumentedServiceStateStore()
+    var serviceStateStore: OrderedServiceStateStore = FakeInstrumentedServiceStateStore()
+
+    @BindValue
+    @JvmField
+    var serviceStateStoreContract: ServiceStateStore = serviceStateStore
 
     @BindValue
     @JvmField
@@ -769,7 +778,11 @@ class MainActivityBiometricStartupInstrumentedTest {
 
     @BindValue
     @JvmField
-    var serviceStateStore: ServiceStateStore = FakeInstrumentedServiceStateStore()
+    var serviceStateStore: OrderedServiceStateStore = FakeInstrumentedServiceStateStore()
+
+    @BindValue
+    @JvmField
+    var serviceStateStoreContract: ServiceStateStore = serviceStateStore
 
     @BindValue
     @JvmField

--- a/app/src/androidTest/kotlin/com/poyka/ripdpi/integration/MainActivityShellInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/com/poyka/ripdpi/integration/MainActivityShellInstrumentedTest.kt
@@ -18,6 +18,7 @@ import com.poyka.ripdpi.core.Tun2SocksBridgeFactory
 import com.poyka.ripdpi.core.Tun2SocksBridgeFactoryModule
 import com.poyka.ripdpi.data.AppSettingsRepository
 import com.poyka.ripdpi.data.AppSettingsRepositoryModule
+import com.poyka.ripdpi.data.OrderedServiceStateStore
 import com.poyka.ripdpi.data.ServiceStateStore
 import com.poyka.ripdpi.data.ServiceStateStoreModule
 import com.poyka.ripdpi.diagnostics.DiagnosticsActiveConnectionPolicySource
@@ -166,7 +167,11 @@ class MainActivityShellInstrumentedTest {
 
     @BindValue
     @JvmField
-    var serviceStateStore: ServiceStateStore = FakeInstrumentedServiceStateStore()
+    var serviceStateStore: OrderedServiceStateStore = FakeInstrumentedServiceStateStore()
+
+    @BindValue
+    @JvmField
+    var serviceStateStoreContract: ServiceStateStore = serviceStateStore
 
     @BindValue
     @JvmField

--- a/app/src/androidTest/kotlin/com/poyka/ripdpi/integration/ServiceLifecycleIntegrationTest.kt
+++ b/app/src/androidTest/kotlin/com/poyka/ripdpi/integration/ServiceLifecycleIntegrationTest.kt
@@ -27,6 +27,7 @@ import com.poyka.ripdpi.data.Mode
 import com.poyka.ripdpi.data.NativeRuntimeSnapshot
 import com.poyka.ripdpi.data.NetworkFingerprint
 import com.poyka.ripdpi.data.NetworkHandoverEvent
+import com.poyka.ripdpi.data.OrderedServiceStateStore
 import com.poyka.ripdpi.data.Sender
 import com.poyka.ripdpi.data.ServiceEvent
 import com.poyka.ripdpi.data.ServiceStateStore
@@ -115,7 +116,11 @@ class ServiceLifecycleIntegrationTest {
 
     @BindValue
     @JvmField
-    var serviceStateStore: ServiceStateStore = IntegrationTestOverrides.serviceStateStore
+    var orderedServiceStateStore: OrderedServiceStateStore = IntegrationTestOverrides.serviceStateStore
+
+    @BindValue
+    @JvmField
+    var serviceStateStore: ServiceStateStore = orderedServiceStateStore
 
     @BindValue
     @JvmField
@@ -151,7 +156,8 @@ class ServiceLifecycleIntegrationTest {
         proxyPreferencesResolver = bindings.proxyPreferencesResolver
         proxyFactory = bindings.proxyFactory
         tun2SocksBridgeFactory = bindings.tun2SocksBridgeFactory
-        serviceStateStore = bindings.serviceStateStore
+        orderedServiceStateStore = bindings.serviceStateStore
+        serviceStateStore = orderedServiceStateStore
         vpnTunnelSessionProvider = bindings.vpnTunnelSessionProvider
         networkHandoverMonitor = bindings.networkHandoverMonitor
         permissionWatchdog = bindings.permissionWatchdog

--- a/app/src/androidTest/kotlin/com/poyka/ripdpi/testing/IntegrationTestOverrides.kt
+++ b/app/src/androidTest/kotlin/com/poyka/ripdpi/testing/IntegrationTestOverrides.kt
@@ -20,9 +20,10 @@ import com.poyka.ripdpi.data.Mode
 import com.poyka.ripdpi.data.NativeNetworkSnapshot
 import com.poyka.ripdpi.data.NativeRuntimeSnapshot
 import com.poyka.ripdpi.data.NetworkHandoverEvent
+import com.poyka.ripdpi.data.OrderedServiceStateStore
 import com.poyka.ripdpi.data.Sender
 import com.poyka.ripdpi.data.ServiceEvent
-import com.poyka.ripdpi.data.ServiceStateStore
+import com.poyka.ripdpi.data.ServiceHistoryEvent
 import com.poyka.ripdpi.data.ServiceTelemetrySnapshot
 import com.poyka.ripdpi.data.TunnelStats
 import com.poyka.ripdpi.proto.AppSettings
@@ -34,6 +35,7 @@ import com.poyka.ripdpi.services.VpnTunnelNetworkParameters
 import com.poyka.ripdpi.services.VpnTunnelSession
 import com.poyka.ripdpi.services.VpnTunnelSessionProvider
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,6 +43,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import java.util.concurrent.CopyOnWriteArrayList
 
 class FakeAndroidAppSettingsRepository(
@@ -67,35 +70,52 @@ class FakeAndroidAppSettingsRepository(
 
 class RecordingServiceStateStore(
     initialStatus: Pair<AppStatus, Mode> = AppStatus.Halted to Mode.VPN,
-) : ServiceStateStore {
+) : OrderedServiceStateStore {
     private val statusState = MutableStateFlow(initialStatus)
     private val eventFlow = MutableSharedFlow<ServiceEvent>(extraBufferCapacity = 8)
+    private val historyEventStream = Channel<ServiceHistoryEvent>(capacity = Channel.UNLIMITED)
     private val telemetryState = MutableStateFlow(ServiceTelemetrySnapshot())
 
     val eventHistory = CopyOnWriteArrayList<ServiceEvent>()
 
     override val status: StateFlow<Pair<AppStatus, Mode>> = statusState.asStateFlow()
     override val events: SharedFlow<ServiceEvent> = eventFlow.asSharedFlow()
+    override val historyEvents: Flow<ServiceHistoryEvent> = historyEventStream.receiveAsFlow()
     override val telemetry: StateFlow<ServiceTelemetrySnapshot> = telemetryState.asStateFlow()
+
+    init {
+        publishHistory(ServiceHistoryEvent.StatusChanged(initialStatus.first, initialStatus.second))
+    }
 
     override fun setStatus(
         status: AppStatus,
         mode: Mode,
     ) {
-        statusState.value = status to mode
+        val previousStatus = statusState.value
+        val nextStatus = status to mode
+        statusState.value = nextStatus
+        if (previousStatus != nextStatus) {
+            publishHistory(ServiceHistoryEvent.StatusChanged(status, mode))
+        }
     }
 
     override fun emitFailed(
         sender: Sender,
         reason: FailureReason,
     ) {
-        val event = ServiceEvent.Failed(sender, reason)
+        val (status, mode) = statusState.value
+        val event = ServiceEvent.Failed(sender, reason, status, mode)
         eventHistory += event
         eventFlow.tryEmit(event)
+        publishHistory(ServiceHistoryEvent.Failed(event))
     }
 
     override fun updateTelemetry(snapshot: ServiceTelemetrySnapshot) {
         telemetryState.value = snapshot
+    }
+
+    private fun publishHistory(event: ServiceHistoryEvent) {
+        check(historyEventStream.trySend(event).isSuccess) { "Service history event stream is unavailable" }
     }
 }
 

--- a/app/src/androidTest/kotlin/com/poyka/ripdpi/testing/MainActivityTestDoubles.kt
+++ b/app/src/androidTest/kotlin/com/poyka/ripdpi/testing/MainActivityTestDoubles.kt
@@ -19,9 +19,10 @@ import com.poyka.ripdpi.data.FailureReason
 import com.poyka.ripdpi.data.Mode
 import com.poyka.ripdpi.data.NativeNetworkSnapshot
 import com.poyka.ripdpi.data.NativeRuntimeSnapshot
+import com.poyka.ripdpi.data.OrderedServiceStateStore
 import com.poyka.ripdpi.data.Sender
 import com.poyka.ripdpi.data.ServiceEvent
-import com.poyka.ripdpi.data.ServiceStateStore
+import com.poyka.ripdpi.data.ServiceHistoryEvent
 import com.poyka.ripdpi.data.ServiceTelemetrySnapshot
 import com.poyka.ripdpi.data.TunnelStats
 import com.poyka.ripdpi.diagnostics.BypassApproachSummary
@@ -79,6 +80,7 @@ import com.poyka.ripdpi.services.VpnTunnelBuilderHost
 import com.poyka.ripdpi.services.VpnTunnelNetworkParameters
 import com.poyka.ripdpi.services.VpnTunnelSession
 import com.poyka.ripdpi.services.VpnTunnelSessionProvider
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -86,6 +88,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
@@ -376,31 +379,49 @@ class StubInstrumentedDiagnosticsActiveConnectionPolicySource : DiagnosticsActiv
 
 class FakeInstrumentedServiceStateStore(
     initialStatus: Pair<AppStatus, Mode> = AppStatus.Halted to Mode.VPN,
-) : ServiceStateStore {
+) : OrderedServiceStateStore {
     private val statusState = MutableStateFlow(initialStatus)
     private val eventFlow = MutableSharedFlow<ServiceEvent>(extraBufferCapacity = 1)
+    private val historyEventStream = Channel<ServiceHistoryEvent>(capacity = Channel.UNLIMITED)
     private val telemetryState = MutableStateFlow(ServiceTelemetrySnapshot())
 
     override val status: StateFlow<Pair<AppStatus, Mode>> = statusState.asStateFlow()
     override val events: SharedFlow<ServiceEvent> = eventFlow.asSharedFlow()
+    override val historyEvents: Flow<ServiceHistoryEvent> = historyEventStream.receiveAsFlow()
     override val telemetry: StateFlow<ServiceTelemetrySnapshot> = telemetryState.asStateFlow()
+
+    init {
+        publishHistory(ServiceHistoryEvent.StatusChanged(initialStatus.first, initialStatus.second))
+    }
 
     override fun setStatus(
         status: AppStatus,
         mode: Mode,
     ) {
-        statusState.value = status to mode
+        val previousStatus = statusState.value
+        val nextStatus = status to mode
+        statusState.value = nextStatus
+        if (previousStatus != nextStatus) {
+            publishHistory(ServiceHistoryEvent.StatusChanged(status, mode))
+        }
     }
 
     override fun emitFailed(
         sender: Sender,
         reason: FailureReason,
     ) {
-        eventFlow.tryEmit(ServiceEvent.Failed(sender, reason))
+        val (status, mode) = statusState.value
+        val event = ServiceEvent.Failed(sender, reason, status, mode)
+        eventFlow.tryEmit(event)
+        publishHistory(ServiceHistoryEvent.Failed(event))
     }
 
     override fun updateTelemetry(snapshot: ServiceTelemetrySnapshot) {
         telemetryState.value = snapshot
+    }
+
+    private fun publishHistory(event: ServiceHistoryEvent) {
+        check(historyEventStream.trySend(event).isSuccess) { "Service history event stream is unavailable" }
     }
 }
 

--- a/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/ServiceStateStore.kt
+++ b/core/data/runtime-state/src/main/kotlin/com/poyka/ripdpi/data/ServiceStateStore.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -45,6 +46,27 @@ sealed class ServiceEvent {
     data class PermissionRevoked(
         val kind: String,
     ) : ServiceEvent()
+}
+
+sealed class ServiceHistoryEvent {
+    data class StatusChanged(
+        val status: AppStatus,
+        val mode: Mode,
+    ) : ServiceHistoryEvent()
+
+    data class Failed(
+        val event: ServiceEvent.Failed,
+    ) : ServiceHistoryEvent()
+}
+
+/**
+ * Service-state contract for the singleton runtime-history consumer.
+ *
+ * [historyEvents] is a lossless, single-consumer queue: collecting it from a second owner would split
+ * transitions instead of broadcasting them. Status/failure publishers are deliberately low-rate.
+ */
+interface OrderedServiceStateStore : ServiceStateStore {
+    val historyEvents: Flow<ServiceHistoryEvent>
 }
 
 object NetworkHandoverStates {
@@ -130,6 +152,7 @@ interface ServiceStateStore {
      */
     val status: StateFlow<Pair<AppStatus, Mode>>
     val events: SharedFlow<ServiceEvent>
+
     val telemetry: StateFlow<ServiceTelemetrySnapshot>
 
     fun setStatus(
@@ -174,7 +197,7 @@ class DefaultServiceStateStore
         private val widgetStateRepository: WidgetStateRepository,
         private val widgetNotifier: WidgetNotifier,
         @param:ApplicationScope private val applicationScope: CoroutineScope,
-    ) : ServiceStateStore {
+    ) : OrderedServiceStateStore {
         constructor() : this(
             NoopWidgetStateRepository,
             NoopWidgetNotifier,
@@ -206,11 +229,16 @@ class DefaultServiceStateStore
                     started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 0L),
                     replay = 0,
                 )
+        private val historyEventStream = Channel<ServiceHistoryEvent>(capacity = Channel.UNLIMITED)
+
+        /** Status and failure transitions serialized under the state-store lock. */
+        override val historyEvents: Flow<ServiceHistoryEvent> = historyEventStream.receiveAsFlow()
 
         override val telemetry: StateFlow<ServiceTelemetrySnapshot> =
             MappedStateFlow(projection, ServiceStateProjection::telemetry)
 
         init {
+            publishHistoryStatus(AppStatus.Halted, Mode.VPN)
             applicationScope.launch {
                 val snapshots = projection.map { state -> toWidgetSnapshot(state.status, state.telemetry) }
                 merge(
@@ -235,6 +263,7 @@ class DefaultServiceStateStore
             synchronized(lock) {
                 val currentProjection = projection.value
                 val previousStatus = currentProjection.status.first
+                val previousStatusPair = currentProjection.status
                 val now = System.currentTimeMillis()
                 val currentTelemetry = currentProjection.telemetry
                 projection.value =
@@ -272,6 +301,9 @@ class DefaultServiceStateStore
                                 updatedAt = now,
                             ),
                     )
+                if (previousStatusPair != status to mode) {
+                    publishHistoryStatus(status, mode)
+                }
             }
         }
 
@@ -305,6 +337,7 @@ class DefaultServiceStateStore
             val generation =
                 synchronized(lock) {
                     val previousEventStream = eventStream.value
+                    val previousStatus = projection.value.status
                     val generation = previousEventStream.generation + 1L
                     val restartCount = projection.value.telemetry.restartCount
                     eventStream.value = SessionEventStream(generation)
@@ -319,6 +352,9 @@ class DefaultServiceStateStore
                                     restartCount = restartCount,
                                 ),
                         )
+                    if (previousStatus != AppStatus.Halted to mode) {
+                        publishHistoryStatus(AppStatus.Halted, mode)
+                    }
                     generation
                 }
             return SessionBoundServiceStateStore(this, generation)
@@ -373,6 +409,7 @@ class DefaultServiceStateStore
                     publishFailedEvent(terminalStream, sender, reason)
                 }
                 val terminalProjection = projection.value
+                val previousStatus = terminalProjection.status
                 val mode = terminalProjection.status.second
                 val terminalTelemetry = terminalProjection.telemetry
                 val resetTelemetry =
@@ -410,6 +447,18 @@ class DefaultServiceStateStore
                                     },
                             ),
                     )
+                if (previousStatus != AppStatus.Halted to mode) {
+                    publishHistoryStatus(AppStatus.Halted, mode)
+                }
+            }
+        }
+
+        private fun publishHistoryStatus(
+            status: AppStatus,
+            mode: Mode,
+        ) {
+            check(historyEventStream.trySend(ServiceHistoryEvent.StatusChanged(status, mode)).isSuccess) {
+                "Service history event stream is unavailable"
             }
         }
 
@@ -458,6 +507,9 @@ class DefaultServiceStateStore
                 )
             check(stream.events.trySend(event).isSuccess) {
                 "Service event stream is unavailable"
+            }
+            check(historyEventStream.trySend(ServiceHistoryEvent.Failed(event)).isSuccess) {
+                "Service history event stream is unavailable"
             }
         }
 
@@ -584,4 +636,8 @@ abstract class ServiceStateStoreModule {
     @Binds
     @Singleton
     abstract fun bindServiceStateStore(serviceStateStore: DefaultServiceStateStore): ServiceStateStore
+
+    @Binds
+    @Singleton
+    abstract fun bindOrderedServiceStateStore(serviceStateStore: DefaultServiceStateStore): OrderedServiceStateStore
 }

--- a/core/data/runtime-state/src/test/kotlin/com/poyka/ripdpi/data/ServiceStateStoreConcurrencyTest.kt
+++ b/core/data/runtime-state/src/test/kotlin/com/poyka/ripdpi/data/ServiceStateStoreConcurrencyTest.kt
@@ -119,4 +119,32 @@ class ServiceStateStoreConcurrencyTest {
             assertEquals(Mode.VPN, failure.modeAtFailure)
             assertEquals(AppStatus.Halted to Mode.VPN, store.status.value)
         }
+
+    @Test
+    fun `history events preserve failure before terminal status`() =
+        runTest {
+            val store = DefaultServiceStateStore()
+            store.setStatus(AppStatus.Running, Mode.VPN)
+            store.emitFailed(Sender.Proxy, FailureReason.NativeError("boom"))
+            store.setStatus(AppStatus.Halted, Mode.VPN)
+
+            val history = store.historyEvents.take(4).toList()
+
+            assertEquals(
+                listOf(
+                    ServiceHistoryEvent.StatusChanged(AppStatus.Halted, Mode.VPN),
+                    ServiceHistoryEvent.StatusChanged(AppStatus.Running, Mode.VPN),
+                    ServiceHistoryEvent.Failed(
+                        ServiceEvent.Failed(
+                            sender = Sender.Proxy,
+                            reason = FailureReason.NativeError("boom"),
+                            statusAtFailure = AppStatus.Running,
+                            modeAtFailure = Mode.VPN,
+                        ),
+                    ),
+                    ServiceHistoryEvent.StatusChanged(AppStatus.Halted, Mode.VPN),
+                ),
+                history,
+            )
+        }
 }

--- a/core/diagnostics/src/main/kotlin/com/poyka/ripdpi/diagnostics/RuntimeArtifactPersister.kt
+++ b/core/diagnostics/src/main/kotlin/com/poyka/ripdpi/diagnostics/RuntimeArtifactPersister.kt
@@ -115,7 +115,9 @@ class RuntimeArtifactPersister
                     serviceTelemetry.relayTelemetry.nativeEvents +
                     serviceTelemetry.tunnelTelemetry.nativeEvents
             ).mapNotNull(NativeRuntimeEvent::toPrivacySafePersistedRuntimeEvent)
-                .forEach { event ->
+                .filterNot { event ->
+                    connectionSessionId == null && event.kind == "data_plane_final"
+                }.forEach { event ->
                     persistRuntimeEvent(
                         event.toSessionEvent(
                             id =

--- a/core/diagnostics/src/main/kotlin/com/poyka/ripdpi/diagnostics/RuntimeHistoryMonitor.kt
+++ b/core/diagnostics/src/main/kotlin/com/poyka/ripdpi/diagnostics/RuntimeHistoryMonitor.kt
@@ -1,10 +1,11 @@
 package com.poyka.ripdpi.diagnostics
 
 import co.touchlab.kermit.Logger
+import com.poyka.ripdpi.data.AppStatus
 import com.poyka.ripdpi.data.ApplicationIoScope
 import com.poyka.ripdpi.data.DeviceRuntimeEvidenceStore
-import com.poyka.ripdpi.data.ServiceEvent
-import com.poyka.ripdpi.data.ServiceStateStore
+import com.poyka.ripdpi.data.OrderedServiceStateStore
+import com.poyka.ripdpi.data.ServiceHistoryEvent
 import com.poyka.ripdpi.data.diagnostics.ActiveConnectionPolicyStore
 import dagger.Binds
 import dagger.Module
@@ -27,7 +28,7 @@ fun interface RuntimeHistoryStartup {
 class RuntimeHistoryMonitor
     @Inject
     constructor(
-        private val serviceStateStore: ServiceStateStore,
+        private val serviceStateStore: OrderedServiceStateStore,
         private val activeConnectionPolicyStore: ActiveConnectionPolicyStore,
         private val deviceRuntimeEvidenceStore: DeviceRuntimeEvidenceStore,
         private val networkPathValidationSource: NetworkPathValidationSource,
@@ -51,9 +52,24 @@ class RuntimeHistoryMonitor
         private suspend fun collectRuntimeHistory() =
             supervisorScope {
                 launch {
-                    serviceStateStore.status.collect { (status, mode) ->
-                        persistSafely("status") {
-                            sessionCoordinator.handleStatusChange(status = status, mode = mode)
+                    serviceStateStore.historyEvents.collect { event ->
+                        when (event) {
+                            is ServiceHistoryEvent.StatusChanged -> {
+                                persistSafely("lifecycle") {
+                                    sessionCoordinator.handleStatusChange(event.status, event.mode)
+                                }
+                                if (event.status == AppStatus.Running) {
+                                    persistSafely("telemetry") {
+                                        sessionCoordinator.handleTelemetryUpdate(serviceStateStore.telemetry.value)
+                                    }
+                                }
+                            }
+
+                            is ServiceHistoryEvent.Failed -> {
+                                persistSafely("lifecycle") {
+                                    sessionCoordinator.handleFailure(event.event.sender, event.event.reason)
+                                }
+                            }
                         }
                     }
                 }
@@ -62,17 +78,6 @@ class RuntimeHistoryMonitor
                     serviceStateStore.telemetry.collect { telemetry ->
                         persistSafely("telemetry") {
                             sessionCoordinator.handleTelemetryUpdate(telemetry)
-                        }
-                    }
-                }
-
-                launch {
-                    serviceStateStore.events.collect { event ->
-                        persistSafely("events") {
-                            when (event) {
-                                is ServiceEvent.Failed -> sessionCoordinator.handleFailure(event.sender, event.reason)
-                                is ServiceEvent.PermissionRevoked -> Unit
-                            }
                         }
                     }
                 }

--- a/core/diagnostics/src/main/kotlin/com/poyka/ripdpi/diagnostics/RuntimeSessionCoordinator.kt
+++ b/core/diagnostics/src/main/kotlin/com/poyka/ripdpi/diagnostics/RuntimeSessionCoordinator.kt
@@ -116,21 +116,21 @@ class RuntimeSessionCoordinator
 
         suspend fun handleTelemetryUpdate(telemetry: ServiceTelemetrySnapshot) {
             stateMutex.withLock {
-                if (serviceStateStore.status.value.first == AppStatus.Running) {
-                    persistPendingTerminalSession()
-                    val mode = serviceStateStore.status.value.second
-                    ensureRecorderAttachedUsageSession(mode)
-                    updateActiveUsageSession(
-                        serviceMode = mode,
-                        telemetry = telemetry,
-                        networkType = activeUsageSession?.networkType ?: "unknown",
-                        publicIp = activeUsageSession?.publicIp,
-                    )
-                    val handoverState = telemetry.networkHandoverState?.takeIf(String::isNotBlank)
-                    if (handoverState != null && handoverState != lastRecordedNetworkHandoverState) {
-                        deviceStateEventRecorder.recordHandover()
-                        lastRecordedNetworkHandoverState = handoverState
-                    }
+                if (serviceStateStore.status.value.first != AppStatus.Running || activeUsageSession == null) {
+                    return@withLock
+                }
+                persistPendingTerminalSession()
+                val mode = serviceStateStore.status.value.second
+                updateActiveUsageSession(
+                    serviceMode = mode,
+                    telemetry = telemetry,
+                    networkType = activeUsageSession?.networkType ?: "unknown",
+                    publicIp = activeUsageSession?.publicIp,
+                )
+                val handoverState = telemetry.networkHandoverState?.takeIf(String::isNotBlank)
+                if (handoverState != null && handoverState != lastRecordedNetworkHandoverState) {
+                    deviceStateEventRecorder.recordHandover()
+                    lastRecordedNetworkHandoverState = handoverState
                 }
                 artifactPersister.persistRuntimeEvents(
                     serviceTelemetry = telemetry,

--- a/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/DiagnosticsServiceTestSupport.kt
+++ b/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/DiagnosticsServiceTestSupport.kt
@@ -15,6 +15,7 @@ import com.poyka.ripdpi.data.FailureReason
 import com.poyka.ripdpi.data.Mode
 import com.poyka.ripdpi.data.NetworkFingerprint
 import com.poyka.ripdpi.data.NetworkFingerprintProvider
+import com.poyka.ripdpi.data.OrderedServiceStateStore
 import com.poyka.ripdpi.data.PolicyHandoverEvent
 import com.poyka.ripdpi.data.PolicyHandoverEventStore
 import com.poyka.ripdpi.data.PreferredEdgeCandidate
@@ -32,7 +33,7 @@ import com.poyka.ripdpi.data.ServerCapabilityRecord
 import com.poyka.ripdpi.data.ServerCapabilityScope
 import com.poyka.ripdpi.data.ServerCapabilityStore
 import com.poyka.ripdpi.data.ServiceEvent
-import com.poyka.ripdpi.data.ServiceStateStore
+import com.poyka.ripdpi.data.ServiceHistoryEvent
 import com.poyka.ripdpi.data.ServiceTelemetrySnapshot
 import com.poyka.ripdpi.data.TemporaryResolverOverride
 import com.poyka.ripdpi.data.WifiNetworkIdentityTuple
@@ -85,6 +86,7 @@ import com.poyka.ripdpi.proto.AppSettings
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
@@ -97,6 +99,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
@@ -1487,20 +1490,35 @@ internal class FakePolicyHandoverEventStore : PolicyHandoverEventStore {
 
 internal class FakeServiceStateStore(
     initialStatus: Pair<AppStatus, Mode> = AppStatus.Halted to Mode.VPN,
-) : ServiceStateStore {
+) : OrderedServiceStateStore {
     private val statusState = MutableStateFlow(initialStatus)
     private val eventFlow = MutableSharedFlow<ServiceEvent>(extraBufferCapacity = 1)
     private val telemetryState = MutableStateFlow(ServiceTelemetrySnapshot())
+    private val historyEventChannel = Channel<ServiceHistoryEvent>(Channel.UNLIMITED)
 
     override val status: StateFlow<Pair<AppStatus, Mode>> = statusState.asStateFlow()
     override val events: SharedFlow<ServiceEvent> = eventFlow.asSharedFlow()
+    override val historyEvents: Flow<ServiceHistoryEvent> = historyEventChannel.receiveAsFlow()
     override val telemetry: StateFlow<ServiceTelemetrySnapshot> = telemetryState.asStateFlow()
+
+    init {
+        check(
+            historyEventChannel
+                .trySend(
+                    ServiceHistoryEvent.StatusChanged(initialStatus.first, initialStatus.second),
+                ).isSuccess,
+        )
+    }
 
     override fun setStatus(
         status: AppStatus,
         mode: Mode,
     ) {
+        val previousStatus = statusState.value
         statusState.value = status to mode
+        if (previousStatus != status to mode) {
+            check(historyEventChannel.trySend(ServiceHistoryEvent.StatusChanged(status, mode)).isSuccess)
+        }
         val now = System.currentTimeMillis()
         val currentTelemetry = telemetryState.value
         telemetryState.value =
@@ -1538,7 +1556,9 @@ internal class FakeServiceStateStore(
                 lastFailureAt = now,
                 updatedAt = now,
             )
-        eventFlow.tryEmit(ServiceEvent.Failed(sender, reason))
+        val event = ServiceEvent.Failed(sender, reason, statusState.value.first, statusState.value.second)
+        eventFlow.tryEmit(event)
+        check(historyEventChannel.trySend(ServiceHistoryEvent.Failed(event)).isSuccess)
     }
 
     override fun updateTelemetry(snapshot: ServiceTelemetrySnapshot) {

--- a/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/DiagnosticsTestBuilders.kt
+++ b/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/DiagnosticsTestBuilders.kt
@@ -10,9 +10,9 @@ import com.poyka.ripdpi.data.NativeNetworkSnapshot
 import com.poyka.ripdpi.data.NativeNetworkSnapshotProvider
 import com.poyka.ripdpi.data.NetworkFingerprintProvider
 import com.poyka.ripdpi.data.NoopStartupJournal
+import com.poyka.ripdpi.data.OrderedServiceStateStore
 import com.poyka.ripdpi.data.PolicyHandoverEventStore
 import com.poyka.ripdpi.data.ResolverOverrideStore
-import com.poyka.ripdpi.data.ServiceStateStore
 import com.poyka.ripdpi.data.diagnostics.ActiveConnectionPolicy
 import com.poyka.ripdpi.data.diagnostics.ActiveConnectionPolicyStore
 import com.poyka.ripdpi.data.diagnostics.DefaultNetworkDnsPathPreferenceStore
@@ -82,7 +82,7 @@ internal fun createDiagnosticsServices(
     diagnosticsContextProvider: DiagnosticsContextProvider,
     networkDiagnosticsBridgeFactory: NetworkDiagnosticsBridgeFactory,
     runtimeCoordinator: DiagnosticsRuntimeCoordinator,
-    serviceStateStore: ServiceStateStore,
+    serviceStateStore: OrderedServiceStateStore,
     activeConnectionPolicyStore: ActiveConnectionPolicyStore = EmptyActiveConnectionPolicyStore(),
     deviceRuntimeEvidenceStore: DeviceRuntimeEvidenceStore = DefaultDeviceRuntimeEvidenceStore(),
     logcatSnapshotCollector: LogcatSnapshotCollector = LogcatSnapshotCollector(),
@@ -376,7 +376,7 @@ internal fun createRuntimeHistoryMonitor(
     stores: FakeDiagnosticsHistoryStores,
     networkMetadataProvider: NetworkMetadataProvider,
     diagnosticsContextProvider: DiagnosticsContextProvider,
-    serviceStateStore: ServiceStateStore,
+    serviceStateStore: OrderedServiceStateStore,
     diagnosticsHistoryClock: DiagnosticsHistoryClock = TestDiagnosticsHistoryClock(),
     rememberedNetworkPolicyStore: RememberedNetworkPolicyStore =
         DefaultRememberedNetworkPolicyStore(stores, diagnosticsHistoryClock),

--- a/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/RuntimeHistoryMonitorPersistenceTest.kt
+++ b/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/RuntimeHistoryMonitorPersistenceTest.kt
@@ -181,6 +181,17 @@ internal class RuntimeHistoryMonitorPersistenceTest : RuntimeHistoryMonitorPersi
         }
 
     @Test
+    fun `runtime persistence ignores terminal data plane event without an active session`() =
+        runTest {
+            val stores = FakeDiagnosticsHistoryStores()
+            val persister = createArtifactPersister(stores)
+
+            persister.persistRuntimeEvents(finalDataPlaneTelemetry(createdAt = 1L), connectionSessionId = null)
+
+            assertTrue(stores.nativeEventsState.value.isEmpty())
+        }
+
+    @Test
     fun `status before telemetry persists final data plane event on active session`() =
         runTest {
             val stores = FakeDiagnosticsHistoryStores()

--- a/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/RuntimeHistoryMonitorPersistenceTest.kt
+++ b/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/RuntimeHistoryMonitorPersistenceTest.kt
@@ -1,5 +1,6 @@
 package com.poyka.ripdpi.diagnostics
 
+import com.poyka.ripdpi.data.AppSettingsRepository
 import com.poyka.ripdpi.data.AppStatus
 import com.poyka.ripdpi.data.DefaultDeviceRuntimeEvidenceStore
 import com.poyka.ripdpi.data.DefaultServiceStateStore
@@ -20,14 +21,18 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -40,6 +45,7 @@ internal class RuntimeHistoryMonitorPersistenceTest : RuntimeHistoryMonitorPersi
         runTest {
             val stores = FakeDiagnosticsHistoryStores()
             val serviceStateStore = DefaultServiceStateStore()
+            serviceStateStore.setStatus(AppStatus.Running, Mode.VPN)
             val firstWriteStarted = CompletableDeferred<Unit>()
             val releaseFirstWrite = CompletableDeferred<Unit>()
             stores.beforeInsertNativeSessionEvent = { event ->
@@ -48,20 +54,33 @@ internal class RuntimeHistoryMonitorPersistenceTest : RuntimeHistoryMonitorPersi
                     releaseFirstWrite.await()
                 }
             }
-            val monitorScope = monitorScope()
-            val monitor = createMonitor(stores, serviceStateStore, monitorScope)
+            val monitorScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val monitor =
+                createMonitor(
+                    stores,
+                    serviceStateStore,
+                    monitorScope,
+                    appSettingsRepository = disabledMonitorSettingsRepository(),
+                )
 
             monitor.start()
-            runCurrent()
+            waitForPersistence { stores.usageSessionsState.value.size == 1 }
             serviceStateStore.updateTelemetry(telemetryWithEvent("first", createdAt = 1L))
-            runCurrent()
             firstWriteStarted.await()
             serviceStateStore.updateTelemetry(telemetryWithEvent("second", createdAt = 2L))
-            runCurrent()
             releaseFirstWrite.complete(Unit)
-            runCurrent()
+            waitForPersistence {
+                stores.nativeEventsState.value
+                    .map { it.message }
+                    .containsAll(listOf("first", "second"))
+            }
 
-            assertEquals(listOf("first", "second"), stores.nativeEventsState.value.map { it.message })
+            assertEquals(
+                listOf("first", "second"),
+                stores.nativeEventsState.value
+                    .map { it.message }
+                    .filter { it == "first" || it == "second" },
+            )
             monitorScope.cancel()
         }
 
@@ -70,6 +89,7 @@ internal class RuntimeHistoryMonitorPersistenceTest : RuntimeHistoryMonitorPersi
         runTest {
             val stores = FakeDiagnosticsHistoryStores()
             val serviceStateStore = DefaultServiceStateStore()
+            serviceStateStore.setStatus(AppStatus.Running, Mode.VPN)
             var failNextWrite = true
             stores.beforeInsertNativeSessionEvent = { event ->
                 if (event.message == "fails" && failNextWrite) {
@@ -77,15 +97,20 @@ internal class RuntimeHistoryMonitorPersistenceTest : RuntimeHistoryMonitorPersi
                     error("injected persistence failure")
                 }
             }
-            val monitorScope = monitorScope()
-            val monitor = createMonitor(stores, serviceStateStore, monitorScope)
+            val monitorScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val monitor =
+                createMonitor(
+                    stores,
+                    serviceStateStore,
+                    monitorScope,
+                    appSettingsRepository = disabledMonitorSettingsRepository(),
+                )
 
             monitor.start()
-            runCurrent()
+            waitForPersistence { stores.usageSessionsState.value.size == 1 }
             serviceStateStore.updateTelemetry(telemetryWithEvent("fails", createdAt = 3L))
-            runCurrent()
             serviceStateStore.updateTelemetry(telemetryWithEvent("after-failure", createdAt = 4L))
-            runCurrent()
+            waitForPersistence { stores.nativeEventsState.value.any { it.message == "after-failure" } }
 
             assertTrue(stores.nativeEventsState.value.any { it.message == "after-failure" })
             monitorScope.cancel()
@@ -1093,6 +1118,24 @@ internal class RuntimeLifecyclePersistenceTest : RuntimeHistoryMonitorPersistenc
 }
 
 internal abstract class RuntimeHistoryMonitorPersistenceTestSupport {
+    protected fun disabledMonitorSettingsRepository(): AppSettingsRepository =
+        FakeAppSettingsRepository(
+            defaultDiagnosticsAppSettings()
+                .toBuilder()
+                .setDiagnosticsMonitorEnabled(false)
+                .build(),
+        )
+
+    protected suspend fun waitForPersistence(predicate: () -> Boolean) {
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(8_000L) {
+                while (!predicate()) {
+                    delay(10L)
+                }
+            }
+        }
+    }
+
     protected fun kotlinx.coroutines.test.TestScope.monitorScope(): CoroutineScope =
         CoroutineScope(
             SupervisorJob() +
@@ -1106,9 +1149,10 @@ internal abstract class RuntimeHistoryMonitorPersistenceTestSupport {
         scope: CoroutineScope,
         deviceRuntimeEvidenceStore: DeviceRuntimeEvidenceStore = DefaultDeviceRuntimeEvidenceStore(),
         networkTransitionFlush: (suspend (NetworkTransitionAdmission) -> Boolean)? = null,
+        appSettingsRepository: AppSettingsRepository = FakeAppSettingsRepository(),
     ): RuntimeHistoryStartup =
         createRuntimeHistoryMonitor(
-            appSettingsRepository = FakeAppSettingsRepository(),
+            appSettingsRepository = appSettingsRepository,
             stores = stores,
             networkMetadataProvider = FakeNetworkMetadataProvider(),
             diagnosticsContextProvider = FakeDiagnosticsContextProvider(),

--- a/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/RuntimeHistoryMonitorTest.kt
+++ b/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/RuntimeHistoryMonitorTest.kt
@@ -222,36 +222,6 @@ class RuntimeHistoryMonitorTest {
             assertEquals(2_048L, stoppedTelemetrySample.rxBytes)
         }
 
-    @Test
-    fun `delayed monitor attaches current telemetry to queued running session exactly once`() =
-        runTest {
-            val stores = FakeDiagnosticsHistoryStores()
-            val serviceStateStore = DefaultServiceStateStore()
-            serviceStateStore.setStatus(AppStatus.Running, Mode.VPN)
-            emitRunningTelemetryWithCloudflare(serviceStateStore)
-            val orderedStore = TelemetryBeforeRunningServiceStateStore(serviceStateStore)
-            val monitor =
-                createRuntimeHistoryMonitor(
-                    appSettingsRepository = RecorderFakeAppSettingsRepository(),
-                    stores = stores,
-                    networkMetadataProvider = RecorderFakeNetworkMetadataProvider(),
-                    diagnosticsContextProvider = RecorderFakeDiagnosticsContextProvider(),
-                    serviceStateStore = orderedStore,
-                )
-
-            monitor.start()
-
-            waitUntil(timeoutMillis = 8_000) {
-                stores.usageSessionsState.value.size == 1 &&
-                    stores.telemetryState.value.any { it.resolverId == "cloudflare" } &&
-                    stores.nativeEventsState.value.count { it.source == "proxy" } == 1
-            }
-            val session = stores.usageSessionsState.value.single()
-            assertTrue(stores.telemetryState.value.all { it.connectionSessionId == session.id })
-            assertTrue(stores.nativeEventsState.value.all { it.connectionSessionId == session.id })
-            assertEquals(1, stores.nativeEventsState.value.count { it.source == "proxy" })
-        }
-
     private fun emitRunningTelemetryWithCloudflare(serviceStateStore: DefaultServiceStateStore) {
         serviceStateStore.updateTelemetry(
             ServiceTelemetrySnapshot(
@@ -712,6 +682,64 @@ class RuntimeHistoryMonitorTest {
             )
             assertEquals(true, session.rememberedPolicyAppliedByExactMatch)
         }
+}
+
+class RuntimeHistoryMonitorOrderingTest {
+    @Test
+    fun `delayed monitor attaches current telemetry to queued running session exactly once`() =
+        runTest {
+            val stores = FakeDiagnosticsHistoryStores()
+            val serviceStateStore = DefaultServiceStateStore()
+            serviceStateStore.setStatus(AppStatus.Running, Mode.VPN)
+            serviceStateStore.updateTelemetry(queuedRunningTelemetry())
+            val orderedStore = TelemetryBeforeRunningServiceStateStore(serviceStateStore)
+            val monitor =
+                createRuntimeHistoryMonitor(
+                    appSettingsRepository = RecorderFakeAppSettingsRepository(),
+                    stores = stores,
+                    networkMetadataProvider = RecorderFakeNetworkMetadataProvider(),
+                    diagnosticsContextProvider = RecorderFakeDiagnosticsContextProvider(),
+                    serviceStateStore = orderedStore,
+                )
+
+            monitor.start()
+
+            waitUntil(timeoutMillis = 8_000) {
+                stores.usageSessionsState.value.size == 1 &&
+                    stores.telemetryState.value.any { it.resolverId == "cloudflare" } &&
+                    stores.nativeEventsState.value.count { it.source == "proxy" } == 1
+            }
+            val session = stores.usageSessionsState.value.single()
+            assertTrue(stores.telemetryState.value.all { it.connectionSessionId == session.id })
+            assertTrue(stores.nativeEventsState.value.all { it.connectionSessionId == session.id })
+            assertEquals(1, stores.nativeEventsState.value.count { it.source == "proxy" })
+        }
+
+    private fun queuedRunningTelemetry(): ServiceTelemetrySnapshot =
+        ServiceTelemetrySnapshot(
+            mode = Mode.VPN,
+            status = AppStatus.Running,
+            proxyTelemetry =
+                NativeRuntimeSnapshot(
+                    source = "proxy",
+                    nativeEvents =
+                        listOf(
+                            NativeRuntimeEvent(
+                                source = "proxy",
+                                level = "info",
+                                message = "accepted",
+                                createdAt = 100L,
+                            ),
+                        ),
+                ),
+            tunnelTelemetry =
+                NativeRuntimeSnapshot(
+                    source = "tunnel",
+                    resolverId = "cloudflare",
+                    resolverProtocol = "doh",
+                ),
+            updatedAt = System.currentTimeMillis(),
+        )
 }
 
 private class CountingNetworkPathValidationSource : NetworkPathValidationSource {

--- a/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/RuntimeHistoryMonitorTest.kt
+++ b/core/diagnostics/src/test/kotlin/com/poyka/ripdpi/diagnostics/RuntimeHistoryMonitorTest.kt
@@ -12,6 +12,7 @@ import com.poyka.ripdpi.data.NetworkFingerprintSummary
 import com.poyka.ripdpi.data.NetworkPathAssociationActiveDefault
 import com.poyka.ripdpi.data.NetworkPathAssociationServiceBinder
 import com.poyka.ripdpi.data.NetworkPathObservation
+import com.poyka.ripdpi.data.OrderedServiceStateStore
 import com.poyka.ripdpi.data.RememberedNetworkPolicyJson
 import com.poyka.ripdpi.data.RememberedNetworkPolicyProofDurationMs
 import com.poyka.ripdpi.data.RememberedNetworkPolicyProofTransferBytes
@@ -20,6 +21,7 @@ import com.poyka.ripdpi.data.RememberedNetworkPolicyStatusValidated
 import com.poyka.ripdpi.data.RttBand
 import com.poyka.ripdpi.data.RuntimeFieldTelemetry
 import com.poyka.ripdpi.data.Sender
+import com.poyka.ripdpi.data.ServiceHistoryEvent
 import com.poyka.ripdpi.data.ServiceTelemetrySnapshot
 import com.poyka.ripdpi.data.TunnelStats
 import com.poyka.ripdpi.data.diagnostics.ActiveConnectionPolicy
@@ -28,9 +30,13 @@ import com.poyka.ripdpi.data.diagnostics.DefaultRememberedNetworkPolicyStore
 import com.poyka.ripdpi.data.diagnostics.RememberedNetworkPolicyEntity
 import com.poyka.ripdpi.data.diagnostics.decodedSource
 import com.poyka.ripdpi.proto.AppSettings
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -214,6 +220,36 @@ class RuntimeHistoryMonitorTest {
             )
             assertEquals(1_024L, stoppedTelemetrySample.txBytes)
             assertEquals(2_048L, stoppedTelemetrySample.rxBytes)
+        }
+
+    @Test
+    fun `delayed monitor attaches current telemetry to queued running session exactly once`() =
+        runTest {
+            val stores = FakeDiagnosticsHistoryStores()
+            val serviceStateStore = DefaultServiceStateStore()
+            serviceStateStore.setStatus(AppStatus.Running, Mode.VPN)
+            emitRunningTelemetryWithCloudflare(serviceStateStore)
+            val orderedStore = TelemetryBeforeRunningServiceStateStore(serviceStateStore)
+            val monitor =
+                createRuntimeHistoryMonitor(
+                    appSettingsRepository = RecorderFakeAppSettingsRepository(),
+                    stores = stores,
+                    networkMetadataProvider = RecorderFakeNetworkMetadataProvider(),
+                    diagnosticsContextProvider = RecorderFakeDiagnosticsContextProvider(),
+                    serviceStateStore = orderedStore,
+                )
+
+            monitor.start()
+
+            waitUntil(timeoutMillis = 8_000) {
+                stores.usageSessionsState.value.size == 1 &&
+                    stores.telemetryState.value.any { it.resolverId == "cloudflare" } &&
+                    stores.nativeEventsState.value.count { it.source == "proxy" } == 1
+            }
+            val session = stores.usageSessionsState.value.single()
+            assertTrue(stores.telemetryState.value.all { it.connectionSessionId == session.id })
+            assertTrue(stores.nativeEventsState.value.all { it.connectionSessionId == session.id })
+            assertEquals(1, stores.nativeEventsState.value.count { it.source == "proxy" })
         }
 
     private fun emitRunningTelemetryWithCloudflare(serviceStateStore: DefaultServiceStateStore) {
@@ -526,6 +562,7 @@ class RuntimeHistoryMonitorTest {
 
             val persisted =
                 requireNotNull(stores.getRememberedNetworkPolicy("fingerprint-fail", Mode.VPN.preferenceValue))
+            assertEquals(stores.usageSessionsState.value.joinToString(), 1, stores.usageSessionsState.value.size)
             val session = stores.usageSessionsState.value.single()
             assertEquals(1, persisted.failureCount)
             assertEquals(1, persisted.consecutiveFailureCount)
@@ -776,6 +813,42 @@ private class RecorderFakeNetworkMetadataProvider : NetworkMetadataProvider {
                 ),
             capturedAt = System.currentTimeMillis(),
         )
+}
+
+private class TelemetryBeforeRunningServiceStateStore(
+    delegate: OrderedServiceStateStore,
+) : OrderedServiceStateStore by delegate {
+    private val initialTelemetryHandled = CompletableDeferred<Unit>()
+
+    override val telemetry: StateFlow<ServiceTelemetrySnapshot> =
+        SignallingStateFlow(delegate.telemetry) { initialTelemetryHandled.complete(Unit) }
+
+    override val historyEvents: Flow<ServiceHistoryEvent> =
+        flow {
+            delegate.historyEvents.collect { event ->
+                if (event is ServiceHistoryEvent.StatusChanged && event.status == AppStatus.Running) {
+                    initialTelemetryHandled.await()
+                }
+                emit(event)
+            }
+        }
+}
+
+@OptIn(ExperimentalForInheritanceCoroutinesApi::class)
+private class SignallingStateFlow<T>(
+    private val delegate: StateFlow<T>,
+    private val onFirstValueHandled: () -> Unit,
+) : StateFlow<T> by delegate {
+    override suspend fun collect(collector: FlowCollector<T>): Nothing {
+        var first = true
+        delegate.collect { value ->
+            collector.emit(value)
+            if (first) {
+                first = false
+                onFirstValueHandled()
+            }
+        }
+    }
 }
 
 private class RecorderFakeDiagnosticsContextProvider : DiagnosticsContextProvider {


### PR DESCRIPTION
## Summary
- keep the terminal outbox as the single owner of final data-plane events
- ignore only unbound `data_plane_final` events in regular telemetry persistence
- cover the delayed telemetry-after-halt race without weakening the strict session-bound assertion

## Verification
- focused diagnostics unit test: PASS
- architecture delta and configured hooks: PASS
- `git diff --check`: PASS

## Context
PR #467 became redundant after main independently integrated the runtime model split and API snapshot refresh. This PR carries only the remaining runtime correctness fix on the current main tree.
