### PR TITLE
chore(contract): mirror observability cardinality bound

### DIFF
--- a/core/data/src/test/resources/contract/observability-metric-manifest.schema.json
+++ b/core/data/src/test/resources/contract/observability-metric-manifest.schema.json
@@ -60,7 +60,7 @@
             "enum": ["node", "role", "profile", "policy", "severity", "vantage", "state"]
           }
         },
-        "max_series": {"type": "integer", "minimum": 1, "maximum": 1024},
+        "max_series": {"type": "integer", "minimum": 1, "maximum": 2048},
         "cadence_seconds": {"type": "integer", "minimum": 1, "maximum": 86400},
         "stale_after_seconds": {"type": "integer", "minimum": 1, "maximum": 604800},
         "alert_use": {"type": "boolean"}


### PR DESCRIPTION
## Summary

- mirror the deployment observability manifest schema cardinality ceiling byte-for-byte
- allow the evidence-state family to declare all 256 targets across eight lifecycle states
- keep client runtime and other contract mirrors unchanged

## Verification

- producer: `ripdpi-vpn-deploy@fdbf8023d296c3ec08b3301b8c2692ac5b76ba93`
- byte comparison and JSON parse: PASS
- `build-gate -- ./gradlew :core:data:testDebugUnitTest --no-configuration-cache --no-daemon --max-workers=2`: PASS
- `python3 scripts/ci/check_architecture_health.py --check`: PASS, 23 indicators unchanged
- `./taskctl validate`: PASS, 32 tasks / 144 steps
- configured Lefthook pre-commit: PASS

No device behavior changes; this is a test-resource contract mirror only.
