### PR TITLE
fix(ci): prefer cached tasking dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           cache-dependency-path: tools/tasking/package-lock.json
 
       - name: Install pinned tasking tools
-        run: npm ci --prefix tools/tasking --ignore-scripts
+        run: npm ci --prefix tools/tasking --ignore-scripts --no-audit --prefer-offline
 
       - name: Run tasking contract tests
         run: |

--- a/scripts/tests/test_resolve_change_routing.py
+++ b/scripts/tests/test_resolve_change_routing.py
@@ -229,7 +229,10 @@ class ResolveChangeRoutingTest(unittest.TestCase):
         )
         self.assertIn("workflow-only-contracts:", source)
         self.assertIn("task-contracts:", source)
-        self.assertIn("npm ci --prefix tools/tasking --ignore-scripts", source)
+        self.assertIn(
+            "npm ci --prefix tools/tasking --ignore-scripts --no-audit --prefer-offline",
+            source,
+        )
         self.assertIn("./taskctl validate", source)
         self.assertIn("fixture-contracts:", source)
         self.assertIn("actionlint .github/workflows/*.yml", source)


### PR DESCRIPTION
Fixes the task/OpenSpec gate timeout caused by an unnecessary audit-registry request. The locked install now reuses the setup-node cache first while retaining cold-cache downloads.\n\nValidated locally: targeted workflow contract tests, task-contract tests, taskctl validation, actionlint, and pre-commit hooks.