### PR TITLE
chore(contract): mirror observability agent metrics

### DIFF
--- a/core/data/src/test/resources/contract/observability-metric-manifest.example.json
+++ b/core/data/src/test/resources/contract/observability-metric-manifest.example.json
@@ -8,8 +8,48 @@
       "owner": "observability_agent",
       "type": "gauge",
       "unit": "ratio",
-      "labels": ["node", "role"],
+      "labels": [
+        "node",
+        "role"
+      ],
       "max_series": 16,
+      "cadence_seconds": 60,
+      "stale_after_seconds": 180,
+      "alert_use": true
+    },
+    {
+      "name": "vpn_observability_adapter_collection_success",
+      "owner": "observability_agent",
+      "type": "gauge",
+      "unit": "ratio",
+      "labels": [],
+      "max_series": 1,
+      "cadence_seconds": 60,
+      "stale_after_seconds": 180,
+      "alert_use": true
+    },
+    {
+      "name": "vpn_observability_adapter_collected_timestamp_seconds",
+      "owner": "observability_agent",
+      "type": "gauge",
+      "unit": "seconds",
+      "labels": [],
+      "max_series": 1,
+      "cadence_seconds": 60,
+      "stale_after_seconds": 180,
+      "alert_use": true
+    },
+    {
+      "name": "vpn_observability_node_manifest_identity",
+      "owner": "observability_agent",
+      "type": "gauge",
+      "unit": null,
+      "labels": [
+        "node",
+        "role",
+        "state"
+      ],
+      "max_series": 512,
       "cadence_seconds": 60,
       "stale_after_seconds": 180,
       "alert_use": true
@@ -19,7 +59,10 @@
       "owner": "observability_contract",
       "type": "gauge",
       "unit": null,
-      "labels": ["node", "role"],
+      "labels": [
+        "node",
+        "role"
+      ],
       "max_series": 256,
       "cadence_seconds": 60,
       "stale_after_seconds": 180,
@@ -30,7 +73,11 @@
       "owner": "observability_contract",
       "type": "gauge",
       "unit": null,
-      "labels": ["node", "role", "state"],
+      "labels": [
+        "node",
+        "role",
+        "state"
+      ],
       "max_series": 2048,
       "cadence_seconds": 60,
       "stale_after_seconds": 180,


### PR DESCRIPTION
## Summary

- mirror the observability metric manifest example from deploy source commit `c376ee181307068c3c99a45ba8c537e7987d653b`
- add the three bounded observability-agent metric families byte-for-byte
- keep client runtime and all other contracts unchanged

## Verification

- full 30-file contract mirror comparison against the exact deploy source: PASS
- observability metric manifest JSON Schema validation: PASS
- `./taskctl validate`: 32 tasks, 144 steps
- taskctl and harness-link unit tests: 33 PASS
- `python3 scripts/ci/check_architecture_health.py --check`: no new or worsened indicators
- `build-gate -- ./gradlew :core:data:testDebugUnitTest --no-daemon --max-workers=4`: BUILD SUCCESSFUL
- configured pre-commit and commit-msg hooks: PASS

## Boundary

This PR only updates the vendored test-resource contract. It does not change client runtime behavior.
